### PR TITLE
update isValid parameter from * to Date | Number

### DIFF
--- a/src/fp/index.js.flow
+++ b/src/fp/index.js.flow
@@ -355,7 +355,7 @@ declare module.exports: {
   isSunday: CurriedFn1<Date | number, boolean>,
   isThursday: CurriedFn1<Date | number, boolean>,
   isTuesday: CurriedFn1<Date | number, boolean>,
-  isValid: CurriedFn1<any, boolean>,
+  isValid: CurriedFn1<Date | number, boolean>,
   isWednesday: CurriedFn1<Date | number, boolean>,
   isWeekend: CurriedFn1<Date | number, boolean>,
   isWithinInterval: CurriedFn2<Interval, Date | number, boolean>,

--- a/src/fp/isValid/index.js.flow
+++ b/src/fp/isValid/index.js.flow
@@ -49,4 +49,4 @@ export type Duration = {
 
 type CurriedFn1<A, R> = <A>(a: A) => R
 
-declare module.exports: CurriedFn1<any, boolean>
+declare module.exports: CurriedFn1<Date | number, boolean>

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -495,7 +495,7 @@ declare module.exports: {
 
   isTuesday: (date: Date | number) => boolean,
 
-  isValid: (date: any) => boolean,
+  isValid: (date: Date | number) => boolean,
 
   isWednesday: (date: Date | number) => boolean,
 

--- a/src/isValid/index.js
+++ b/src/isValid/index.js
@@ -39,7 +39,7 @@ import requiredArgs from '../_lib/requiredArgs/index.js'
  *   that try to coerce arguments to the expected type
  *   (which is also the case with other *date-fns* functions).
  *
- * @param {*} date - the date to check
+ * @param {Date | Number} date - the value to check, in the form of Date object or number (in milliseconds Unix time)
  * @returns {Boolean} the date is valid
  * @throws {TypeError} 1 argument required
  *

--- a/src/isValid/index.js.flow
+++ b/src/isValid/index.js.flow
@@ -47,4 +47,4 @@ export type Duration = {
   seconds?: number
 }
 
-declare module.exports: (date: any) => boolean
+declare module.exports: (date: Date | number) => boolean

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -685,7 +685,7 @@ declare module 'date-fns' {
   function isTuesday(date: Date | number): boolean
   namespace isTuesday {}
 
-  function isValid(date: any): boolean
+  function isValid(date: Date | number): boolean
   namespace isValid {}
 
   function isWednesday(date: Date | number): boolean
@@ -4357,7 +4357,7 @@ declare module 'date-fns/fp' {
   const isTuesday: CurriedFn1<Date | number, boolean>
   namespace isTuesday {}
 
-  const isValid: CurriedFn1<any, boolean>
+  const isValid: CurriedFn1<Date | number, boolean>
   namespace isValid {}
 
   const isWednesday: CurriedFn1<Date | number, boolean>
@@ -8214,7 +8214,7 @@ declare module 'date-fns/esm' {
   function isTuesday(date: Date | number): boolean
   namespace isTuesday {}
 
-  function isValid(date: any): boolean
+  function isValid(date: Date | number): boolean
   namespace isValid {}
 
   function isWednesday(date: Date | number): boolean
@@ -11886,7 +11886,7 @@ declare module 'date-fns/esm/fp' {
   const isTuesday: CurriedFn1<Date | number, boolean>
   namespace isTuesday {}
 
-  const isValid: CurriedFn1<any, boolean>
+  const isValid: CurriedFn1<Date | number, boolean>
   namespace isValid {}
 
   const isWednesday: CurriedFn1<Date | number, boolean>
@@ -18058,7 +18058,7 @@ interface dateFns {
 
   isTuesday(date: Date | number): boolean
 
-  isValid(date: any): boolean
+  isValid(date: Date | number): boolean
 
   isWednesday(date: Date | number): boolean
 


### PR DESCRIPTION
Fixes https://github.com/date-fns/date-fns/issues/1575. 

Currently, the typing in `isValid`'s function documentation expects a parameter of type `any`. This might lead to confusion as users might think they could pass anything into it.

This PR updates the parameter documentation from `*` to `Date | Number`. This is aimed to ensure let users know what parameter is actually expected by the function.

Signed-off-by: Try Ajitiono <ballinst@gmail.com>