### PR TITLE
Timezone fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 tmp
 build
+dist

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-fns",
-  "version": "0.14.10",
+  "version": "0.14.11",
   "author": "Sasha Koss <kossnocorp@gmail.com>",
   "description": "Date helpers",
   "repository": "https://github.com/js-fns/date-fns",

--- a/src/__tests__/format_test.js
+++ b/src/__tests__/format_test.js
@@ -146,5 +146,11 @@ describe('format', function() {
       expect(format(this._date, 's ss')).to.be.equal('0 00');
     });
   });
+
+  describe('timezones', function() {
+    it('should parse dates without timezones', function() {
+      expect(format('2015-01-01', 'YYYY-MM-DD')).to.be.equal('2015-01-01')
+    })
+  })
 });
 

--- a/src/__tests__/set_iso_week_test.js
+++ b/src/__tests__/set_iso_week_test.js
@@ -21,5 +21,10 @@ describe('setISOWeek', function() {
     setISOWeek(date, 52);
     expect(date).to.be.eql(new Date(2014, 6 /* Jul */, 2));
   });
+
+  it('sets hours and minutes to the start of the day', function() {
+    var result = setISOWeek(new Date(2015, 0, 1, 20, 0), 1);
+    expect(result).to.be.eql(new Date(2015, 0, 1, 0, 0, 0));
+  });
 });
 

--- a/src/format.js
+++ b/src/format.js
@@ -1,5 +1,6 @@
 var startOfDay = require('./start_of_day');
 var startOfYear = require('./start_of_year');
+var parse = require('./parse');
 
 var NUMBER_OF_MS_IN_DAY = 864e5;
 
@@ -10,7 +11,12 @@ var NUMBER_OF_MS_IN_DAY = 864e5;
  * @returns {string}
  */
 var format = function(date, format) {
-  date = date instanceof Date ? date : new Date(date);
+  var type = toString.call(date)
+  if (type == '[object String]') {
+    date = parse(date)
+  } else if(type == '[object Number]') {
+    date = new Date(date)
+  }
 
   if (!format) {
     format = 'YYYY-MM-DDTHH:mm:ss.SSSZ';

--- a/src/format.js
+++ b/src/format.js
@@ -11,10 +11,9 @@ var NUMBER_OF_MS_IN_DAY = 864e5;
  * @returns {string}
  */
 var format = function(date, format) {
-  var type = toString.call(date)
-  if (type == '[object String]') {
+  if (typeof date == 'string') {
     date = parse(date)
-  } else if(type == '[object Number]') {
+  } else if(typeof date == 'number') {
     date = new Date(date)
   }
 

--- a/src/set_iso_week.js
+++ b/src/set_iso_week.js
@@ -1,4 +1,5 @@
 var getISOWeek = require('./get_iso_week');
+var startOfDay = require('./start_of_day');
 
 var MILLISECONDS_IN_WEEK = 604800000;
 
@@ -15,7 +16,7 @@ var setISOWeek = function(dirtyDate, isoWeek) {
   var date = new Date(dirtyDate);
   var diff = getISOWeek(date) - isoWeek;
   date.setTime(date.getTime() - diff * MILLISECONDS_IN_WEEK);
-  return date;
+  return startOfDay(date);
 };
 
 module.exports = setISOWeek;


### PR DESCRIPTION
 - use `parse` instead of `Date` constructor to parse string passed to `format` function
 - `setISOWeek` will set hours and minutes to the starts of the day