### PR TITLE
new `isAnniversary` and `getAnniversaryForYear` functions

### DIFF
--- a/src/getAnniversaryForYear/index.ts
+++ b/src/getAnniversaryForYear/index.ts
@@ -64,7 +64,7 @@ export default function getAnniversaryForYear(
     resolveLeapYearAnniversaryAs !== 'mar1' &&
     anniversaryDate.getDate() === 29 &&
     anniversaryDate.getMonth() === 1 &&
-    !isLeapYear(year)
+    !isLeapYear(resultDate)
   ) {
     if (resolveLeapYearAnniversaryAs === 'feb28') {
       resultDate.setMonth(1, 28)

--- a/src/getAnniversaryForYear/index.ts
+++ b/src/getAnniversaryForYear/index.ts
@@ -1,0 +1,77 @@
+import isLeapYear from '../isLeapYear/index'
+import toDate from '../toDate/index'
+import requiredArgs from '../_lib/requiredArgs/index'
+import toInteger from '../_lib/toInteger/index'
+
+/**
+ * @name getAnniversaryForYear
+ * @category Common Helpers
+ * @summary Returns the date of an anniversary for a given year
+ *
+ * @description
+ * Returns the date of an anniversary for a given year. Can handle different resolve behaviors for leap year anniversaries.
+ *
+ * @param {Date|Number} anniversaryDate - the anniversary date
+ * @param {Number} year - the target year
+ * @param {'feb28' | 'mar1' | 'invalid'} [resolveLeapYearAnniversaryAs='mar1'] - the resolve behavior of a leap year anniversary for non-leap year
+ * @returns {Date} - the anniversary date for the given year
+ * @throws {TypeError} - 2 arguments required
+ *
+ * @example
+ * // For an anniversary of July 2nd 2014, get the anniversary date for 2021:
+ * const result = getAnniversaryForYear(new Date(2014, 6, 2), 2021)
+ * //=> Fri Jul 02 2021 00:00:00
+ *
+ * @example
+ * // For a leap year anniversary of February 29th 2020, get the anniversary date for 2024 (a leap year as well):
+ * const result = getAnniversaryForYear(new Date(2020, 1, 29), 2024)
+ * //=> Thu Feb 29 2024 00:00:00
+ *
+ * @example
+ * // For a leap year anniversary of February 29th 2020, get the anniversary date for a non-leap year using different resolve behaviors:
+ *
+ * // resolve to March 1st on non-leap years (default)
+ * const result = getAnniversaryForYear(new Date(2020, 1, 29), 2023, 'mar1')
+ * //=> Wed Mar 01 2023 00:00:00
+ *
+ * // resolve to February 28th on non-leap years
+ * const result = getAnniversaryForYear(new Date(2020, 1, 29), 2023, 'feb28')
+ * //=> Tue Feb 28 2023 00:00:00
+ *
+ * // treat as invalid date, no anniversary on non-leap years
+ * const result = getAnniversaryForYear(new Date(2020, 1, 29), 2023, 'invalid')
+ * //=> Invalid Date
+ */
+export default function getAnniversaryForYear(
+  dirtyAnniversaryDate: Date | number,
+  dirtyYear: number,
+  resolveLeapYearAnniversaryAs: 'feb28' | 'mar1' | 'invalid' = 'mar1'
+): Date {
+  requiredArgs(2, arguments)
+
+  const anniversaryDate = toDate(dirtyAnniversaryDate)
+
+  if (isNaN(anniversaryDate.getTime())) return new Date(NaN)
+
+  const year = toInteger(dirtyYear)
+
+  const resultDate = toDate(dirtyAnniversaryDate)
+  resultDate.setFullYear(year)
+
+  // leap year anniversary date for a non-leap year
+  // note: default behavior with setFullYear() lands us on March 1st
+  if (
+    resolveLeapYearAnniversaryAs !== 'mar1' &&
+    anniversaryDate.getDate() === 29 &&
+    anniversaryDate.getMonth() === 1 &&
+    !isLeapYear(year)
+  ) {
+    if (resolveLeapYearAnniversaryAs === 'feb28') {
+      resultDate.setMonth(1, 28)
+    } else if (resolveLeapYearAnniversaryAs === 'invalid') {
+      return new Date(NaN)
+    }
+  }
+
+  return resultDate
+}

--- a/src/getAnniversaryForYear/test.ts
+++ b/src/getAnniversaryForYear/test.ts
@@ -1,0 +1,69 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'assert'
+import getAnniversaryForYear from '.'
+
+describe('getAnniversaryForYear', function () {
+  it('returns the anniversary date for the given year', function () {
+    const result = getAnniversaryForYear(new Date(2014, 6 /* Jul */, 2), 2021)
+    const expected = new Date(2021, 6, 2)
+    assert(result.getTime() === expected.getTime())
+  })
+
+  it('keeps the anniversary time', function () {
+    const result = getAnniversaryForYear(
+      new Date(2014, 6 /* Jul */, 2, 12, 11, 10, 9),
+      2021
+    )
+    const expected = new Date(2021, 6, 2, 12, 11, 10, 9)
+    assert(result.getTime() === expected.getTime())
+  })
+
+  it('handles leap year anniversaries correctly', function () {
+    const feb29 = new Date(2020, 1, 29)
+    let result, expected
+
+    // target year is also leap year
+    result = getAnniversaryForYear(feb29, 2024)
+    expected = new Date(2024, 1, 29)
+    assert(result.getTime() === expected.getTime())
+
+    // target leap year is not leap year, 3 possible resolve behaviors:
+
+    // resolve as March 1st (default)
+    result = getAnniversaryForYear(feb29, 2023, 'mar1')
+    expected = new Date(2023, 2, 1)
+    assert(result.getTime() === expected.getTime())
+
+    // resolve as February 28th
+    result = getAnniversaryForYear(feb29, 2023, 'feb28')
+    expected = new Date(2023, 1, 28)
+    assert(result.getTime() === expected.getTime())
+
+    // invalid
+    result = getAnniversaryForYear(feb29, 2023, 'invalid')
+    assert(isNaN(result.getTime()))
+  })
+
+  it('accepts a timestamp', function () {
+    const result = getAnniversaryForYear(
+      new Date(2014, 6 /* Jul */, 2).getTime(),
+      2021
+    )
+    const expected = new Date(2021, 6, 2)
+    assert(result.getTime() === expected.getTime())
+  })
+
+  it('returns NaN if the given anniversary date is invalid', function () {
+    const result = getAnniversaryForYear(new Date(NaN), 2021)
+    assert(isNaN(result.getTime()))
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    // @ts-expect-error
+    assert.throws(getAnniversaryForYear.bind(null), TypeError)
+    // @ts-expect-error
+    assert.throws(getAnniversaryForYear.bind(null, 1), TypeError)
+  })
+})

--- a/src/isAnniversary/index.ts
+++ b/src/isAnniversary/index.ts
@@ -1,0 +1,78 @@
+import isLeapYear from '../isLeapYear/index'
+import toDate from '../toDate/index'
+import requiredArgs from '../_lib/requiredArgs/index'
+
+/**
+ * @name isAnniversary
+ * @category Common Helpers
+ * @summary Is the date an anniversary of the given reference date?
+ *
+ * @description
+ * Is the date an anniversary of the given reference date? Can handle different resolve behaviors for leap year anniversaries.
+ *
+ * @param {Date|Number} anniversaryDate - the reference anniversary date
+ * @param {Date|Number} date - the date to compare against the anniversary date
+ * @param {'feb28' | 'mar1' | 'invalid'} [resolveLeapYearAnniversaryAs='mar1'] - the resolve behavior of a leap year anniversary for non-leap year
+ * @returns {Boolean} - the date is an anniversary
+ * @throws {TypeError} - 2 arguments required
+ *
+ * @example
+ * // For an anniversary of July 2nd 2014, the July 2nd 2021 date is an anniversary:
+ * const result = isAnniversary(new Date(2014, 6, 2), new Date(2021, 6, 2))
+ * //=> true
+ *
+ * @example
+ * // For a leap year anniversary of February 29th 2020, the February 29th 2024 date (a leap year as well) is an anniversary:
+ * const result = isAnniversary(new Date(2020, 1, 29), new Date(2024, 1, 29))
+ * //=> true
+ *
+ * @example
+ * // For a leap year anniversary of February 29th 2020, check if a date is an anniversary for a non-leap year using different resolve behaviors:
+ *
+ * // resolve to March 1st on non-leap years (default)
+ * const result = isAnniversary(new Date(2020, 1, 29), new Date(2023, 2, 1), 'mar1')
+ * //=> true
+ *
+ * // resolve to February 28th on non-leap years
+ * const result = isAnniversary(new Date(2020, 1, 29), new Date(2023, 1, 28), 'feb28') // resolve to February 28th
+ * //=> true
+ *
+ * // treat as invalid date, no anniversary on non-leap years
+ * const result = isAnniversary(new Date(2020, 1, 29), new Date(2023, 1, 28), 'invalid')
+ * //=> false
+ * const result = isAnniversary(new Date(2020, 1, 29), new Date(2023, 2, 1), 'invalid')
+ * //=> false
+ */
+export default function isAnniversary(
+  dirtyAnniversaryDate: Date | number,
+  dirtyDate: Date | number,
+  resolveLeapYearAnniversaryAs: 'feb28' | 'mar1' | 'invalid' = 'mar1'
+): boolean {
+  requiredArgs(2, arguments)
+
+  const anniversaryDate = toDate(dirtyAnniversaryDate)
+  if (isNaN(anniversaryDate.getTime())) return false
+
+  const date = toDate(dirtyDate)
+  if (isNaN(date.getTime())) return false
+
+  // leap year anniversary date for a non-leap year
+  if (
+    anniversaryDate.getDate() === 29 &&
+    anniversaryDate.getMonth() === 1 &&
+    !isLeapYear(date)
+  ) {
+    if (resolveLeapYearAnniversaryAs === 'feb28') {
+      return date.getDate() === 28 && date.getMonth() === 1
+    } else if (resolveLeapYearAnniversaryAs === 'mar1') {
+      return date.getDate() === 1 && date.getMonth() === 2
+    } else if (resolveLeapYearAnniversaryAs === 'invalid') {
+      return false
+    }
+  }
+
+  return (
+    date.getDate() === anniversaryDate.getDate() &&
+    date.getMonth() === anniversaryDate.getMonth()
+  )
+}

--- a/src/isAnniversary/test.ts
+++ b/src/isAnniversary/test.ts
@@ -1,0 +1,102 @@
+// @flow
+/* eslint-env mocha */
+
+import assert from 'assert'
+import isAnniversary from '.'
+
+describe('isAnniversary', function () {
+  it('identifies anniversaries correctly', function () {
+    let result
+    const anniversary = new Date(2014, 6 /* Jul */, 2)
+
+    result = isAnniversary(anniversary, new Date(2020, 6 /* Jul */, 2))
+    assert(result === true)
+
+    result = isAnniversary(anniversary, new Date(2020, 6 /* Jul */, 1))
+    assert(result === false)
+  })
+
+  it('is the anniversary day for the whole day', function () {
+    let result
+    const anniversary = new Date(2014, 6 /* Jul */, 2)
+
+    result = isAnniversary(
+      anniversary,
+      new Date(2020, 6 /* Jul */, 1, 23, 59, 59, 999)
+    )
+    assert(result === false)
+
+    result = isAnniversary(anniversary, new Date(2020, 6 /* Jul */, 2))
+    assert(result === true)
+
+    result = isAnniversary(anniversary, new Date(2020, 6 /* Jul */, 2, 1))
+    assert(result === true)
+
+    result = isAnniversary(
+      anniversary,
+      new Date(2020, 6 /* Jul */, 2, 23, 59, 59, 999)
+    )
+    assert(result === true)
+
+    result = isAnniversary(anniversary, new Date(2020, 6 /* Jul */, 3))
+    assert(result === false)
+  })
+
+  it('handles leap year anniversaries correctly', function () {
+    const feb29 = new Date(2020, 1, 29)
+    let result
+
+    // target year is also leap year
+    result = isAnniversary(feb29, new Date(2024, 1, 28))
+    assert(result === false)
+    result = isAnniversary(feb29, new Date(2024, 1, 29))
+    assert(result === true)
+    result = isAnniversary(feb29, new Date(2024, 2, 1))
+    assert(result === false)
+
+    // target leap year is not leap year, 3 possible resolve behaviors:
+
+    // resolve as March 1st (default)
+    result = isAnniversary(feb29, new Date(2023, 1, 28), 'mar1')
+    assert(result === false)
+    result = isAnniversary(feb29, new Date(2023, 2, 1), 'mar1')
+    assert(result === true)
+
+    // resolve as February 28th
+    result = isAnniversary(feb29, new Date(2023, 1, 28), 'feb28')
+    assert(result === true)
+    result = isAnniversary(feb29, new Date(2023, 2, 1), 'feb28')
+    assert(result === false)
+
+    // invalid
+    result = isAnniversary(feb29, new Date(2023, 1, 28), 'invalid')
+    assert(result === false)
+    result = isAnniversary(feb29, new Date(2023, 2, 1), 'invalid')
+    assert(result === false)
+  })
+
+  it('accepts a timestamp for either dates', function () {
+    const result = isAnniversary(
+      new Date(2014, 6 /* Jul */, 2).getTime(),
+      new Date(2020, 6 /* Jul */, 2).getTime()
+    )
+    assert(result === true)
+  })
+
+  it('returns false if the given date or anniversary date are invalid', function () {
+    let result
+
+    result = isAnniversary(new Date(NaN), new Date())
+    assert(result === false)
+
+    result = isAnniversary(new Date(), new Date(NaN))
+    assert(result === false)
+  })
+
+  it('throws TypeError exception if passed less than 2 arguments', function () {
+    // @ts-expect-error
+    assert.throws(isAnniversary.bind(null), TypeError)
+    // @ts-expect-error
+    assert.throws(isAnniversary.bind(null, 1), TypeError)
+  })
+})


### PR DESCRIPTION
Inspired by #2539, this adds the new functions `isAnniversary` and `getAnniversaryForYear`.

Both functions allow you to configure the resolve behavior for leap year anniversaries on non-leap years as either March 1st (default), February 28th or as invalid.