### PR TITLE
Round seconds

### DIFF
--- a/src/intervalToDuration/index.js
+++ b/src/intervalToDuration/index.js
@@ -4,7 +4,7 @@ import differenceInMonths from '../differenceInMonths/index'
 import differenceInDays from '../differenceInDays/index'
 import differenceInHours from '../differenceInHours/index'
 import differenceInMinutes from '../differenceInMinutes/index'
-import differenceInSeconds from '../differenceInSeconds/index'
+import differenceInMilliseconds from '../differenceInMilliseconds/index'
 import isValid from '../isValid/index'
 import requiredArgs from '../_lib/requiredArgs/index'
 import toDate from '../toDate/index'
@@ -75,7 +75,7 @@ export default function intervalToDuration({ start, end }) {
   const remainingSeconds = sub(remainingMinutes, {
     minutes: sign * duration.minutes
   })
-  duration.seconds = Math.abs(differenceInSeconds(remainingSeconds, dateRight))
+  duration.seconds = Math.round(Math.abs(differenceInMilliseconds(remainingSeconds, dateRight) / 1000))
 
   return duration
 }

--- a/src/intervalToDuration/test.js
+++ b/src/intervalToDuration/test.js
@@ -50,6 +50,21 @@ describe('intervalToDuration', function () {
     })
   })
 
+  it('returns rounded seconds', function () {
+    const start = new Date(1929, 0, 15, 12, 0, 0)
+    const end = new Date(1968, 3, 4, 19, 5, 0, 750)
+    const result = intervalToDuration({ start, end })
+
+    assert.deepEqual(result, {
+      years: 39,
+      months: 2,
+      days: 20,
+      hours: 7,
+      minutes: 5,
+      seconds: 1,
+    })
+  })
+
   describe('edge cases', function () {
     it('returns correct duration for dates in the end of Feb - issue 2255', function () {
       assert.deepEqual(


### PR DESCRIPTION
When using `differenceInSeconds`, the value is truncated: 1.9 second become 1 second. However, until a rounding option is introduced, it is more accurate to round the remaining seconds instead of truncating it.