### PR TITLE
Allow formatRelative to accept desired formats.

### DIFF
--- a/src/formatRelative/index.js
+++ b/src/formatRelative/index.js
@@ -26,23 +26,27 @@ import subMilliseconds from '../subMilliseconds/index.js'
  * @param {Date|String|Number} baseDate - the date to compare with
  * @param {Options} [options] - the object with options. See [Options]{@link https://date-fns.org/docs/Options}
  * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
+ * @param {Formats} [options.formats=null] - the formats object from which the format is picked.
+ *                  Falls back to default locale if none is provided.
+ *                  Can be provided as either a function or an Object.
  * @returns {String} the date in words
  * @throws {TypeError} 2 arguments required
  * @throws {RangeError} `options.additionalDigits` must be 0, 1 or 2
  * @throws {RangeError} `options.locale` must contain `localize` property
  * @throws {RangeError} `options.locale` must contain `formatLong` property
- * @throws {RangeError} `options.locale` must contain `formatRelative` property
+ * @throws {RangeError} `options.locale` must contain `formatRelative` property or formats be provided separately
  */
 export default function formatRelative (dirtyDate, dirtyBaseDate, dirtyOptions) {
   if (arguments.length < 2) {
     throw new TypeError('2 arguments required, but only ' + arguments.length + ' present')
   }
 
-  var date = toDate(dirtyDate, dirtyOptions)
-  var baseDate = toDate(dirtyBaseDate, dirtyOptions)
+  const date = toDate(dirtyDate, dirtyOptions)
+  const baseDate = toDate(dirtyBaseDate, dirtyOptions)
 
-  var options = dirtyOptions || {}
-  var locale = options.locale || defaultLocale
+  const options = dirtyOptions || {}
+  const locale = options.locale || defaultLocale
+  const formats = options.formats || locale.formatRelative
 
   if (!locale.localize) {
     throw new RangeError('locale must contain localize property')
@@ -52,17 +56,17 @@ export default function formatRelative (dirtyDate, dirtyBaseDate, dirtyOptions) 
     throw new RangeError('locale must contain formatLong property')
   }
 
-  if (!locale.formatRelative) {
-    throw new RangeError('locale must contain formatRelative property')
+  if (!formats) {
+    throw new RangeError('locale must contain formatRelative property or formats be provided separately')
   }
 
-  var diff = differenceInCalendarDays(date, baseDate, options)
+  const diff = differenceInCalendarDays(date, baseDate, options)
 
   if (isNaN(diff)) {
     return 'Invalid Date'
   }
 
-  var token
+  let token
   if (diff < -6) {
     token = 'other'
   } else if (diff < -1) {
@@ -81,6 +85,6 @@ export default function formatRelative (dirtyDate, dirtyBaseDate, dirtyOptions) 
 
   var utcDate = subMilliseconds(date, getTimezoneOffsetInMilliseconds(date), options)
   var utcBaseDate = subMilliseconds(baseDate, getTimezoneOffsetInMilliseconds(baseDate), options)
-  var formatStr = locale.formatRelative(token, utcDate, utcBaseDate, options)
+  var formatStr = typeof formats === 'function' ? formats(token, utcDate, utcBaseDate, options) : formats[token]
   return format(date, formatStr, options)
 }

--- a/src/formatRelative/test.js
+++ b/src/formatRelative/test.js
@@ -73,6 +73,20 @@ describe('formatRelative', function () {
     })
   })
 
+  describe('custom format', function () {
+    it('accepts formats as a function', function () {
+      const formats = (token, date, baseDate, options) => "'formats work'"
+      const result = formatRelative(new Date(1986, 2 /* Mar */, 28, 16, 50), baseDate, {formats: formats})
+      assert(result === 'formats work')
+    })
+
+    it('accepts formats as an object', function () {
+      const formats = {today: "'on this very day at' p"}
+      const result = formatRelative(new Date(1986, 3 /* Apr */, 4, 16, 50), baseDate, {formats: formats})
+      assert(result === 'on this very day at 4:50 PM')
+    })
+  })
+
   describe('custom locale', function () {
     it('allows to pass a custom locale', function () {
       var customLocale = {


### PR DESCRIPTION
Formats are accepted through options and fall back to `locale.formatRelative` if not provided.
Formats can be given as either a function (like they are given in locales) or a straignt object.

Close #824 
