### PR TITLE
fixed addMonths bug

### DIFF
--- a/src/__tests__/add_months_test.js
+++ b/src/__tests__/add_months_test.js
@@ -16,5 +16,11 @@ describe('addMonths', function() {
     addMonths(date, 12);
     expect(date).to.be.eql(new Date(2014, 8 /* Sep */, 1));
   });
+
+  it('works well when desired month have less days and provided date is on the last day of month', function() {
+    var date = new Date(2014, 11 /* Dec */, 31);
+    var result = addMonths(date, 2);
+    expect(result).to.be.eql(new Date(2015, 1 /* Feb */, 28));
+  });
 });
 

--- a/src/add_months.js
+++ b/src/add_months.js
@@ -6,7 +6,11 @@
  */
 var addMonths = function(dirtyDate, amount) {
   var date = new Date(dirtyDate);
-  date.setMonth(date.getMonth() + amount);
+  var desiredMonth = date.getMonth() + amount;
+  var daysInDesiredMonth = new Date(Date.UTC(date.getFullYear(), desiredMonth + 1, 0)).getUTCDate();
+
+  date.setDate(Math.min(daysInDesiredMonth, date.getDate()));
+  date.setMonth(desiredMonth);
   return date;
 };
 


### PR DESCRIPTION
dateFns.addMonths((29 january), 1) == (1 march), but should be (28 february)

https://github.com/js-fns/date-fns/issues/17