### PR TITLE
Update `parseISO` to reject input with an invalid UTC offset

### DIFF
--- a/src/parseISO/index.js
+++ b/src/parseISO/index.js
@@ -273,7 +273,7 @@ function parseTimezone(timezoneString) {
   if (timezoneString === 'Z') return 0
 
   var captures = timezoneString.match(timezoneRegex)
-  if (!captures) return 0
+  if (!captures) return NaN
 
   var sign = captures[1] === '+' ? -1 : 1
   var hours = parseInt(captures[2])

--- a/src/parseISO/test.js
+++ b/src/parseISO/test.js
@@ -349,6 +349,18 @@ describe('parseISO', () => {
         assert(result instanceof Date)
         assert(isNaN(result))
       })
+
+      it('returns `Invalid Date` for text after a UTC designator', () => {
+        const result = parseISO('2014-02-11T21:35:45ZZ')
+        assert(result instanceof Date)
+        assert(isNaN(result))
+      })
+
+      it('returns `Invalid Date` for text after a UTC offset', () => {
+        const result = parseISO('2014-02-11T21:35:45+04:00Z')
+        assert(result instanceof Date)
+        assert(isNaN(result))
+      })
     })
   })
 


### PR DESCRIPTION
Fixes #2489