### PR TITLE
Use default "other" token in formatRelative and improve error message

### DIFF
--- a/src/format/index.js
+++ b/src/format/index.js
@@ -326,6 +326,7 @@ var unescapedLatinCharacterRegExp = /[a-zA-Z]/
  * @throws {RangeError} use `d` instead of `D` for formatting days of the month using [format provided] to the input [input provided]; see: https://git.io/fxCyr
  * @throws {RangeError} use `dd` instead of `DD` for formatting days of the month using [format provided] to the input [input provided]; see: https://git.io/fxCyr
  * @throws {RangeError} format string contains an unescaped latin alphabet character
+ * @throws {RangeError} format string is undefined
  *
  * @example
  * // Represent 11 February 2014 in middle-endian format:
@@ -347,6 +348,10 @@ var unescapedLatinCharacterRegExp = /[a-zA-Z]/
  */
 export default function format(dirtyDate, dirtyFormatStr, dirtyOptions) {
   requiredArgs(2, arguments)
+
+  if (dirtyFormatStr === undefined) {
+    throw new RangeError('format must be defined')
+  }
 
   var formatStr = String(dirtyFormatStr)
   var options = dirtyOptions || {}

--- a/src/format/index.js
+++ b/src/format/index.js
@@ -8,7 +8,7 @@ import getTimezoneOffsetInMilliseconds from '../_lib/getTimezoneOffsetInMillisec
 import {
   isProtectedDayOfYearToken,
   isProtectedWeekYearToken,
-  throwProtectedError
+  throwProtectedError,
 } from '../_lib/protectedTokens/index'
 import toInteger from '../_lib/toInteger/index'
 import requiredArgs from '../_lib/requiredArgs/index'
@@ -413,12 +413,12 @@ export default function format(dirtyDate, dirtyFormatStr, dirtyOptions) {
     firstWeekContainsDate: firstWeekContainsDate,
     weekStartsOn: weekStartsOn,
     locale: locale,
-    _originalDate: originalDate
+    _originalDate: originalDate,
   }
 
   var result = formatStr
     .match(longFormattingTokensRegExp)
-    .map(function(substring) {
+    .map(function (substring) {
       var firstCharacter = substring[0]
       if (firstCharacter === 'p' || firstCharacter === 'P') {
         var longFormatter = longFormatters[firstCharacter]
@@ -428,7 +428,7 @@ export default function format(dirtyDate, dirtyFormatStr, dirtyOptions) {
     })
     .join('')
     .match(formattingTokensRegExp)
-    .map(function(substring) {
+    .map(function (substring) {
       // Replace two single quote characters with one single quote character
       if (substring === "''") {
         return "'"

--- a/src/format/test.js
+++ b/src/format/test.js
@@ -4,7 +4,7 @@
 import assert from 'power-assert'
 import format from '.'
 
-describe('format', function() {
+describe('format', function () {
   var date = new Date(1986, 3 /* Apr */, 4, 10, 32, 55, 123)
 
   var offset = date.getTimezoneOffset()
@@ -35,33 +35,33 @@ describe('format', function() {
   var timestamp = date.getTime().toString()
   var secondsTimestamp = Math.floor(date.getTime() / 1000).toString()
 
-  it('accepts a timestamp', function() {
+  it('accepts a timestamp', function () {
     var date = new Date(2014, 3, 4).getTime()
     assert(format(date, 'yyyy-MM-dd') === '2014-04-04')
   })
 
-  it('escapes characters between the single quote characters', function() {
+  it('escapes characters between the single quote characters', function () {
     var result = format(date, "'yyyy-'MM-dd'THH:mm:ss.SSSX' yyyy-'MM-dd'")
     assert(result === 'yyyy-04-04THH:mm:ss.SSSX 1986-MM-dd')
   })
 
-  it('two single quote characters are transformed into a "real" single quote', function() {
+  it('two single quote characters are transformed into a "real" single quote', function () {
     var date = new Date(2014, 3, 4, 5)
     assert(format(date, "''h 'o''clock'''") === "'5 o'clock'")
   })
 
-  it('accepts new line charactor', function() {
+  it('accepts new line charactor', function () {
     var date = new Date(2014, 3, 4, 5)
     assert.equal(format(date, "yyyy-MM-dd'\n'HH:mm:ss"), '2014-04-04\n05:00:00')
   })
 
-  describe('ordinal numbers', function() {
-    it('ordinal day of an ordinal month', function() {
+  describe('ordinal numbers', function () {
+    it('ordinal day of an ordinal month', function () {
       var result = format(date, "do 'day of the' Mo 'month of' yyyy")
       assert(result === '4th day of the 4th month of 1986')
     })
 
-    it('should return a correct ordinal number', function() {
+    it('should return a correct ordinal number', function () {
       var result = []
       for (var i = 1; i <= 31; i++) {
         result.push(format(new Date(2015, 0, i), 'do'))
@@ -97,32 +97,32 @@ describe('format', function() {
         '28th',
         '29th',
         '30th',
-        '31st'
+        '31st',
       ]
       assert.deepEqual(result, expected)
     })
   })
 
-  it('era', function() {
+  it('era', function () {
     var result = format(date, 'G GG GGG GGGG GGGGG')
     assert(result === 'AD AD AD Anno Domini A')
   })
 
-  describe('year', function() {
-    describe('regular year', function() {
-      it('works as expected', function() {
+  describe('year', function () {
+    describe('regular year', function () {
+      it('works as expected', function () {
         var result = format(date, 'y yo yy yyy yyyy yyyyy')
         assert(result === '1986 1986th 86 1986 1986 01986')
       })
 
-      it('1 BC formats as 1', function() {
+      it('1 BC formats as 1', function () {
         var date = new Date(0, 0 /* Jan */, 1)
         date.setFullYear(0)
         var result = format(date, 'y')
         assert(result === '1')
       })
 
-      it('2 BC formats as 2', function() {
+      it('2 BC formats as 2', function () {
         var date = new Date(0, 0 /* Jan */, 1)
         date.setFullYear(-1)
         var result = format(date, 'y')
@@ -130,45 +130,45 @@ describe('format', function() {
       })
     })
 
-    describe('local week-numbering year', function() {
-      it('works as expected', function() {
+    describe('local week-numbering year', function () {
+      it('works as expected', function () {
         var result = format(date, 'Y Yo YY YYY YYYY YYYYY', {
-          useAdditionalWeekYearTokens: true
+          useAdditionalWeekYearTokens: true,
         })
         assert(result === '1986 1986th 86 1986 1986 01986')
       })
 
-      it('the first week of the next year', function() {
+      it('the first week of the next year', function () {
         var result = format(new Date(2013, 11 /* Dec */, 29), 'YYYY', {
-          useAdditionalWeekYearTokens: true
+          useAdditionalWeekYearTokens: true,
         })
         assert(result === '2014')
       })
 
-      it('allows to specify `weekStartsOn` and `firstWeekContainsDate` in options', function() {
+      it('allows to specify `weekStartsOn` and `firstWeekContainsDate` in options', function () {
         var result = format(new Date(2013, 11 /* Dec */, 29), 'YYYY', {
           weekStartsOn: 1,
           firstWeekContainsDate: 4,
-          useAdditionalWeekYearTokens: true
+          useAdditionalWeekYearTokens: true,
         })
         assert(result === '2013')
       })
 
-      it('the first week of year', function() {
+      it('the first week of year', function () {
         var result = format(new Date(2016, 0 /* Jan */, 1), 'YYYY', {
-          useAdditionalWeekYearTokens: true
+          useAdditionalWeekYearTokens: true,
         })
         assert(result === '2016')
       })
 
-      it('1 BC formats as 1', function() {
+      it('1 BC formats as 1', function () {
         var date = new Date(0, 6 /* Jul */, 2)
         date.setFullYear(0)
         var result = format(date, 'Y')
         assert(result === '1')
       })
 
-      it('2 BC formats as 2', function() {
+      it('2 BC formats as 2', function () {
         var date = new Date(0, 6 /* Jul */, 2)
         date.setFullYear(-1)
         var result = format(date, 'Y')
@@ -176,30 +176,30 @@ describe('format', function() {
       })
     })
 
-    describe('ISO week-numbering year', function() {
-      it('works as expected', function() {
+    describe('ISO week-numbering year', function () {
+      it('works as expected', function () {
         var result = format(date, 'R RR RRR RRRR RRRRR')
         assert(result === '1986 1986 1986 1986 01986')
       })
 
-      it('the first week of the next year', function() {
+      it('the first week of the next year', function () {
         var result = format(new Date(2013, 11 /* Dec */, 30), 'RRRR')
         assert(result === '2014')
       })
 
-      it('the last week of the previous year', function() {
+      it('the last week of the previous year', function () {
         var result = format(new Date(2016, 0 /* Jan */, 1), 'RRRR')
         assert(result === '2015')
       })
 
-      it('1 BC formats as 0', function() {
+      it('1 BC formats as 0', function () {
         var date = new Date(0, 6 /* Jul */, 2)
         date.setFullYear(0)
         var result = format(date, 'R')
         assert(result === '0')
       })
 
-      it('2 BC formats as -1', function() {
+      it('2 BC formats as -1', function () {
         var date = new Date(0, 6 /* Jul */, 2)
         date.setFullYear(-1)
         var result = format(date, 'R')
@@ -207,20 +207,20 @@ describe('format', function() {
       })
     })
 
-    describe('extended year', function() {
-      it('works as expected', function() {
+    describe('extended year', function () {
+      it('works as expected', function () {
         var result = format(date, 'u uu uuu uuuu uuuuu')
         assert(result === '1986 1986 1986 1986 01986')
       })
 
-      it('1 BC formats as 0', function() {
+      it('1 BC formats as 0', function () {
         var date = new Date(0, 0, 1)
         date.setFullYear(0)
         var result = format(date, 'u')
         assert(result === '0')
       })
 
-      it('2 BC formats as -1', function() {
+      it('2 BC formats as -1', function () {
         var date = new Date(0, 0, 1)
         date.setFullYear(-1)
         var result = format(date, 'u')
@@ -229,18 +229,18 @@ describe('format', function() {
     })
   })
 
-  describe('quarter', function() {
-    it('formatting quarter', function() {
+  describe('quarter', function () {
+    it('formatting quarter', function () {
       var result = format(date, 'Q Qo QQ QQQ QQQQ QQQQQ')
       assert(result === '2 2nd 02 Q2 2nd quarter 2')
     })
 
-    it('stand-alone quarter', function() {
+    it('stand-alone quarter', function () {
       var result = format(date, 'q qo qq qqq qqqq qqqqq')
       assert(result === '2 2nd 02 Q2 2nd quarter 2')
     })
 
-    it('returns a correct quarter for each month', function() {
+    it('returns a correct quarter for each month', function () {
       var result = []
       for (var i = 0; i <= 11; i++) {
         result.push(format(new Date(1986, i, 1), 'Q'))
@@ -257,64 +257,64 @@ describe('format', function() {
         '3',
         '4',
         '4',
-        '4'
+        '4',
       ]
       assert.deepEqual(result, expected)
     })
   })
 
-  describe('month', function() {
-    it('formatting month', function() {
+  describe('month', function () {
+    it('formatting month', function () {
       var result = format(date, 'M Mo MM MMM MMMM MMMMM')
       assert(result === '4 4th 04 Apr April A')
     })
 
-    it('stand-alone month', function() {
+    it('stand-alone month', function () {
       var result = format(date, 'L Lo LL LLL LLLL LLLLL')
       assert(result === '4 4th 04 Apr April A')
     })
   })
 
-  describe('week', function() {
-    describe('local week of year', function() {
-      it('works as expected', function() {
+  describe('week', function () {
+    describe('local week of year', function () {
+      it('works as expected', function () {
         var date = new Date(1986, 3 /* Apr */, 6)
         var result = format(date, 'w wo ww')
         assert(result === '15 15th 15')
       })
 
-      it('allows to specify `weekStartsOn` and `firstWeekContainsDate` in options', function() {
+      it('allows to specify `weekStartsOn` and `firstWeekContainsDate` in options', function () {
         var date = new Date(1986, 3 /* Apr */, 6)
         var result = format(date, 'w wo ww', {
           weekStartsOn: 1,
-          firstWeekContainsDate: 4
+          firstWeekContainsDate: 4,
         })
         assert(result === '14 14th 14')
       })
     })
 
-    it('ISO week of year', function() {
+    it('ISO week of year', function () {
       var date = new Date(1986, 3 /* Apr */, 6)
       var result = format(date, 'I Io II')
       assert(result === '14 14th 14')
     })
   })
 
-  describe('day', function() {
-    it('date', function() {
+  describe('day', function () {
+    it('date', function () {
       var result = format(date, 'd do dd')
       assert(result === '4 4th 04')
     })
 
-    describe('day of year', function() {
-      it('works as expected', function() {
+    describe('day of year', function () {
+      it('works as expected', function () {
         var result = format(date, 'D Do DD DDD DDDDD', {
-          useAdditionalDayOfYearTokens: true
+          useAdditionalDayOfYearTokens: true,
         })
         assert(result === '94 94th 94 094 00094')
       })
 
-      it('returns a correct day number for the last day of a leap year', function() {
+      it('returns a correct day number for the last day of a leap year', function () {
         var result = format(
           new Date(1992, 11 /* Dec */, 31, 23, 59, 59, 999),
           'D',
@@ -325,21 +325,21 @@ describe('format', function() {
     })
   })
 
-  describe('week day', function() {
-    describe('day of week', function() {
-      it('works as expected', function() {
+  describe('week day', function () {
+    describe('day of week', function () {
+      it('works as expected', function () {
         var result = format(date, 'E EE EEE EEEE EEEEE EEEEEE')
         assert(result === 'Fri Fri Fri Friday F Fr')
       })
     })
 
-    describe('ISO day of week', function() {
-      it('works as expected', function() {
+    describe('ISO day of week', function () {
+      it('works as expected', function () {
         var result = format(date, 'i io ii iii iiii iiiii iiiiii')
         assert(result === '5 5th 05 Fri Friday F Fr')
       })
 
-      it('returns a correct day of an ISO week', function() {
+      it('returns a correct day of an ISO week', function () {
         var result = []
         for (var i = 1; i <= 7; i++) {
           result.push(format(new Date(1986, 8 /* Sep */, i), 'i'))
@@ -349,13 +349,13 @@ describe('format', function() {
       })
     })
 
-    describe('formatting day of week', function() {
-      it('works as expected', function() {
+    describe('formatting day of week', function () {
+      it('works as expected', function () {
         var result = format(date, 'e eo ee eee eeee eeeee eeeeee')
         assert(result === '6 6th 06 Fri Friday F Fr')
       })
 
-      it('by default, 1 is Sunday, 2 is Monday, ...', function() {
+      it('by default, 1 is Sunday, 2 is Monday, ...', function () {
         var result = []
         for (var i = 7; i <= 13; i++) {
           result.push(format(new Date(1986, 8 /* Sep */, i), 'e'))
@@ -364,7 +364,7 @@ describe('format', function() {
         assert.deepEqual(result, expected)
       })
 
-      it('allows to specify which day is the first day of the week', function() {
+      it('allows to specify which day is the first day of the week', function () {
         var result = []
         for (var i = 1; i <= 7; i++) {
           result.push(
@@ -376,13 +376,13 @@ describe('format', function() {
       })
     })
 
-    describe('stand-alone day of week', function() {
-      it('works as expected', function() {
+    describe('stand-alone day of week', function () {
+      it('works as expected', function () {
         var result = format(date, 'c co cc ccc cccc ccccc cccccc')
         assert(result === '6 6th 06 Fri Friday F Fr')
       })
 
-      it('by default, 1 is Sunday, 2 is Monday, ...', function() {
+      it('by default, 1 is Sunday, 2 is Monday, ...', function () {
         var result = []
         for (var i = 7; i <= 13; i++) {
           result.push(format(new Date(1986, 8 /* Sep */, i), 'c'))
@@ -391,7 +391,7 @@ describe('format', function() {
         assert.deepEqual(result, expected)
       })
 
-      it('allows to specify which day is the first day of the week', function() {
+      it('allows to specify which day is the first day of the week', function () {
         var result = []
         for (var i = 1; i <= 7; i++) {
           result.push(
@@ -404,29 +404,29 @@ describe('format', function() {
     })
   })
 
-  describe('day period and hour', function() {
-    it('hour [1-12]', function() {
+  describe('day period and hour', function () {
+    it('hour [1-12]', function () {
       var result = format(new Date(2018, 0 /* Jan */, 1, 0, 0, 0, 0), 'h ho hh')
       assert(result === '12 12th 12')
     })
 
-    it('hour [0-23]', function() {
+    it('hour [0-23]', function () {
       var result = format(new Date(2018, 0 /* Jan */, 1, 0, 0, 0, 0), 'H Ho HH')
       assert(result === '0 0th 00')
     })
 
-    it('hour [0-11]', function() {
+    it('hour [0-11]', function () {
       var result = format(new Date(2018, 0 /* Jan */, 1, 0, 0, 0, 0), 'K Ko KK')
       assert(result === '0 0th 00')
     })
 
-    it('hour [1-24]', function() {
+    it('hour [1-24]', function () {
       var result = format(new Date(2018, 0 /* Jan */, 1, 0, 0, 0, 0), 'k ko kk')
       assert(result === '24 24th 24')
     })
 
-    describe('AM, PM', function() {
-      it('works as expected', function() {
+    describe('AM, PM', function () {
+      it('works as expected', function () {
         var result = format(
           new Date(2018, 0 /* Jan */, 1, 0, 0, 0, 0),
           'a aa aaa aaaa aaaaa'
@@ -434,19 +434,19 @@ describe('format', function() {
         assert(result === 'AM AM am a.m. a')
       })
 
-      it('12 PM', function() {
+      it('12 PM', function () {
         var date = new Date(1986, 3 /* Apr */, 4, 12, 0, 0, 900)
         assert(format(date, 'h H K k a') === '12 12 0 12 PM')
       })
 
-      it('12 AM', function() {
+      it('12 AM', function () {
         var date = new Date(1986, 3 /* Apr */, 6, 0, 0, 0, 900)
         assert(format(date, 'h H K k a') === '12 0 0 24 AM')
       })
     })
 
-    describe('AM, PM, noon, midnight', function() {
-      it('works as expected', function() {
+    describe('AM, PM, noon, midnight', function () {
+      it('works as expected', function () {
         var result = format(
           new Date(1986, 3 /* Apr */, 6, 2, 0, 0, 900),
           'b bb bbb bbbb bbbbb'
@@ -454,12 +454,12 @@ describe('format', function() {
         assert(result === 'AM AM am a.m. a')
       })
 
-      it('12 PM', function() {
+      it('12 PM', function () {
         var date = new Date(1986, 3 /* Apr */, 4, 12, 0, 0, 900)
         assert(format(date, 'b bb bbb bbbb bbbbb') === 'noon noon noon noon n')
       })
 
-      it('12 AM', function() {
+      it('12 AM', function () {
         var date = new Date(1986, 3 /* Apr */, 6, 0, 0, 0, 900)
         assert(
           format(date, 'b bb bbb bbbb bbbbb') ===
@@ -468,8 +468,8 @@ describe('format', function() {
       })
     })
 
-    describe('flexible day periods', function() {
-      it('works as expected', function() {
+    describe('flexible day periods', function () {
+      it('works as expected', function () {
         var result = format(date, 'B, BB, BBB, BBBB, BBBBB')
         assert(
           result ===
@@ -477,173 +477,173 @@ describe('format', function() {
         )
       })
 
-      it('12 PM', function() {
+      it('12 PM', function () {
         var date = new Date(1986, 3 /* Apr */, 4, 12, 0, 0, 900)
         assert(format(date, 'h B') === '12 in the afternoon')
       })
 
-      it('5 PM', function() {
+      it('5 PM', function () {
         var date = new Date(1986, 3 /* Apr */, 6, 17, 0, 0, 900)
         assert(format(date, 'h B') === '5 in the evening')
       })
 
-      it('12 AM', function() {
+      it('12 AM', function () {
         var date = new Date(1986, 3 /* Apr */, 6, 0, 0, 0, 900)
         assert(format(date, 'h B') === '12 at night')
       })
 
-      it('4 AM', function() {
+      it('4 AM', function () {
         var date = new Date(1986, 3 /* Apr */, 6, 4, 0, 0, 900)
         assert(format(date, 'h B') === '4 in the morning')
       })
     })
   })
 
-  it('minute', function() {
+  it('minute', function () {
     var result = format(date, 'm mo mm')
     assert(result === '32 32nd 32')
   })
 
-  describe('second', function() {
-    it('second', function() {
+  describe('second', function () {
+    it('second', function () {
       var result = format(date, 's so ss')
       assert(result === '55 55th 55')
     })
 
-    it('fractional seconds', function() {
+    it('fractional seconds', function () {
       var result = format(date, 'S SS SSS SSSS')
       assert(result === '1 12 123 1230')
     })
   })
 
-  describe('time zone', function() {
-    it('ISO-8601 with Z', function() {
+  describe('time zone', function () {
+    it('ISO-8601 with Z', function () {
       var result = format(date, 'X XX XXX XXXX XXXXX')
       var expectedResult = [
         timezoneWithOptionalMinutesAndZShort,
         timezoneWithZShort,
         timezoneWithZ,
         timezoneWithZShort,
-        timezoneWithZ
+        timezoneWithZ,
       ].join(' ')
       assert(result === expectedResult)
     })
 
-    it('ISO-8601 without Z', function() {
+    it('ISO-8601 without Z', function () {
       var result = format(date, 'x xx xxx xxxx xxxxx')
       var expectedResult = [
         timezoneWithOptionalMinutesShort,
         timezoneShort,
         timezone,
         timezoneShort,
-        timezone
+        timezone,
       ].join(' ')
       assert(result === expectedResult)
     })
 
-    it('GMT', function() {
+    it('GMT', function () {
       var result = format(date, 'O OO OOO OOOO')
       var expectedResult = [
         timezoneGMTShort,
         timezoneGMTShort,
         timezoneGMTShort,
-        timezoneGMT
+        timezoneGMT,
       ].join(' ')
       assert(result === expectedResult)
     })
 
-    it('Specific non-location', function() {
+    it('Specific non-location', function () {
       var result = format(date, 'z zz zzz zzzz')
       var expectedResult = [
         timezoneGMTShort,
         timezoneGMTShort,
         timezoneGMTShort,
-        timezoneGMT
+        timezoneGMT,
       ].join(' ')
       assert(result === expectedResult)
     })
   })
 
-  describe('timestamp', function() {
-    it('seconds timestamp', function() {
+  describe('timestamp', function () {
+    it('seconds timestamp', function () {
       var result = format(date, 't')
       assert(result === secondsTimestamp)
     })
 
-    it('milliseconds timestamp', function() {
+    it('milliseconds timestamp', function () {
       var result = format(date, 'T')
       assert(result === timestamp)
     })
   })
 
-  describe('long format', function() {
-    it('short date', function() {
+  describe('long format', function () {
+    it('short date', function () {
       var result = format(date, 'P')
       assert(result === '04/04/1986')
     })
 
-    it('medium date', function() {
+    it('medium date', function () {
       var result = format(date, 'PP')
       assert(result === 'Apr 4, 1986')
     })
 
-    it('long date', function() {
+    it('long date', function () {
       var result = format(date, 'PPP')
       assert(result === 'April 4th, 1986')
     })
 
-    it('full date', function() {
+    it('full date', function () {
       var result = format(date, 'PPPP')
       assert(result === 'Friday, April 4th, 1986')
     })
 
-    it('short time', function() {
+    it('short time', function () {
       var result = format(date, 'p')
       assert(result === '10:32 AM')
     })
 
-    it('medium time', function() {
+    it('medium time', function () {
       var result = format(date, 'pp')
       assert(result === '10:32:55 AM')
     })
 
-    it('long time', function() {
+    it('long time', function () {
       var result = format(date, 'ppp')
       assert(result === '10:32:55 AM ' + timezoneGMTShort)
     })
 
-    it('full time', function() {
+    it('full time', function () {
       var result = format(date, 'pppp')
       assert(result === '10:32:55 AM ' + timezoneGMT)
     })
 
-    it('short date + time', function() {
+    it('short date + time', function () {
       var result = format(date, 'Pp')
       assert(result === '04/04/1986, 10:32 AM')
     })
 
-    it('medium date + time', function() {
+    it('medium date + time', function () {
       var result = format(date, 'PPpp')
       assert(result === 'Apr 4, 1986, 10:32:55 AM')
     })
 
-    it('long date + time', function() {
+    it('long date + time', function () {
       var result = format(date, 'PPPppp')
       assert(result === 'April 4th, 1986 at 10:32:55 AM ' + timezoneGMTShort)
     })
 
-    it('full date + time', function() {
+    it('full date + time', function () {
       var result = format(date, 'PPPPpppp')
       assert(result === 'Friday, April 4th, 1986 at 10:32:55 AM ' + timezoneGMT)
     })
 
-    it('allows arbitrary combination of date and time', function() {
+    it('allows arbitrary combination of date and time', function () {
       var result = format(date, 'Ppppp')
       assert(result === '04/04/1986, 10:32:55 AM ' + timezoneGMT)
     })
   })
 
-  describe('edge cases', function() {
+  describe('edge cases', function () {
     it('throws RangeError if the time value is invalid', () => {
       assert.throws(
         format.bind(null, new Date(NaN), 'MMMM d, yyyy'),
@@ -651,7 +651,7 @@ describe('format', function() {
       )
     })
 
-    it('handles dates before 100 AD', function() {
+    it('handles dates before 100 AD', function () {
       var initialDate = new Date(0)
       initialDate.setFullYear(7, 11 /* Dec */, 31)
       initialDate.setHours(0, 0, 0, 0)
@@ -659,7 +659,7 @@ describe('format', function() {
     })
   })
 
-  it('implicitly converts `formatString`', function() {
+  it('implicitly converts `formatString`', function () {
     // eslint-disable-next-line no-new-wrappers
     var formatString = new String('yyyy-MM-dd')
 
@@ -669,76 +669,76 @@ describe('format', function() {
     assert(format(date, formatString) === '2014-04-04')
   })
 
-  describe('custom locale', function() {
-    it('allows to pass a custom locale', function() {
+  describe('custom locale', function () {
+    it('allows to pass a custom locale', function () {
       var customLocale = {
         localize: {
-          month: function() {
+          month: function () {
             return 'works'
-          }
+          },
         },
         formatLong: {
-          date: function() {
+          date: function () {
             return "'It' MMMM!"
-          }
-        }
+          },
+        },
       }
       // $ExpectedMistake
       var result = format(date, 'PPPP', { locale: customLocale })
       assert(result === 'It works!')
     })
 
-    it("throws `RangeError` if `options.locale` doesn't have `localize` property", function() {
+    it("throws `RangeError` if `options.locale` doesn't have `localize` property", function () {
       var customLocale = {
-        formatLong: {}
+        formatLong: {},
       }
       // $ExpectedMistake
       var block = format.bind(null, date, 'yyyy-MM-dd', {
-        locale: customLocale
+        locale: customLocale,
       })
       assert.throws(block, RangeError)
     })
 
-    it("throws `RangeError` if `options.locale` doesn't have `formatLong` property", function() {
+    it("throws `RangeError` if `options.locale` doesn't have `formatLong` property", function () {
       var customLocale = {
         // $ExpectedMistake
-        localize: {}
+        localize: {},
       }
       // $ExpectedMistake
       var block = format.bind(null, date, 'yyyy-MM-dd', {
-        locale: customLocale
+        locale: customLocale,
       })
       assert.throws(block, RangeError)
     })
   })
 
-  it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function() {
+  it('throws `RangeError` if `options.weekStartsOn` is not convertable to 0, 1, ..., 6 or undefined', function () {
     // $ExpectedMistake
     var block = format.bind(null, new Date(2007, 11 /* Dec */, 31), 'yyyy', {
-      weekStartsOn: NaN
+      weekStartsOn: NaN,
     })
     assert.throws(block, RangeError)
   })
 
-  it('throws `RangeError` if `options.firstWeekContainsDate` is not convertable to 1, 2, ..., 7 or undefined', function() {
+  it('throws `RangeError` if `options.firstWeekContainsDate` is not convertable to 1, 2, ..., 7 or undefined', function () {
     // $ExpectedMistake
     var block = format.bind(null, new Date(2007, 11 /* Dec */, 31), 'yyyy', {
-      firstWeekContainsDate: NaN
+      firstWeekContainsDate: NaN,
     })
     assert.throws(block, RangeError)
   })
 
-  it('throws RangeError exception if the format string is undefined', function() {
+  it('throws RangeError exception if the format string is undefined', function () {
     const block = format.bind(null, date, undefined)
     assert.throws(block, RangeError)
     assert.throws(block, /format must be defined/)
   })
 
-  it('throws RangeError exception if the format string contains an unescaped latin alphabet character', function() {
+  it('throws RangeError exception if the format string contains an unescaped latin alphabet character', function () {
     assert.throws(format.bind(null, date, 'yyyy-MM-dd-nnnn'), RangeError)
   })
 
-  it('throws TypeError exception if passed less than 2 arguments', function() {
+  it('throws TypeError exception if passed less than 2 arguments', function () {
     assert.throws(format.bind(null), TypeError)
     assert.throws(format.bind(null, 1), TypeError)
   })
@@ -755,7 +755,7 @@ describe('format', function() {
 
     it('allows D token if useAdditionalDayOfYearTokens is set to true', () => {
       const result = format(date, 'yyyy-MM-D', {
-        useAdditionalDayOfYearTokens: true
+        useAdditionalDayOfYearTokens: true,
       })
       assert.deepEqual(result, '1986-04-94')
     })
@@ -771,7 +771,7 @@ describe('format', function() {
 
     it('allows DD token if useAdditionalDayOfYearTokens is set to true', () => {
       const result = format(date, 'yyyy-MM-DD', {
-        useAdditionalDayOfYearTokens: true
+        useAdditionalDayOfYearTokens: true,
       })
       assert.deepEqual(result, '1986-04-94')
     })
@@ -787,7 +787,7 @@ describe('format', function() {
 
     it('allows YY token if useAdditionalWeekYearTokens is set to true', () => {
       const result = format(date, 'YY-MM-dd', {
-        useAdditionalWeekYearTokens: true
+        useAdditionalWeekYearTokens: true,
       })
       assert.deepEqual(result, '86-04-04')
     })
@@ -803,7 +803,7 @@ describe('format', function() {
 
     it('allows YYYY token if useAdditionalWeekYearTokens is set to true', () => {
       const result = format(date, 'YYYY-MM-dd', {
-        useAdditionalWeekYearTokens: true
+        useAdditionalWeekYearTokens: true,
       })
       assert.deepEqual(result, '1986-04-04')
     })

--- a/src/format/test.js
+++ b/src/format/test.js
@@ -728,6 +728,12 @@ describe('format', function() {
     assert.throws(block, RangeError)
   })
 
+  it('throws RangeError exception if the format string is undefined', function() {
+    const block = format.bind(null, date, undefined)
+    assert.throws(block, RangeError)
+    assert.throws(block, /format must be defined/)
+  })
+
   it('throws RangeError exception if the format string contains an unescaped latin alphabet character', function() {
     assert.throws(format.bind(null, date, 'yyyy-MM-dd-nnnn'), RangeError)
   })

--- a/src/formatRelative/index.js
+++ b/src/formatRelative/index.js
@@ -91,5 +91,9 @@ export default function formatRelative(dirtyDate, dirtyBaseDate, dirtyOptions) {
     getTimezoneOffsetInMilliseconds(baseDate)
   )
   var formatStr = locale.formatRelative(token, utcDate, utcBaseDate, options)
+  if (formatStr === undefined) {
+    token = 'other'
+    formatStr = locale.formatRelative(token, utcDate, utcBaseDate, options)
+  }
   return format(date, formatStr, options)
 }

--- a/src/formatRelative/test.js
+++ b/src/formatRelative/test.js
@@ -160,6 +160,32 @@ describe('formatRelative', function() {
       })
       assert.throws(block, RangeError)
     })
+    
+    it("fallbacks to `other` token when locale's `formatRelative` does not handle the more precise token", function() {
+      var customLocale = {
+        localize: {
+          month: function() {
+            return 'works'
+          }
+        },
+        formatLong: {
+          date: function() {
+            return "'It' MMMM"
+          }
+        },
+        formatRelative: function(token) {
+          if (token === 'other') {
+            return "P 'perfectly!'"
+          }
+        }
+      }
+      var result = formatRelative(
+        new Date(1986, 3 /* Apr */, 5, 10, 32, 0, 900),
+        baseDate,
+        { locale: customLocale }
+      )
+      assert(result === 'It works perfectly!')
+    })
   })
 
   it('throws TypeError exception if passed less than 2 arguments', function() {

--- a/src/formatRelative/test.js
+++ b/src/formatRelative/test.js
@@ -4,15 +4,15 @@
 import assert from 'power-assert'
 import formatRelative from '.'
 
-describe('formatRelative', function() {
+describe('formatRelative', function () {
   var baseDate = new Date(1986, 3 /* Apr */, 4, 10, 32, 0, 900)
 
-  it('accepts a timestamp', function() {
+  it('accepts a timestamp', function () {
     var date = new Date(2014, 3 /* Apr */, 4)
     assert(formatRelative(date.getTime(), baseDate.getTime()) === '04/04/2014')
   })
 
-  it('before the last week', function() {
+  it('before the last week', function () {
     var result = formatRelative(
       new Date(1986, 2 /* Mar */, 28, 16, 50),
       baseDate
@@ -20,12 +20,12 @@ describe('formatRelative', function() {
     assert(result === '03/28/1986')
   })
 
-  it('last week', function() {
+  it('last week', function () {
     var result = formatRelative(new Date(1986, 3 /* Apr */, 1), baseDate)
     assert(result === 'last Tuesday at 12:00 AM')
   })
 
-  it('yesterday', function() {
+  it('yesterday', function () {
     var result = formatRelative(
       new Date(1986, 3 /* Apr */, 3, 22, 22),
       baseDate
@@ -33,7 +33,7 @@ describe('formatRelative', function() {
     assert(result === 'yesterday at 10:22 PM')
   })
 
-  it('today', function() {
+  it('today', function () {
     var result = formatRelative(
       new Date(1986, 3 /* Apr */, 4, 16, 50),
       baseDate
@@ -41,17 +41,17 @@ describe('formatRelative', function() {
     assert(result === 'today at 4:50 PM')
   })
 
-  it('tomorrow', function() {
+  it('tomorrow', function () {
     var result = formatRelative(new Date(1986, 3 /* Apr */, 5, 7, 30), baseDate)
     assert(result === 'tomorrow at 7:30 AM')
   })
 
-  it('next week', function() {
+  it('next week', function () {
     var result = formatRelative(new Date(1986, 3 /* Apr */, 6, 12, 0), baseDate)
     assert(result === 'Sunday at 12:00 PM')
   })
 
-  it('after the next week', function() {
+  it('after the next week', function () {
     var result = formatRelative(
       new Date(1986, 3 /* Apr */, 11, 16, 50),
       baseDate
@@ -59,15 +59,15 @@ describe('formatRelative', function() {
     assert(result === '04/11/1986')
   })
 
-  describe('edge cases', function() {
-    it("throws RangeError if the date isn't valid", function() {
+  describe('edge cases', function () {
+    it("throws RangeError if the date isn't valid", function () {
       assert.throws(
         formatRelative.bind(null, new Date(NaN), baseDate),
         RangeError
       )
     })
 
-    it("throws RangeError if the base date isn't valid", function() {
+    it("throws RangeError if the base date isn't valid", function () {
       assert.throws(
         formatRelative.bind(
           null,
@@ -78,14 +78,14 @@ describe('formatRelative', function() {
       )
     })
 
-    it("throws RangeError if both dates aren't valid", function() {
+    it("throws RangeError if both dates aren't valid", function () {
       assert.throws(
         formatRelative.bind(null, new Date(NaN), new Date(NaN)),
         RangeError
       )
     })
 
-    it('handles dates before 100 AD', function() {
+    it('handles dates before 100 AD', function () {
       var date = new Date(0)
       date.setFullYear(7, 11 /* Dec */, 31)
       date.setHours(0, 0, 0, 0)
@@ -93,22 +93,22 @@ describe('formatRelative', function() {
     })
   })
 
-  describe('custom locale', function() {
-    it('allows to pass a custom locale', function() {
+  describe('custom locale', function () {
+    it('allows to pass a custom locale', function () {
       var customLocale = {
         localize: {
-          month: function() {
+          month: function () {
             return 'works'
-          }
+          },
         },
         formatLong: {
-          date: function() {
+          date: function () {
             return "'It' MMMM"
-          }
+          },
         },
-        formatRelative: function() {
+        formatRelative: function () {
           return "P 'perfectly!'"
-        }
+        },
       }
       var result = formatRelative(
         new Date(1986, 2 /* Mar */, 28, 16, 50),
@@ -119,65 +119,65 @@ describe('formatRelative', function() {
       assert(result === 'It works perfectly!')
     })
 
-    it("throws `RangeError` if `options.locale` doesn't have `localize` property", function() {
+    it("throws `RangeError` if `options.locale` doesn't have `localize` property", function () {
       var customLocale = {
         formatLong: {},
-        formatRelative: function() {
+        formatRelative: function () {
           return ''
-        }
+        },
       }
       // $ExpectedMistake
       var block = formatRelative.bind(null, new Date(2017, 0, 1), baseDate, {
-        locale: customLocale
+        locale: customLocale,
       })
       assert.throws(block, RangeError)
     })
 
-    it("throws `RangeError` if `options.locale` doesn't have `formatLong` property", function() {
+    it("throws `RangeError` if `options.locale` doesn't have `formatLong` property", function () {
       var customLocale = {
         // $ExpectedMistake
         localize: {},
-        formatRelative: function() {
+        formatRelative: function () {
           return ''
-        }
+        },
       }
       // $ExpectedMistake
       var block = formatRelative.bind(null, new Date(2017, 0, 1), baseDate, {
-        locale: customLocale
+        locale: customLocale,
       })
       assert.throws(block, RangeError)
     })
 
-    it("throws `RangeError` if `options.locale` doesn't have `formatRelative` property", function() {
+    it("throws `RangeError` if `options.locale` doesn't have `formatRelative` property", function () {
       var customLocale = {
         // $ExpectedMistake
         localize: {},
-        formatLong: {}
+        formatLong: {},
       }
       // $ExpectedMistake
       var block = formatRelative.bind(null, new Date(2017, 0, 1), baseDate, {
-        locale: customLocale
+        locale: customLocale,
       })
       assert.throws(block, RangeError)
     })
-    
-    it("fallbacks to `other` token when locale's `formatRelative` does not handle the more precise token", function() {
+
+    it("fallbacks to `other` token when locale's `formatRelative` does not handle the more precise token", function () {
       var customLocale = {
         localize: {
-          month: function() {
+          month: function () {
             return 'works'
-          }
+          },
         },
         formatLong: {
-          date: function() {
+          date: function () {
             return "'It' MMMM"
-          }
+          },
         },
-        formatRelative: function(token) {
+        formatRelative: function (token) {
           if (token === 'other') {
             return "P 'perfectly!'"
           }
-        }
+        },
       }
       var result = formatRelative(
         new Date(1986, 3 /* Apr */, 5, 10, 32, 0, 900),
@@ -188,7 +188,7 @@ describe('formatRelative', function() {
     })
   })
 
-  it('throws TypeError exception if passed less than 2 arguments', function() {
+  it('throws TypeError exception if passed less than 2 arguments', function () {
     assert.throws(formatRelative.bind(null), TypeError)
     assert.throws(formatRelative.bind(null, 1), TypeError)
   })


### PR DESCRIPTION
This PR aims to solve 2 problems mentioned in https://github.com/date-fns/date-fns/issues/1273:

1. Use the `"other"` token as default when locale's `formatRelative` does not handle a more specific token (e.g. `"tomorrow"` returns `undefined`) (solution suggested in https://github.com/date-fns/date-fns/issues/1273#issuecomment-522949806)
2. Improve the error message thrown when `formatStr` passed to `format` is undefined.
    Previously, the error message thrown in such a situation would be `RangeError: Format string contains an unescaped latin alphabet character n`, which does not really say much

The 2nd change is not mentioned specifically in the ticket, but I reckon it would at least help with debugging in some cases, especially when `format` is called internally within some other API function.

This is my first contribution to the project, which I am excited about 🙂 

## Formatting changes

I have noticed that the formatting in the files I modified differs vastly from what prettier's formatting. I presume this is because of a recent commit that upgrades prettier (https://github.com/date-fns/date-fns/commit/4a328dda165320dde149c531d8643c597ce7170f), but does not reformat files.

That confused me a bit and made me spend time on verifying prettier's configuration 😄 I reckon it would be nice to clearly communicate in `CONTRIBUTING.md` that there may be formatting issues and how to proceed in such cases (reformat the file, or discard formatting changes) 🙂 That could help other contributors

I separated reformatting the files I modified in this PR into separate commits. Hopefully, that makes the functional changes easier to verify

## Rebuilng using `scripts/build/build.sh`

I have tried running `build.sh`, as instructed in `CONTRIBUTING.md`, but it failed:

```sh
✘-INT ~/projects/open-source/date-fns [use-default-token-in-formatRelative|…1]
09:17 $ ./scripts/build/build.sh
+ ./scripts/build/docs.js
TypeError: Cannot read property 'customTags' of undefined
    at /home/voreny/projects/open-source/date-fns/scripts/build/docs.js:43:13
    at Array.map (<anonymous>)
    at generateDocsFromSource (/home/voreny/projects/open-source/date-fns/scripts/build/docs.js:41:6)
```

I did not dig deep enough to find out why, as I don't have much knowledge about this build pipeline.

Here are the contents of my `./tmp` directory (inside of the repo):
```sh
09:32 $ ls tmp --all --tree
tmp
├── .gitkeep
└── tests_count.txt
```

Let me know what I should do in this case 🙂 