### PR TITLE
improved `clamp` implementation

### DIFF
--- a/src/clamp/index.ts
+++ b/src/clamp/index.ts
@@ -1,5 +1,5 @@
 import toDate from '../toDate/index'
-import { Interval } from '../types'
+import type { Interval } from '../types'
 import requiredArgs from '../_lib/requiredArgs/index'
 
 /**

--- a/src/clamp/index.ts
+++ b/src/clamp/index.ts
@@ -1,6 +1,5 @@
-import max from '../max/index'
-import min from '../min/index'
-import type { Interval } from '../types'
+import toDate from '../toDate/index'
+import { Interval } from '../types'
 import requiredArgs from '../_lib/requiredArgs/index'
 
 /**
@@ -28,11 +27,29 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * @param {Interval} interval - the interval to bound to
  * @returns {Date} the date bounded by the start and the end of the interval
  * @throws {TypeError} 2 arguments required
+ * @throws {RangeError} `date` must not be Invalid Date
+ * @throws {RangeError} `start` must not be Invalid Date
+ * @throws {RangeError} `end` must not be Invalid Date
+ * @throws {RangeError} The start of an interval cannot be after its end
  */
 export default function clamp(
-  date: Date | number,
-  { start, end }: Interval
+  dirtyDate: Date | number,
+  interval: Interval
 ): Date {
   requiredArgs(2, arguments)
-  return min([max([date, start]), end])
+
+  const date = toDate(dirtyDate)
+  const start = toDate(interval.start)
+  const end = toDate(interval.end)
+
+  if (isNaN(date.getTime())) throw new RangeError('Date is invalid')
+  if (isNaN(start.getTime())) throw new RangeError('Start Date is invalid')
+  if (isNaN(end.getTime())) throw new RangeError('End Date is invalid')
+  if (start > end) {
+    throw new RangeError('The start of an interval cannot be after its end')
+  }
+
+  if (date <= start) return start
+  if (date >= end) return end
+  return date
 }

--- a/src/clamp/test.ts
+++ b/src/clamp/test.ts
@@ -36,6 +36,31 @@ describe('clamp', () => {
     assert.deepStrictEqual(result, new Date(2001, 1, 1))
   })
 
+  it('throws RangeError exception if the date is invalid', () => {
+    const interval = { start: new Date(2001, 1, 1), end: new Date(2003, 1, 1) }
+    assert.throws(clamp.bind(null, new Date(NaN), interval), RangeError)
+  })
+
+  it('throws RangeError exception if the interval start date is invalid', () => {
+    const interval = { start: new Date(NaN), end: new Date(2003, 1, 1) }
+    assert.throws(clamp.bind(null, new Date(), interval), RangeError)
+  })
+
+  it('throws RangeError exception if the interval end date is invalid', () => {
+    const interval = { start: new Date(2001, 1, 1), end: new Date(NaN) }
+    assert.throws(clamp.bind(null, new Date(), interval), RangeError)
+  })
+
+  it('throws RangeError exception if both interval dates are invalid', () => {
+    const interval = { start: new Date(NaN), end: new Date(NaN) }
+    assert.throws(clamp.bind(null, new Date(), interval), RangeError)
+  })
+
+  it('throws RangeError exception if interval start date is greater than its end date', () => {
+    const interval = { start: new Date(2003, 1, 1), end: new Date(2000, 1, 1) }
+    assert.throws(clamp.bind(null, new Date(), interval), RangeError)
+  })
+
   it('throws TypeError exception if passed less than 2 arguments', () => {
     // @ts-expect-error
     assert.throws(clamp.bind(null), TypeError)


### PR DESCRIPTION
This is an improved implementation of the `clamp` function.

- approx. 45% faster perf (1.8MM vs 2.6MM ops/sec)
- slightly smaller overall file size by removing min/max imports
- fix missing import of Interval type
- RangeErrors for date and interval arguments
- added `eslint-env mocha` to test file to remove eslint errors