### PR TITLE
Fix string pattern for calendar year (date-fns#942)

### DIFF
--- a/src/parse/_lib/parsers/index.js
+++ b/src/parse/_lib/parsers/index.js
@@ -324,7 +324,11 @@ var parsers = {
             valueCallback: valueCallback
           })
         default:
-          return parseNDigits(token.length, string, valueCallback)
+          return parseNumericPattern(
+            '^\\d{' + token.length + '}',
+            string,
+            valueCallback
+          )
       }
     },
 

--- a/src/parse/test.js
+++ b/src/parse/test.js
@@ -133,6 +133,16 @@ describe('parse', function() {
       assert.deepEqual(result, expectedResult)
     })
 
+    it('returns `Invalid Date` if date has one digit', function() {
+      var result = parse('1', 'yy', referenceDate)
+      assert(result instanceof Date && isNaN(result.getTime()))
+    })
+
+    it('returns `Invalid Date` if date has two digits', function() {
+      var result = parse('20', 'yyyy', referenceDate)
+      assert(result instanceof Date && isNaN(result.getTime()))
+    })
+
     describe('validation', () => {
       ;[
         ['y', '2019'],


### PR DESCRIPTION
According to Unicode Technical Standard, it should not allow years
with number of digits less than length of 'y' field