### PR TITLE
Allow flattening overflowing duration during format

### DIFF
--- a/src/formatDuration/index.js
+++ b/src/formatDuration/index.js
@@ -1,4 +1,6 @@
+import add from '../add/index'
 import defaultLocale from '../locale/en-US/index'
+import intervalToDuration from '../intervalToDuration/index'
 
 const defaultFormat = [
   'years',
@@ -22,9 +24,10 @@ const defaultFormat = [
  * @param {Object} [options] - an object with options.
 
  * @param {string[]} [options.format=['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds']] - the array of units to format
- * @param {boolean} [options.zero=false] - should be zeros be included in the output?
+ * @param {boolean} [options.zero=false] - should zeros be included in the output?
  * @param {string} [options.delimiter=' '] - delimiter string
  * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
+ * @param {boolean} [options.flatten=false] - should units be converted into higher equivalent?
  * @returns {string} the formatted date string
  * @throws {TypeError} 1 argument required
  *
@@ -72,6 +75,13 @@ const defaultFormat = [
  * // Customize the delimiter
  * formatDuration({ years: 2, months: 9, weeks: 3 }, { delimiter: ', ' })
  * //=> '2 years, 9 months, 3 weeks'
+ *
+ * @example
+ * // Flatten the duration
+ * formatDuration({ seconds: 90 }, { flatten: false })
+ * //=> '90 seconds'
+ * formatDuration({ seconds: 90 }, { flatten: true })
+ * //=> '1 minute 30 seconds'
  */
 export default function formatDuration(duration, options) {
   if (arguments.length < 1) {
@@ -84,6 +94,12 @@ export default function formatDuration(duration, options) {
   const locale = options?.locale || defaultLocale
   const zero = options?.zero || false
   const delimiter = options?.delimiter || ' '
+  const flatten = options?.flatten || false
+
+  if (flatten) {
+    const now = new Date()
+    duration = intervalToDuration({ start: now, end: add(now, duration) })
+  }
 
   const result = format
     .reduce((acc, unit) => {

--- a/src/formatDuration/index.js.flow
+++ b/src/formatDuration/index.js.flow
@@ -56,5 +56,6 @@ declare module.exports: (
     zero?: boolean,
     delimiter?: string,
     locale?: Locale,
+    flatten?: boolean,
   }
 ) => string

--- a/src/formatDuration/test.js
+++ b/src/formatDuration/test.js
@@ -14,7 +14,7 @@ describe('formatDuration', () => {
         days: 7,
         hours: 5,
         minutes: 9,
-        seconds: 30
+        seconds: 30,
       }) === '2 years 9 months 1 week 7 days 5 hours 9 minutes 30 seconds'
     )
   })
@@ -33,7 +33,7 @@ describe('formatDuration', () => {
           days: 7,
           hours: 5,
           minutes: 9,
-          seconds: 30
+          seconds: 30,
         },
         { format: ['months', 'weeks'] }
       ) === '9 months 1 week'
@@ -49,7 +49,7 @@ describe('formatDuration', () => {
         days: 0,
         hours: 0,
         minutes: 0,
-        seconds: 0
+        seconds: 0,
       }) === '1 week'
     )
   })
@@ -64,7 +64,7 @@ describe('formatDuration', () => {
           days: 0,
           hours: 0,
           minutes: 0,
-          seconds: 0
+          seconds: 0,
         },
         { zero: true }
       ) === '0 years 0 months 1 week 0 days 0 hours 0 minutes 0 seconds'
@@ -75,6 +75,18 @@ describe('formatDuration', () => {
     assert(
       formatDuration({ months: 9, days: 2 }, { delimiter: ', ' }) ===
         '9 months, 2 days'
+    )
+  })
+
+  it('allows for the duration to be flattened', () => {
+    assert(formatDuration({ seconds: 90 }, { flatten: false }) === '90 seconds')
+    assert(
+      formatDuration({ seconds: 90 }, { flatten: true }) ===
+        '1 minute 30 seconds'
+    )
+    assert(
+      formatDuration({ seconds: 35 * 24 * 60 * 60 + 75 }, { flatten: true }) ===
+        '1 month 5 days 1 minute 15 seconds'
     )
   })
 })

--- a/src/fp/formatDurationWithOptions/index.js.flow
+++ b/src/fp/formatDurationWithOptions/index.js.flow
@@ -57,6 +57,7 @@ type CurriedFn2<A, B, R> = <A>(
 
 declare module.exports: CurriedFn2<
   {
+    flatten?: boolean,
     locale?: Locale,
     delimiter?: string,
     zero?: boolean,

--- a/src/fp/index.js.flow
+++ b/src/fp/index.js.flow
@@ -237,6 +237,7 @@ declare module.exports: {
   formatDuration: CurriedFn1<Duration, string>,
   formatDurationWithOptions: CurriedFn2<
     {
+      flatten?: boolean,
       locale?: Locale,
       delimiter?: string,
       zero?: boolean,

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -331,6 +331,7 @@ declare module.exports: {
       zero?: boolean,
       delimiter?: string,
       locale?: Locale,
+      flatten?: boolean,
     }
   ) => string,
 

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -442,6 +442,7 @@ declare module 'date-fns' {
       zero?: boolean
       delimiter?: string
       locale?: Locale
+      flatten?: boolean
     }
   ): string
   namespace formatDuration {}
@@ -4888,6 +4889,7 @@ declare module 'date-fns/fp' {
 
   const formatDurationWithOptions: CurriedFn2<
     {
+      flatten?: boolean
       locale?: Locale
       delimiter?: string
       zero?: boolean
@@ -9542,6 +9544,7 @@ declare module 'date-fns/esm' {
       zero?: boolean
       delimiter?: string
       locale?: Locale
+      flatten?: boolean
     }
   ): string
   namespace formatDuration {}
@@ -13988,6 +13991,7 @@ declare module 'date-fns/esm/fp' {
 
   const formatDurationWithOptions: CurriedFn2<
     {
+      flatten?: boolean
       locale?: Locale
       delimiter?: string
       zero?: boolean
@@ -21510,6 +21514,7 @@ interface dateFns {
       zero?: boolean
       delimiter?: string
       locale?: Locale
+      flatten?: boolean
     }
   ): string
 


### PR DESCRIPTION
## What

Allow the `formatDuration`, to convert overflowing values into its higher units.

`90 seconds` -> `1 minute 30 seconds`
`3024075 seconds` -> `1 month 5 days 1 minute 15 seconds`