### PR TITLE
Add am/pm as long with a.m./p.m. to the format function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-fns",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "author": "Sasha Koss <kossnocorp@gmail.com>",
   "description": "Date helpers",
   "repository": "https://github.com/js-fns/date-fns",

--- a/src/__tests__/format_test.js
+++ b/src/__tests__/format_test.js
@@ -126,18 +126,33 @@ describe('format', function() {
   })
 
   describe('hours', function() {
-    it('a.m./p.m.', function() {
-      expect(format(this._date, 'hh:mm a')).to.be.equal('10:32 a.m.')
+    it('am/pm', function() {
+      expect(format(this._date, 'hh:mm a')).to.be.equal('10:32 am')
     })
 
-    it('12 p.m.', function() {
+    it('12 pm', function() {
       var date = new Date(1986, 3, 4, 12, 00, 0, 900)
-      expect(format(date, 'hh:mm a')).to.be.equal('12:00 p.m.')
+      expect(format(date, 'hh:mm a')).to.be.equal('12:00 pm')
+    })
+
+    it('12 am', function() {
+      var date = new Date(1986, 3, 4, 00, 00, 0, 900)
+      expect(format(date, 'h:mm a')).to.be.equal('12:00 am')
     })
 
     it('12 a.m.', function() {
       var date = new Date(1986, 3, 4, 00, 00, 0, 900)
-      expect(format(date, 'h:mm a')).to.be.equal('12:00 a.m.')
+      expect(format(date, 'h:mm aa')).to.be.equal('12:00 a.m.')
+    })
+
+    it('12 p.m.', function() {
+      var date = new Date(1986, 3, 4, 12, 00, 0, 900)
+      expect(format(date, 'hh:mm aa')).to.be.equal('12:00 p.m.')
+    })
+
+    it('12PM', function() {
+      var date = new Date(1986, 3, 4, 12, 00, 0, 900)
+      expect(format(date, 'hh:mmA')).to.be.equal('12:00PM')
     })
   })
 

--- a/src/format.js
+++ b/src/format.js
@@ -80,6 +80,9 @@ var formats = {
     return (this.getHours() / 12) >= 1 ? 'PM' : 'AM'
   },
   'a': function() {
+    return (this.getHours() / 12) >= 1 ? 'pm' : 'am'
+  },
+  'aa': function(){
     return (this.getHours() / 12) >= 1 ? 'p.m.' : 'a.m.'
   },
   'H': function() {

--- a/src/format.js
+++ b/src/format.js
@@ -82,7 +82,7 @@ var formats = {
   'a': function() {
     return (this.getHours() / 12) >= 1 ? 'pm' : 'am'
   },
-  'aa': function(){
+  'aa': function() {
     return (this.getHours() / 12) >= 1 ? 'p.m.' : 'a.m.'
   },
   'H': function() {


### PR DESCRIPTION
In sake of consistency with `moment` format, let's leave `a` format option as "am/pm", and introduce a new format key "aa" which will return "a.m./p.m" with dots.