### PR TITLE
feat: add custom businessDays option to addBusinessDays

### DIFF
--- a/src/addBusinessDays/index.ts
+++ b/src/addBusinessDays/index.ts
@@ -1,9 +1,6 @@
-import isWeekend from '../isWeekend/index'
 import toDate from '../toDate/index'
 import toInteger from '../_lib/toInteger/index'
 import requiredArgs from '../_lib/requiredArgs/index'
-import isSunday from '../isSunday/index'
-import isSaturday from '../isSaturday/index'
 
 /**
  * @name addBusinessDays
@@ -15,6 +12,8 @@ import isSaturday from '../isSaturday/index'
  *
  * @param {Date|Number} date - the date to be changed
  * @param {Number} amount - the amount of business days to be added. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Object} [options] - an object with options.
+ * @param {Number[]} [options.businessDays=[1, 2, 3, 4, 5]] - the business days. default is Monday to Friday.
  * @returns {Date} the new date with the business days added
  * @throws {TypeError} 2 arguments required
  *
@@ -25,40 +24,59 @@ import isSaturday from '../isSaturday/index'
  */
 export default function addBusinessDays(
   dirtyDate: Date | number,
-  dirtyAmount: number
+  dirtyAmount: number,
+  dirtyOptions?: {
+    businessDays?: number[]
+  }
 ): Date {
   requiredArgs(2, arguments)
+  const options = dirtyOptions || {}
+  const businessDays =
+    options.businessDays == null
+      ? [1, 2, 3, 4, 5]
+      : options.businessDays.map(toInteger)
 
   const date = toDate(dirtyDate)
-  const startedOnWeekend = isWeekend(date)
   const amount = toInteger(dirtyAmount)
+  const isHoliday = (date: Date) => !businessDays.includes(date.getDay())
+  const startedOnHoliday = isHoliday(date)
 
   if (isNaN(amount)) return new Date(NaN)
 
+  if (date.toString() === 'Invalid Date') {
+    return date
+  }
+
   const hours = date.getHours()
   const sign = amount < 0 ? -1 : 1
-  const fullWeeks = toInteger(amount / 5)
-
+  const fullWeeks = toInteger(amount / businessDays.length)
   date.setDate(date.getDate() + fullWeeks * 7)
 
   // Get remaining days not part of a full week
-  let restDays = Math.abs(amount % 5)
+  let restDays = Math.abs(amount % businessDays.length)
 
   // Loops over remaining days
   while (restDays > 0) {
     date.setDate(date.getDate() + sign)
-    if (!isWeekend(date)) restDays -= 1
+    if (!isHoliday(date)) restDays -= 1
   }
 
-  // If the date is a weekend day and we reduce a dividable of
-  // 5 from it, we land on a weekend date.
+  // If the date is a holiday and we reduce a dividable of
+  // certain days (say 5 when holiday is Saturday and Sunday) from it, we land on a holiday date.
   // To counter this, we add days accordingly to land on the next business day
-  if (startedOnWeekend && isWeekend(date) && amount !== 0) {
-    // If we're reducing days, we want to add days until we land on a weekday
-    // If we're adding days we want to reduce days until we land on a weekday
-    if (isSaturday(date)) date.setDate(date.getDate() + (sign < 0 ? 2 : -1))
-    if (isSunday(date)) date.setDate(date.getDate() + (sign < 0 ? 1 : -2))
+  const calc = (date: Date) => {
+    if (
+      startedOnHoliday &&
+      !businessDays.includes(date.getDay()) &&
+      amount !== 0
+    ) {
+      // If we're reducing days, we want to add days until we land on a business day
+      // If we're adding days we want to reduce days until we land on a business day
+      date.setDate(date.getDate() + (sign < 0 ? 1 : -1))
+      calc(date)
+    }
   }
+  calc(date)
 
   // Restore hours to avoid DST lag
   date.setHours(hours)

--- a/src/addBusinessDays/index.ts
+++ b/src/addBusinessDays/index.ts
@@ -62,21 +62,17 @@ export default function addBusinessDays(
   }
 
   // If the date is a holiday and we reduce a dividable of
-  // certain days (say 5 when holiday is Saturday and Sunday) from it, we land on a holiday date.
+  // certain days (say 5 when holidays are Saturday and Sunday) from it, we land on a holiday date.
   // To counter this, we add days accordingly to land on the next business day
-  const calc = (date: Date) => {
-    if (
-      startedOnHoliday &&
-      !businessDays.includes(date.getDay()) &&
-      amount !== 0
-    ) {
+  const reduceIfHoliday = (date: Date) => {
+    if (startedOnHoliday && isHoliday(date) && amount !== 0) {
       // If we're reducing days, we want to add days until we land on a business day
       // If we're adding days we want to reduce days until we land on a business day
       date.setDate(date.getDate() + (sign < 0 ? 1 : -1))
-      calc(date)
+      reduceIfHoliday(date)
     }
   }
-  calc(date)
+  reduceIfHoliday(date)
 
   // Restore hours to avoid DST lag
   date.setHours(hours)

--- a/src/addBusinessDays/test.ts
+++ b/src/addBusinessDays/test.ts
@@ -4,13 +4,13 @@
 import assert from 'assert'
 import addBusinessDays from '.'
 
-describe('addBusinessDays', function() {
-  it('adds the given number of business days', function() {
+describe('addBusinessDays', function () {
+  it('adds the given number of business days', function () {
     const result = addBusinessDays(new Date(2014, 8 /* Sep */, 1), 10)
     assert.deepStrictEqual(result, new Date(2014, 8 /* Sep */, 15))
   })
 
-  it('handles negative amount', function() {
+  it('handles negative amount', function () {
     const result = addBusinessDays(new Date(2014, 8 /* Sep */, 15), -10)
     assert.deepStrictEqual(result, new Date(2014, 8 /* Sep */, 1))
   })
@@ -36,7 +36,7 @@ describe('addBusinessDays', function() {
     )
   })
 
-  it('can handle a large number of business days', function() {
+  it('can handle a large number of business days', function () {
     // @ts-ignore
     if (typeof this.timeout === 'function') {
       // @ts-ignore
@@ -47,49 +47,75 @@ describe('addBusinessDays', function() {
     assert.deepStrictEqual(result, new Date(15000, 0 /* Jan */, 1))
   })
 
-  it('accepts a timestamp', function() {
+  it('accepts a timestamp', function () {
     const result = addBusinessDays(new Date(2014, 8 /* Sep */, 1).getTime(), 10)
     assert.deepStrictEqual(result, new Date(2014, 8 /* Sep */, 15))
   })
 
-  it('converts a fractional number to an integer', function() {
+  it('converts a fractional number to an integer', function () {
     const result = addBusinessDays(new Date(2014, 8 /* Sep */, 1), 10.5)
     assert.deepStrictEqual(result, new Date(2014, 8 /* Sep */, 15))
   })
 
-  it('implicitly converts number arguments', function() {
+  it('implicitly converts number arguments', function () {
     // @ts-expect-error
     const result = addBusinessDays(new Date(2014, 8 /* Sep */, 1), '10')
     assert.deepStrictEqual(result, new Date(2014, 8 /* Sep */, 15))
   })
 
-  it('does not mutate the original date', function() {
+  it('does not mutate the original date', function () {
     const date = new Date(2014, 8 /* Sep */, 1)
     addBusinessDays(date, 11)
     assert.deepStrictEqual(date, new Date(2014, 8 /* Sep */, 1))
   })
 
-  it('returns `Invalid Date` if the given date is invalid', function() {
+  it('returns `Invalid Date` if the given date is invalid', function () {
     const result = addBusinessDays(new Date(NaN), 10)
     assert(result instanceof Date && isNaN(result.getTime()))
   })
 
-  it('returns `Invalid Date` if the given amount is NaN', function() {
+  it('returns `Invalid Date` if the given amount is NaN', function () {
     const result = addBusinessDays(new Date(2014, 8 /* Sep */, 1), NaN)
     assert(result instanceof Date && isNaN(result.getTime()))
   })
 
-  it('throws TypeError exception if passed less than 2 arguments', function() {
+  it('throws TypeError exception if passed less than 2 arguments', function () {
     // @ts-expect-error
     assert.throws(addBusinessDays.bind(null), TypeError)
     // @ts-expect-error
     assert.throws(addBusinessDays.bind(null, 1), TypeError)
   })
-  it('starting from a weekend day should land on a weekday when reducing a divisible by 5', function() {
+  it('starting from a weekend day should land on a weekday when reducing a divisible by 5', function () {
     const substractResult = addBusinessDays(new Date(2019, 7, 18), -5)
     assert.deepStrictEqual(substractResult, new Date(2019, 7, 12))
 
     const addResult = addBusinessDays(new Date(2019, 7, 18), 5)
     assert.deepStrictEqual(addResult, new Date(2019, 7, 23))
+  })
+
+  it('starting from a weekend day should land on a weekday when reducing a divisible by 5', function () {
+    const substractResult = addBusinessDays(new Date(2019, 7, 18), -5)
+    assert.deepStrictEqual(substractResult, new Date(2019, 7, 12))
+
+    const addResult = addBusinessDays(new Date(2019, 7, 18), 5)
+    assert.deepStrictEqual(addResult, new Date(2019, 7, 23))
+  })
+
+  it('if custom businessDays are Tuesday to Friday, it should return the Tuesday when 1 day is added on the Saturday ', function () {
+    assert.deepStrictEqual(
+      addBusinessDays(new Date(2020, 0 /* Jan */, 10), 1 /* Friday */, {
+        businessDays: [2, 3, 4, 5],
+      }),
+      new Date(2020, 0 /* Jan */, 14) // Tuesday
+    )
+  })
+
+  it('if custom businessDays are Monday and Wednesday, it returns the Thursday when 2 days is added on the Sunday', function () {
+    assert.deepStrictEqual(
+      addBusinessDays(new Date(2020, 0 /* Jan */, 12), 2 /* Sunday */, {
+        businessDays: [1, 3],
+      }),
+      new Date(2020, 0 /* Jan */, 15) // Thursday
+    )
   })
 })

--- a/src/subBusinessDays/index.ts
+++ b/src/subBusinessDays/index.ts
@@ -12,6 +12,8 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *
  * @param {Date|Number} date - the date to be changed
  * @param {Number} amount - the amount of business days to be subtracted. Positive decimals will be rounded using `Math.floor`, decimals less than zero will be rounded using `Math.ceil`.
+ * @param {Object} [options] - an object with options.
+ * @param {Number[]} [options.businessDays=[1, 2, 3, 4, 5]] - the business days. default is Monday to Friday.
  * @returns {Date} the new date with the business days subtracted
  * @throws {TypeError} 2 arguments required
  *
@@ -20,9 +22,20 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * var result = subBusinessDays(new Date(2014, 8, 1), 10)
  * //=> Mon Aug 18 2014 00:00:00 (skipped weekend days)
  */
-export default function subBusinessDays(dirtyDate, dirtyAmount) {
+export default function subBusinessDays(
+  dirtyDate: Date | number,
+  dirtyAmount: number,
+  dirtyOptions?: {
+    businessDays?: number[]
+  }
+) {
   requiredArgs(2, arguments)
 
-  var amount = toInteger(dirtyAmount)
-  return addBusinessDays(dirtyDate, -amount)
+  const amount = toInteger(dirtyAmount)
+  const options = dirtyOptions || {}
+  const businessDays =
+    options.businessDays == null
+      ? [1, 2, 3, 4, 5]
+      : options.businessDays.map(toInteger)
+  return addBusinessDays(dirtyDate, -amount, { businessDays })
 }


### PR DESCRIPTION
This PR adds custom businessDays option to addBusinessDays (and subBusinessDays).

Typescriptifed subBusinessDays as well https://github.com/date-fns/date-fns-typescriptify/issues/139

```
addBusinessDays(new Date(), 1, {
  businessDays: [1, 2, 3] // <- here
})
```

API design:
* default is Monday to Friday which means it doesn't affect current behavior.
* options now accepts only businessDays, but there could be other options in the future (say holidays).

A Question for maintainers:
I couldn't build docs because of the error below but it happens on master branch as well. I missed something?

```
TypeError: Cannot read property 'customTags' of undefined
    at /Users/nakamurayoshihiro/oss/date-fns/scripts/build/docs.js:43:13
    at Array.map (<anonymous>)
    at generateDocsFromSource (/Users/nakamurayoshihiro/oss/date-fns/scripts/build/docs.js:41:6)
```