### PR TITLE
Deno-related improvements and fixes

### DIFF
--- a/.github/workflows/deno_tests.yaml
+++ b/.github/workflows/deno_tests.yaml
@@ -1,0 +1,36 @@
+name: Deno tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: export DISPLAY
+        run: export DISPLAY=:99.0
+      - name: Install yarn
+        run: npm install -g yarn
+      - name: Install dependencies
+        run: yarn install
+      - name: Build Deno package
+        run: ./scripts/build/deno.sh
+      - name: Test Deno package
+        run: ./scripts/test/deno.sh

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   verbose: false,
-  testPathIgnorePatterns: ['<rootDir>/test.js'],
+  testPathIgnorePatterns: ['<rootDir>/test.js', '<rootDir>/test/deno'],
 }

--- a/scripts/build/deno.sh
+++ b/scripts/build/deno.sh
@@ -2,6 +2,6 @@
 
 # The script builds the Deno package.
 
-rsync --archive --prune-empty-dirs --relative --exclude={'*.flow','test.*','snapshot.md'} src/./ deno
-cp {CHANGELOG.md,LICENSE.md,typings.d.ts} deno
+rsync --archive --prune-empty-dirs --relative --exclude={'*.flow','test.*','snapshot.md','*.d.ts'} src/./ deno
+cp {CHANGELOG.md,LICENSE.md} deno
 yarn ts-node scripts/build/_lib/addDenoExtensions.ts

--- a/scripts/test/deno.sh
+++ b/scripts/test/deno.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Runs the Deno unit tests
+# Generate package first by running `./scripts/build/deno.sh`
+
+deno test test/deno/

--- a/src/_lib/isSameUTCWeek/index.ts
+++ b/src/_lib/isSameUTCWeek/index.ts
@@ -1,4 +1,4 @@
-import type { LocaleOptions, WeekStartOptions } from 'src/types'
+import type { LocaleOptions, WeekStartOptions } from '../../types'
 import requiredArgs from '../requiredArgs/index'
 import startOfUTCWeek from '../startOfUTCWeek/index'
 

--- a/test/deno/basic.test.ts
+++ b/test/deno/basic.test.ts
@@ -1,0 +1,46 @@
+import {
+  assertEquals,
+  assertStrictEquals,
+} from 'https://deno.land/std@0.100.0/testing/asserts.ts'
+import addDaysAlt from '../../deno/addDays/index.ts'
+import * as fp from '../../deno/fp/index.ts'
+import * as esm from '../../deno/index.ts'
+import { addDays } from '../../deno/index.ts'
+import * as locales from '../../deno/locale/index.ts'
+
+// Bare-bones tests for the Deno package export. Run `./scripts/build/deno.sh` first.
+// Bulk importing the whole library allows the compiler to run checks.
+
+// The few assertions below just confirms that things look usable, and that different import styles work as intended.
+Deno.test('add a day (esm)', () => {
+  const date = new Date(Date.UTC(2021, 0, 1))
+
+  const result1 = addDays(date, 1)
+  const result2 = esm.addDays(date, 1)
+  const result3 = addDaysAlt(date, 1)
+
+  const expected = '2021-01-02T00:00:00.000Z'
+  assertStrictEquals(result1.toISOString(), expected)
+  assertStrictEquals(result2.toISOString(), expected)
+  assertStrictEquals(result3.toISOString(), expected)
+})
+
+Deno.test('add five years (fp)', () => {
+  const addFiveYears = fp.addYears(5)
+  const dates = [
+    new Date(Date.UTC(1990, 0, 1)),
+    new Date(Date.UTC(2009, 3, 15)),
+  ]
+
+  // NOTE: casting required since fp functions are untyped without typings.d.ts for now
+  const results = dates.map(addFiveYears).map((d) => (d as Date).toISOString())
+
+  assertEquals(results, [
+    '1995-01-01T00:00:00.000Z',
+    '2014-04-15T00:00:00.000Z',
+  ])
+})
+
+Deno.test('enUS locale exists', () => {
+  assertStrictEquals(locales['enUS'].code, 'en-US')
+})


### PR DESCRIPTION
This brings a number of improvements and fixes related to the new Deno package build, which is partially broken at the moment. See https://github.com/date-fns/deno/pull/2

## Fixes
- ~remove the broken locales from output~ (not relevant anymore)
- remove typings.d.ts and *.d.ts from output (they are incompatible with Deno when referenced using `@deno-types`)
- addDenoExtensions build:
  - correctly resolve the file path for imports that reference a directory instead of a file
  - stricter path replace to avoid transforming an import multiple times (ex: `../../types.ts` and `../../../types.ts` in same file)
  - script will now fail if it can't locate a file for an import/export path
  - early exit check in core loop was always a miss because it was using `importPath` instead of `fullPath`
  - minor optimizations
- fix all bad imports in the project (missing types, typos)

## Tests
- added a Deno test which simple runs a few assertions and imports the whole library
- added a Deno github action that builds and tests the Deno package on pull requests/push
- Jest config ignore `test/deno` path