### PR TITLE
Implement date comparison granularity

### DIFF
--- a/src/isBeforeDay/index.js
+++ b/src/isBeforeDay/index.js
@@ -21,7 +21,7 @@ import requiredArgs from '../_lib/requiredArgs/index.js'
  * //=> true
  *
  * // Is 11 July 1989 09:00 before 11 July 1989 10:00 by day?
- * var result = isBeforeDay(new Date(1989, 6, 10, 9), new Date(1989, 6, 11, 10))
+ * var result = isBeforeDay(new Date(1989, 6, 11, 9), new Date(1989, 6, 11, 10))
  * //=> false
  */
 export default function isBeforeDay(dirtyDate, dirtyDateToCompare) {

--- a/src/isBeforeDay/index.js
+++ b/src/isBeforeDay/index.js
@@ -1,0 +1,33 @@
+import toDate from '../toDate/index.js'
+import startOfDay from '../startOfDay/index.js'
+import requiredArgs from '../_lib/requiredArgs/index.js'
+
+/**
+ * @name isBeforeDay
+ * @category Common Helpers
+ * @summary Is the first date before the second one by day?
+ *
+ * @description
+ * Is the first date before the second one by day?
+ *
+ * @param {Date|Number} date - the date that should be before the other one by day to return true
+ * @param {Date|Number} dateToCompare - the date to compare with
+ * @returns {Boolean} the first date is before the second date by day
+ * @throws {TypeError} 2 arguments required
+ *
+ * @example
+ * // Is 10 July 1989 before 11 July 1989 by day?
+ * var result = isBeforeDay(new Date(1989, 6, 10), new Date(1989, 6, 11))
+ * //=> true
+ *
+ * // Is 11 July 1989 09:00 before 11 July 1989 10:00 by day?
+ * var result = isBeforeDay(new Date(1989, 6, 10, 9), new Date(1989, 6, 11, 10))
+ * //=> false
+ */
+export default function isBeforeDay(dirtyDate, dirtyDateToCompare) {
+  requiredArgs(2, arguments)
+
+  var date = toDate(dirtyDate)
+  var dateToCompare = toDate(dirtyDateToCompare)
+  return startOfDay(date).getTime() < startOfDay(dateToCompare).getTime()
+}

--- a/src/isBeforeDay/test.js
+++ b/src/isBeforeDay/test.js
@@ -21,7 +21,7 @@ describe('isBeforeDay', function() {
     assert(result === false)
   })
 
-  it('returns false if the first date is equal to the second one', function() {
+  it('returns false if the first date is equal to the second one by day', function() {
     var result = isBeforeDay(
       new Date(1989, 6 /* Jul */, 10),
       new Date(1989, 6 /* Jul */, 10)

--- a/src/isBeforeDay/test.js
+++ b/src/isBeforeDay/test.js
@@ -1,0 +1,67 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'power-assert'
+import isBeforeDay from '.'
+
+describe('isBeforeDay', function() {
+  it('returns true if the first date is before the second one by day', function() {
+    var result = isBeforeDay(
+      new Date(1989, 6 /* Jul */, 10),
+      new Date(1989, 6 /* Jul */, 11)
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the first date is after the second one by day', function() {
+    var result = isBeforeDay(
+      new Date(1989, 6 /* Jul */, 11),
+      new Date(1989, 6 /* Jul */, 10)
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the first date is equal to the second one', function() {
+    var result = isBeforeDay(
+      new Date(1989, 6 /* Jul */, 10),
+      new Date(1989, 6 /* Jul */, 10)
+    )
+    assert(result === false)
+  })
+
+  it('returns false if the first date is before the second one by hour', function() {
+    var result = isBeforeDay(
+      new Date(1989, 6 /* Jul */, 10, 14),
+      new Date(1989, 6 /* Jul */, 10, 15)
+    )
+    assert(result === false)
+  })
+
+  it('accepts a timestamp', function() {
+    var result = isBeforeDay(
+      new Date(1989, 6 /* Jul */, 10).getTime(),
+      new Date(1989, 6 /* Jul */, 11).getTime()
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the first date is `Invalid Date`', function() {
+    var result = isBeforeDay(new Date(NaN), new Date(1989, 6 /* Jul */, 10))
+    assert(result === false)
+  })
+
+  it('returns false if the second date is `Invalid Date`', function() {
+    var result = isBeforeDay(new Date(1987, 1 /* Feb */, 11), new Date(NaN))
+    assert(result === false)
+  })
+
+  it('returns false if the both dates are `Invalid Date`', function() {
+    var result = isBeforeDay(new Date(NaN), new Date(NaN))
+    assert(result === false)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function() {
+    assert.throws(isBeforeDay.bind(null), TypeError)
+    assert.throws(isBeforeDay.bind(null, 1), TypeError)
+  })
+})


### PR DESCRIPTION
Following up https://github.com/date-fns/date-fns/issues/869.

I have implemented `isBeforeDay` and I would like to know if this format suits you before doing all the others as it's quite mechanical from here. I have taken `isBefore` as a reference and tweaked the docs and test cases accordingly.

Also, I can do one PR for all the `isBefore` variations and another one for the `isAfter` variations if that makes it easier to review (or even one per function if you prefer). Let me know 👍 

Pinging @kossnocorp as he was the one I talked with 😁 