### PR TITLE
Updated parse() behaviour

### DIFF
--- a/src/__tests__/parse_test.js
+++ b/src/__tests__/parse_test.js
@@ -1,6 +1,13 @@
 var parse = require('../parse');
 
 describe('parse', function() {
+  describe('failure', function() {
+    it('returns null if there is no date in string', function() {
+      var result = parse('foobarTbaz');
+      expect(result).to.be.null;
+    });
+  });
+
   describe('year', function() {
     it('parses YYYY', function() {
       var result = parse('2014');
@@ -127,18 +134,14 @@ describe('parse', function() {
   });
 
   describe('plain time', function() {
-    it('parses plain time', function() {
+    it('returns number of milliseconds', function() {
       var result = parse('21:05:30');
-      expect(result.getHours()).to.be.equal(21);
-      expect(result.getMinutes()).to.be.equal(5);
-      expect(result.getSeconds()).to.be.equal(30);
+      expect(result).to.be.equal(75930000);
     });
 
     it('parses float plain time', function() {
       var result = parse('21:05.5');
-      expect(result.getHours()).to.be.equal(21);
-      expect(result.getMinutes()).to.be.equal(5);
-      expect(result.getSeconds()).to.be.equal(30);
+      expect(result).to.be.equal(75930000);
     });
   });
 });


### PR DESCRIPTION
`CHANGE BEHAVIOR: returns null when fails, returns milliseconds when plain time`

I. `returns null when fails` — very useful change: 
1)
```javascript
if (var date = parse(maybeDateString)) {
   // ...
}
```
2)
```javascript
var parse = require('date-fns/src/parse');

var arrayOfDates = arrayOfStringsWithDateSomewhere.reduce(function(array, string) {
  if (var date = parse(string)) {
    array.push(date);
  }
  return array;
}, []);
```

II. `returns milliseconds when plain time` — before, parse() returned today date with time set to parsed time. It made no sense, since we couldn't use that time any meaningful way.
```javascript
var date = parse('2014-07-02');
var time = parse('12:00');
var length = parse('02:00');
date.setTime(date.getTime() + time + length);
//=> Wed Jul 02 2014 14:00:00
```