### PR TITLE
Add function nextBusinessDay

### DIFF
--- a/src/nextBusinessDay/index.ts
+++ b/src/nextBusinessDay/index.ts
@@ -1,40 +1,35 @@
-import { isWeekend, addDays, toDate, isEqual, startOfDay } from '..'
+import { addDays, isEqual, isWeekend, startOfDay, toDate } from '..'
 
 /**
  * @name nextBusinessDay
  * @category Day Helpers
- * @summary Returns the next business day
+ * @summary When is the next business day?
  *
  * @description Returns the next business day (Mon - Fri)
  *
  * @param {Date|Number} date - the initial date
- * @param {Number} [startFromDay=0] - The day that it starts to count, the
- * default is zero. So if the date is on a Monday it will return the current
- * date. To start counting from the next date set this to one.
- * @param {[Date]} excludeDates - An array of holidays or other dates that
- * should not be identified as business days
+ * @param {Number} [startFromDay=0] - the day that it starts counting from with 0 as a default value.
+ * To start counting from the next date set this to 1.
  *
+ * @param {[Date]} excludeDates - an array of dates to exclude e.g. holidays.
  * @returns {Date} the next business day
- *
  * @throws {TypeError} startFrom can't be a negative number
  *
- *
  * @example
- * // returns the next business date from  Sun July 4th, 2021
- * const date = nextBusinessDay(new Date(2021, 6, 4));
- * // => Mon Jul 4 2021 00:00:00
+ * // When is the next business day after July, 4 2021
+ * const result = nextBusinessDay(new Date(2021, 6, 4))
+ * //=> Mon Jul 05 2021 00:00:00
  *
- * // returns the next business day and skip the holidays
- * especified on the excludeDates param
- * const holidays = [new Date(2021, 8, 7)] // September 7h - Brazil Independence Day
- * const date = nextBusinessDay(new Date(2021, 8, 6), 1, holidays)
- * // => Wed Sep 8 2021 00:00:00
+ * // When is the next business day after September, 6 2021 with an excluded day?
+ * const holidays = [new Date(2021, 8, 7)] // September, 7 - Brazil Independence Day
+ * const result = nextBusinessDay(new Date(2021, 8, 6), 1, holidays)
+ * //=> Wed Sep 8 2021 00:00:00
  */
 
 export default function nextBusinessDay(
-  dirtyDate: Date,
+  dirtyDate: Date | number,
   startFromDay = 0,
-  excludeDates: Array<Date> = []
+  excludeDates: Array<Date | number> = []
 ): Date {
   const date = startOfDay(toDate(dirtyDate))
 

--- a/src/nextBusinessDay/index.ts
+++ b/src/nextBusinessDay/index.ts
@@ -1,4 +1,4 @@
-import { isWeekend, addDays, toDate, isEqual, startOfDay } from "..";
+import { isWeekend, addDays, toDate, isEqual, startOfDay } from '..'
 
 /**
  * @name nextBusinessDay
@@ -34,25 +34,24 @@ import { isWeekend, addDays, toDate, isEqual, startOfDay } from "..";
 export default function nextBusinessDay(
   dirtyDate: Date,
   startFromDay = 0,
-  excludeDates: Array<Date> = [],
+  excludeDates: Array<Date> = []
 ): Date {
-  const date = startOfDay(toDate(dirtyDate));
+  const date = startOfDay(toDate(dirtyDate))
 
-  if (startFromDay < 0) throw new TypeError("startFrom can't be a negative number");
+  if (startFromDay < 0)
+    throw new TypeError("startFrom can't be a negative number")
 
-  const initialDate = startFromDay ? addDays(date, startFromDay) : date;
+  const initialDate = addDays(date, startFromDay)
 
   const isOnTheExcludeDatesList = () => {
-    if (excludeDates.length === 0) return false;
+    if (excludeDates.length === 0) return false
 
-    const isPresent = excludeDates.reduce((prev, current): boolean => {
-      return isEqual(initialDate, startOfDay(current)) || prev;
-    }, false);
+    return excludeDates.some((excludeDate) =>
+      isEqual(initialDate, startOfDay(excludeDate))
+    )
+  }
 
-    return isPresent;
-  };
+  if (!isWeekend(initialDate) && !isOnTheExcludeDatesList()) return initialDate
 
-  if (!isWeekend(initialDate) && !isOnTheExcludeDatesList()) return initialDate;
-
-  return nextBusinessDay(addDays(initialDate, 1));
+  return nextBusinessDay(addDays(initialDate, 1), 0, excludeDates)
 }

--- a/src/nextBusinessDay/index.ts
+++ b/src/nextBusinessDay/index.ts
@@ -1,0 +1,58 @@
+import { isWeekend, addDays, toDate, isEqual, startOfDay } from "..";
+
+/**
+ * @name nextBusinessDay
+ * @category Day Helpers
+ * @summary Returns the next business day
+ *
+ * @description Returns the next business day (Mon - Fri)
+ *
+ * @param {Date|Number} date - the initial date
+ * @param {Number} [startFromDay=0] - The day that it starts to count, the
+ * default is zero. So if the date is on a Monday it will return the current
+ * date. To start counting from the next date set this to one.
+ * @param {[Date]} excludeDates - An array of holidays or other dates that
+ * should not be identified as business days
+ *
+ * @returns {Date} the next business day
+ *
+ * @throws {TypeError} startFrom can't be a negative number
+ *
+ *
+ * @example
+ * // returns the next business date from  Sun July 4th, 2021
+ * const date = nextBusinessDay(new Date(2021, 6, 4));
+ * // => Mon Jul 4 2021 00:00:00
+ *
+ * // returns the next business day and skip the holidays
+ * especified on the excludeDates param
+ * const holidays = [new Date(2021, 8, 7)] // September 7h - Brazil Independence Day
+ * const date = nextBusinessDay(new Date(2021, 8, 6), 1, holidays)
+ * // => Wed Sep 8 2021 00:00:00
+ */
+
+export default function nextBusinessDay(
+  dirtyDate: Date,
+  startFromDay = 0,
+  excludeDates: Array<Date> = [],
+): Date {
+  const date = startOfDay(toDate(dirtyDate));
+
+  if (startFromDay < 0) throw new Error("startFrom can't be a negative number");
+
+  const initialDate = startFromDay ? addDays(date, startFromDay) : date;
+
+  const isOnTheExcludeDatesList = () => {
+    if (excludeDates.length === 0) return false;
+
+    const isPresent = excludeDates.reduce((_, current): boolean => {
+      return isEqual(initialDate, startOfDay(current));
+    }, false);
+
+    return isPresent;
+  };
+
+  if (!isWeekend(initialDate) && !isOnTheExcludeDatesList()) return initialDate;
+
+  return nextBusinessDay(addDays(initialDate, 1));
+}

--- a/src/nextBusinessDay/index.ts
+++ b/src/nextBusinessDay/index.ts
@@ -38,15 +38,15 @@ export default function nextBusinessDay(
 ): Date {
   const date = startOfDay(toDate(dirtyDate));
 
-  if (startFromDay < 0) throw new Error("startFrom can't be a negative number");
+  if (startFromDay < 0) throw new TypeError("startFrom can't be a negative number");
 
   const initialDate = startFromDay ? addDays(date, startFromDay) : date;
 
   const isOnTheExcludeDatesList = () => {
     if (excludeDates.length === 0) return false;
 
-    const isPresent = excludeDates.reduce((_, current): boolean => {
-      return isEqual(initialDate, startOfDay(current));
+    const isPresent = excludeDates.reduce((prev, current): boolean => {
+      return isEqual(initialDate, startOfDay(current)) || prev;
     }, false);
 
     return isPresent;

--- a/src/nextBusinessDay/index.ts
+++ b/src/nextBusinessDay/index.ts
@@ -7,11 +7,12 @@ import { addDays, isEqual, isWeekend, startOfDay, toDate } from '..'
  *
  * @description Returns the next business day (Mon - Fri)
  *
- * @param {Date|Number} date - the initial date
- * @param {Number} [startFromDay=0] - the day that it starts counting from with 0 as a default value.
+ * @param {Date|Number} date - The initial date
+ * @param {Object} options - The options object
+ * @param {Number} [options.startFromDay=0] - The day that it starts counting from with 0 as a default value.
  * To start counting from the next date set this to 1.
  *
- * @param {[Date]} excludeDates - an array of dates to exclude e.g. holidays.
+ * @param {[Date]} options.excludeDates - An array of dates to exclude e.g. holidays.
  * @returns {Date} the next business day
  * @throws {TypeError} startFrom can't be a negative number
  *
@@ -26,12 +27,18 @@ import { addDays, isEqual, isWeekend, startOfDay, toDate } from '..'
  * //=> Wed Sep 8 2021 00:00:00
  */
 
+interface Options {
+  startFromDay?: number;
+  excludeDates?: Array<Date | number>;
+}
+
 export default function nextBusinessDay(
   dirtyDate: Date | number,
-  startFromDay = 0,
-  excludeDates: Array<Date | number> = []
+  options: Options = {},
 ): Date {
   const date = startOfDay(toDate(dirtyDate))
+
+  const { startFromDay = 0, excludeDates = [] } = options;
 
   if (startFromDay < 0)
     throw new TypeError("startFrom can't be a negative number")
@@ -48,5 +55,5 @@ export default function nextBusinessDay(
 
   if (!isWeekend(initialDate) && !isOnTheExcludeDatesList()) return initialDate
 
-  return nextBusinessDay(addDays(initialDate, 1), 0, excludeDates)
+  return nextBusinessDay(addDays(initialDate, 1), { startFromDay: 0, excludeDates })
 }

--- a/src/nextBusinessDay/test.ts
+++ b/src/nextBusinessDay/test.ts
@@ -33,7 +33,7 @@ describe("nextBusinessDay function", () => {
 
   it("doesn't accept negative numbers for the startFrom param", () => {
     const initial = new Date(2021, 6, 2); // Friday
-    const errorMessage = "startFrom can't be a negative number";
+    const errorMessage = /startFrom can't be a negative number$/;
 
     assert.throws(() => nextBusinessDay(initial, -1), errorMessage)
   });

--- a/src/nextBusinessDay/test.ts
+++ b/src/nextBusinessDay/test.ts
@@ -1,50 +1,51 @@
 /* eslint-env mocha */
 
-import assert from "power-assert";
-import nextBusinessDay from ".";
+import assert from 'assert'
+import nextBusinessDay from '.'
 
-describe("nextBusinessDay function", () => {
-  describe("when startFrom is zero and the current date is a bussiness day", () => {
-    it("returns the current date", () => {
-      const initial = new Date(2021, 6, 28); // Monday
-
-      assert.deepStrictEqual(nextBusinessDay(initial), initial);
-    });
-  });
+describe('nextBusinessDay function', () => {
+  describe('when startFrom is zero and the current date is a bussiness day', () => {
+    it('returns the current date', () => {
+      const initial = new Date(2021, 6, 28) // Monday
+      assert.deepStrictEqual(nextBusinessDay(initial), initial)
+    })
+  })
 
   describe("when startFrom is zero but the current date isn't a business day", () => {
-    it("returns the next business day", () => {
-      const initial = new Date(2021, 6, 3); // Saturday
-      const expected = new Date(2021, 6, 5); // Monday
+    it('returns the next business day', () => {
+      const initial = new Date(2021, 6, 3) // Saturday
+      const expected = new Date(2021, 6, 5) // Monday
+      assert.deepStrictEqual(nextBusinessDay(initial), expected)
+    })
 
-      assert.deepStrictEqual(nextBusinessDay(initial),expected);
-    });
-  });
+    it('returns the next business day after Jul 4, 2021', () => {
+      const initial = new Date(2021, 6, 4)
+      console.log(1111, nextBusinessDay(initial))
+      assert.deepStrictEqual(nextBusinessDay(initial), new Date(2021, 6, 5))
+    })
+  })
 
-  describe("when startFrom is greater than zero", () => {
-    it("moves the initial date adding the number of days specified on the startFrom param", () => {
-      const initial = new Date(2021, 6, 2); // Friday
-      const expected = new Date(2021, 6, 5); // Monday
-
+  describe('when startFrom is greater than zero', () => {
+    it('moves the initial date adding the number of days specified on the startFrom param', () => {
+      const initial = new Date(2021, 6, 2) // Friday
+      const expected = new Date(2021, 6, 5) // Monday
       // Will start counting from June 4th, 2021
-      assert.deepStrictEqual(nextBusinessDay(initial, 2), expected);
-    });
-  });
+      assert.deepStrictEqual(nextBusinessDay(initial, 2), expected)
+    })
+  })
 
   it("doesn't accept negative numbers for the startFrom param", () => {
-    const initial = new Date(2021, 6, 2); // Friday
-    const errorMessage = /startFrom can't be a negative number$/;
-
+    const initial = new Date(2021, 6, 2) // Friday
+    const errorMessage = /startFrom can't be a negative number$/
     assert.throws(() => nextBusinessDay(initial, -1), errorMessage)
-  });
+  })
 
-  it("skips the dates specified on the excludeDates array", () => {
-    const brazilianIndependenceDay = new Date(2021, 8, 7); // Tuesday
-    const holidays = [brazilianIndependenceDay];
-
+  it('skips the dates specified on the excludeDates array', () => {
+    const brazilianIndependenceDay = new Date(2021, 8, 7) // Tuesday
+    const holidays = [brazilianIndependenceDay]
     assert.deepStrictEqual(
-      nextBusinessDay(new Date(2021, 8, 6), 1, holidays), 
+      nextBusinessDay(new Date(2021, 8, 6), 1, holidays),
       new Date(2021, 8, 8)
-    );
-  });
-});
+    )
+  })
+})

--- a/src/nextBusinessDay/test.ts
+++ b/src/nextBusinessDay/test.ts
@@ -30,21 +30,21 @@ describe('nextBusinessDay function', () => {
       const initial = new Date(2021, 6, 2) // Friday
       const expected = new Date(2021, 6, 5) // Monday
       // Will start counting from June 4th, 2021
-      assert.deepStrictEqual(nextBusinessDay(initial, 2), expected)
+      assert.deepStrictEqual(nextBusinessDay(initial, { startFromDay: 2}), expected)
     })
   })
 
   it("doesn't accept negative numbers for the startFrom param", () => {
     const initial = new Date(2021, 6, 2) // Friday
     const errorMessage = /startFrom can't be a negative number$/
-    assert.throws(() => nextBusinessDay(initial, -1), errorMessage)
+    assert.throws(() => nextBusinessDay(initial, {startFromDay: -1}), errorMessage)
   })
 
   it('skips the dates specified on the excludeDates array', () => {
     const brazilianIndependenceDay = new Date(2021, 8, 7) // Tuesday
     const holidays = [brazilianIndependenceDay]
     assert.deepStrictEqual(
-      nextBusinessDay(new Date(2021, 8, 6), 1, holidays),
+      nextBusinessDay(new Date(2021, 8, 6), {startFromDay: 1, excludeDates: holidays}),
       new Date(2021, 8, 8)
     )
   })

--- a/src/nextBusinessDay/test.ts
+++ b/src/nextBusinessDay/test.ts
@@ -1,0 +1,50 @@
+/* eslint-env mocha */
+
+import assert from "power-assert";
+import nextBusinessDay from ".";
+
+describe("nextBusinessDay function", () => {
+  describe("when startFrom is zero and the current date is a bussiness day", () => {
+    it("returns the current date", () => {
+      const initial = new Date(2021, 6, 28); // Monday
+
+      assert.deepStrictEqual(nextBusinessDay(initial), initial);
+    });
+  });
+
+  describe("when startFrom is zero but the current date isn't a business day", () => {
+    it("returns the next business day", () => {
+      const initial = new Date(2021, 6, 3); // Saturday
+      const expected = new Date(2021, 6, 5); // Monday
+
+      assert.deepStrictEqual(nextBusinessDay(initial),expected);
+    });
+  });
+
+  describe("when startFrom is greater than zero", () => {
+    it("moves the initial date adding the number of days specified on the startFrom param", () => {
+      const initial = new Date(2021, 6, 2); // Friday
+      const expected = new Date(2021, 6, 5); // Monday
+
+      // Will start counting from June 4th, 2021
+      assert.deepStrictEqual(nextBusinessDay(initial, 2), expected);
+    });
+  });
+
+  it("doesn't accept negative numbers for the startFrom param", () => {
+    const initial = new Date(2021, 6, 2); // Friday
+    const errorMessage = "startFrom can't be a negative number";
+
+    assert.throws(() => nextBusinessDay(initial, -1), errorMessage)
+  });
+
+  it("skips the dates specified on the excludeDates array", () => {
+    const brazilianIndependenceDay = new Date(2021, 8, 7); // Tuesday
+    const holidays = [brazilianIndependenceDay];
+
+    assert.deepStrictEqual(
+      nextBusinessDay(new Date(2021, 8, 6), 1, holidays), 
+      new Date(2021, 8, 8)
+    );
+  });
+});


### PR DESCRIPTION
This function returns the next business day. It considers a business day as being a day of the week (Monday - Friday). National holidays or any date that should be considered a non-business day can be specified in the `excludeDates` param, which accepts an array of `Dates`.