### PR TITLE
Add maxUnit option to formatDistance(ToNow)Strict

### DIFF
--- a/src/formatDistanceStrict/index.js
+++ b/src/formatDistanceStrict/index.js
@@ -104,6 +104,7 @@ var MINUTES_IN_YEAR = MINUTES_IN_DAY * 365
  * @param {Boolean} [options.addSuffix=false] - result indicates if the second date is earlier or later than the first
  * @param {'second'|'minute'|'hour'|'day'|'month'|'year'} [options.unit] - if specified, will force a unit
  * @param {'floor'|'ceil'|'round'} [options.roundingMethod='round'] - which way to round partial units
+ * @param {'second'|'minute'|'hour'|'day'|'month'} [options.maxUnit] - if specified, the value will be used as the highest unit possible
  * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
  * @returns {String} the distance in words
  * @throws {TypeError} 2 arguments required
@@ -142,6 +143,14 @@ var MINUTES_IN_YEAR = MINUTES_IN_DAY * 365
  *   unit: 'minute'
  * })
  * //=> '525600 minutes'
+ *
+ * @example
+ * // What is the distance from 1 January 2016
+ * // to 1 January 2015, with month as highest unit?
+ * var result = formatDistanceStrict(new Date(2016, 0, 1), new Date(2015, 0, 1), {
+ *   maxUnit: 'month'
+ * })
+ * //=> '12 months'
  *
  * @example
  * // What is the distance from 1 January 2015
@@ -222,15 +231,21 @@ export default function formatDistanceStrict(
 
   var unit
   if (options.unit == null) {
-    if (minutes < 1) {
+    if (minutes < 1 || options.maxUnit == 'second') {
       unit = 'second'
-    } else if (minutes < 60) {
+    } else if (minutes < 60 || options.maxUnit == 'minute') {
       unit = 'minute'
-    } else if (minutes < MINUTES_IN_DAY) {
+    } else if (minutes < MINUTES_IN_DAY || options.maxUnit == 'hour') {
       unit = 'hour'
-    } else if (dstNormalizedMinutes < MINUTES_IN_MONTH) {
+    } else if (
+      dstNormalizedMinutes < MINUTES_IN_MONTH ||
+      options.maxUnit == 'day'
+    ) {
       unit = 'day'
-    } else if (dstNormalizedMinutes < MINUTES_IN_YEAR) {
+    } else if (
+      dstNormalizedMinutes < MINUTES_IN_YEAR ||
+      options.maxUnit == 'month'
+    ) {
       unit = 'month'
     } else {
       unit = 'year'

--- a/src/formatDistanceStrict/test.js
+++ b/src/formatDistanceStrict/test.js
@@ -281,6 +281,144 @@ describe('formatDistanceStrict', function () {
     })
   })
 
+  describe('when the maxUnit option is supplied', function () {
+    describe('second', function () {
+      it('1 second', function () {
+        var result = formatDistanceStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 4, 10, 32, 1),
+          { maxUnit: 'second' }
+        )
+        assert(result === '1 second')
+      })
+
+      it('1 minute', function () {
+        var result = formatDistanceStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 4, 10, 33, 0),
+          { maxUnit: 'second' }
+        )
+        assert(result === '60 seconds')
+      })
+    })
+
+    describe('minute', function () {
+      it('1 second', function () {
+        var result = formatDistanceStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 4, 10, 32, 1),
+          { maxUnit: 'minute' }
+        )
+        assert(result === '1 second')
+      })
+
+      it('1 minute', function () {
+        var result = formatDistanceStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 4, 10, 33, 0),
+          { maxUnit: 'minute' }
+        )
+        assert(result === '1 minute')
+      })
+
+      it('1 hour', function () {
+        var result = formatDistanceStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 4, 11, 32, 0),
+          { maxUnit: 'minute' }
+        )
+        assert(result === '60 minutes')
+      })
+    })
+
+    describe('hour', function () {
+      it('1 minute', function () {
+        var result = formatDistanceStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 4, 10, 33, 0),
+          { maxUnit: 'hour' }
+        )
+        assert(result === '1 minute')
+      })
+
+      it('1 hour', function () {
+        var result = formatDistanceStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 4, 11, 32, 0),
+          { maxUnit: 'hour' }
+        )
+        assert(result === '1 hour')
+      })
+
+      it('1 day', function () {
+        var result = formatDistanceStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 5, 10, 32, 0),
+          { maxUnit: 'hour' }
+        )
+        assert(result === '24 hours')
+      })
+    })
+
+    describe('day', function () {
+      it('1 hour', function () {
+        var result = formatDistanceStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 4, 11, 32, 0),
+          { maxUnit: 'day' }
+        )
+        assert(result === '1 hour')
+      })
+
+      it('1 day', function () {
+        var result = formatDistanceStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 5, 10, 32, 0),
+          { maxUnit: 'day' }
+        )
+        assert(result === '1 day')
+      })
+
+      it('1 month', function () {
+        var result = formatDistanceStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 4, 4, 10, 32, 0),
+          { maxUnit: 'day' }
+        )
+        assert(result === '30 days')
+      })
+    })
+
+    describe('month', function () {
+      it('1 day', function () {
+        var result = formatDistanceStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 3, 5, 10, 32, 0),
+          { maxUnit: 'month' }
+        )
+        assert(result === '1 day')
+      })
+
+      it('1 month', function () {
+        var result = formatDistanceStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1986, 4, 4, 10, 32, 0),
+          { maxUnit: 'month' }
+        )
+        assert(result === '1 month')
+      })
+
+      it('1 year', function () {
+        var result = formatDistanceStrict(
+          new Date(1986, 3, 4, 10, 32, 0),
+          new Date(1987, 3, 4, 10, 32, 0),
+          { maxUnit: 'month' }
+        )
+        assert(result === '12 months')
+      })
+    })
+  })
+
   it('accepts timestamps', function () {
     var result = formatDistanceStrict(
       new Date(1986, 3, 4, 10, 32, 0).getTime(),

--- a/src/formatDistanceToNowStrict/index.js
+++ b/src/formatDistanceToNowStrict/index.js
@@ -25,6 +25,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * @param {Object} [options] - an object with options.
  * @param {Boolean} [options.addSuffix=false] - result indicates if the second date is earlier or later than the first
  * @param {'second'|'minute'|'hour'|'day'|'month'|'year'} [options.unit] - if specified, will force a unit
+ * @param {'second'|'minute'|'hour'|'day'|'month'} [options.maxUnit] - if specified, the value will be used as the highest unit possible
  * @param {'floor'|'ceil'|'round'} [options.roundingMethod='round'] - which way to round partial units
  * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
  * @returns {String} the distance in words
@@ -64,6 +65,14 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *   roundingMethod: 'ceil'
  * })
  * //=> '1 month'
+ *
+ * @example
+ * // If today is 28 January 2015,
+ * // what is the distance to 30 January 2015, with minute as highest unit?
+ * var result = formatDistanceToNowStrict(new Date(2015, 0, 30), {
+ *   maxUnit: 'minute'
+ * })
+ * //=> '2880 minutes'
  *
  * @example
  * // If today is 1 January 2015,

--- a/src/formatDistanceToNowStrict/test.js
+++ b/src/formatDistanceToNowStrict/test.js
@@ -238,6 +238,130 @@ describe('formatDistanceToNowStrict', function () {
     })
   })
 
+  describe('when the maxUnit option is supplied', function () {
+    describe('second', function () {
+      it('1 second', function () {
+        var result = formatDistanceToNowStrict(
+          new Date(1986, 3, 4, 10, 32, 1),
+          { maxUnit: 'second' }
+        )
+        assert(result === '1 second')
+      })
+
+      it('1 minute', function () {
+        var result = formatDistanceToNowStrict(
+          new Date(1986, 3, 4, 10, 33, 0),
+          { maxUnit: 'second' }
+        )
+        assert(result === '60 seconds')
+      })
+    })
+
+    describe('minute', function () {
+      it('1 second', function () {
+        var result = formatDistanceToNowStrict(
+          new Date(1986, 3, 4, 10, 32, 1),
+          { maxUnit: 'minute' }
+        )
+        assert(result === '1 second')
+      })
+
+      it('1 minute', function () {
+        var result = formatDistanceToNowStrict(
+          new Date(1986, 3, 4, 10, 33, 0),
+          { maxUnit: 'minute' }
+        )
+        assert(result === '1 minute')
+      })
+
+      it('1 hour', function () {
+        var result = formatDistanceToNowStrict(
+          new Date(1986, 3, 4, 11, 32, 0),
+          { maxUnit: 'minute' }
+        )
+        assert(result === '60 minutes')
+      })
+    })
+
+    describe('hour', function () {
+      it('1 minute', function () {
+        var result = formatDistanceToNowStrict(
+          new Date(1986, 3, 4, 10, 33, 0),
+          { maxUnit: 'hour' }
+        )
+        assert(result === '1 minute')
+      })
+
+      it('1 hour', function () {
+        var result = formatDistanceToNowStrict(
+          new Date(1986, 3, 4, 11, 32, 0),
+          { maxUnit: 'hour' }
+        )
+        assert(result === '1 hour')
+      })
+
+      it('1 day', function () {
+        var result = formatDistanceToNowStrict(
+          new Date(1986, 3, 5, 10, 32, 0),
+          { maxUnit: 'hour' }
+        )
+        assert(result === '24 hours')
+      })
+    })
+
+    describe('day', function () {
+      it('1 hour', function () {
+        var result = formatDistanceToNowStrict(
+          new Date(1986, 3, 4, 11, 32, 0),
+          { maxUnit: 'day' }
+        )
+        assert(result === '1 hour')
+      })
+
+      it('1 day', function () {
+        var result = formatDistanceToNowStrict(
+          new Date(1986, 3, 5, 10, 32, 0),
+          { maxUnit: 'day' }
+        )
+        assert(result === '1 day')
+      })
+
+      it('1 month', function () {
+        var result = formatDistanceToNowStrict(
+          new Date(1986, 4, 4, 10, 32, 0),
+          { maxUnit: 'day' }
+        )
+        assert(result === '30 days')
+      })
+    })
+
+    describe('month', function () {
+      it('1 day', function () {
+        var result = formatDistanceToNowStrict(
+          new Date(1986, 3, 5, 10, 32, 0),
+          { maxUnit: 'month' }
+        )
+        assert(result === '1 day')
+      })
+
+      it('1 month', function () {
+        var result = formatDistanceToNowStrict(
+          new Date(1986, 4, 4, 10, 32, 0),
+          { maxUnit: 'month' }
+        )
+        assert(result === '1 month')
+      })
+
+      it('1 year', function () {
+        var result = formatDistanceToNowStrict(
+          new Date(1987, 3, 4, 10, 32, 0),
+          { maxUnit: 'month' }
+        )
+        assert(result === '12 months')
+      })
+    })
+  })
+
   it('accepts timestamps', function () {
     var result = formatDistanceToNowStrict(
       new Date(1986, 3, 4, 11, 32, 0).getTime()


### PR DESCRIPTION
This PR adds a `maxUnit` option to both `formatDistanceStrict` and `formatDistanceToNowStrict` methods.

Different from the regular `unit`, which forces the displayed unit, this option lets one choose the highest unit that should be used.

That might be useful when dealing with a particular range of distances, forcing the highest but letting multiple units be used.

This option should receive any of these values: `'second' | 'minute' | 'hour' | 'day' | 'month'`. `'year'` was not included, as it represents the regular use case. 

Tests were added to cover all use cases.

ex: by using `day` as `maxUnit`, distances will be displayed normally with `second, minute, hour and day` units, and distances of `month and year` will be forced as `days`. That can be observed in the tests below.

```js
      it('1 hour', function () {
        var result = formatDistanceStrict(
          new Date(1986, 3, 4, 10, 32, 0),
          new Date(1986, 3, 4, 11, 32, 0),
          { maxUnit: 'day' }
        )
        assert(result === '1 hour')
      })

      it('1 day', function () {
        var result = formatDistanceStrict(
          new Date(1986, 3, 4, 10, 32, 0),
          new Date(1986, 3, 5, 10, 32, 0),
          { maxUnit: 'day' }
        )
        assert(result === '1 day')
      })

      it('1 month', function () {
        var result = formatDistanceStrict(
          new Date(1986, 3, 4, 10, 32, 0),
          new Date(1986, 4, 4, 10, 32, 0),
          { maxUnit: 'day' }
        )
        assert(result === '30 days')
      })
```

