### PR TITLE
Clarify start vs. end parameters in differenceIn* methods

### DIFF
--- a/src/differenceInBusinessDays/index.ts
+++ b/src/differenceInBusinessDays/index.ts
@@ -10,17 +10,17 @@ import requiredArgs from '../_lib/requiredArgs/index'
 /**
  * @name differenceInBusinessDays
  * @category Day Helpers
- * @summary Get the number of business days between the given dates.
+ * @summary Get the number of business days to one date from another.
  *
  * @description
- * Get the number of business day periods between the given dates.
+ * Get the number of business day periods to one date from another.
  * Business days being days that arent in the weekend.
  * Like `differenceInCalendarDays`, the function removes the times from
  * the dates before calculating the difference.
  *
- * @param {Date|Number} dateLeft - the later date
- * @param {Date|Number} dateRight - the earlier date
- * @returns {Number} the number of business days
+ * @param {Date|Number} dateTo - the target date
+ * @param {Date|Number} dateFrom - the start date
+ * @returns {Number} the number of business days from dateFrom to dateTo
  * @throws {TypeError} 2 arguments required
  *
  * @example

--- a/src/differenceInCalendarDays/index.ts
+++ b/src/differenceInCalendarDays/index.ts
@@ -7,19 +7,19 @@ const MILLISECONDS_IN_DAY = 86400000
 /**
  * @name differenceInCalendarDays
  * @category Day Helpers
- * @summary Get the number of calendar days between the given dates.
+ * @summary Get the number of calendar days to one date from another.
  *
  * @description
- * Get the number of calendar days between the given dates. This means that the times are removed
+ * Get the number of calendar days to one date from another. This means that the times are removed
  * from the dates and then the difference in days is calculated.
  *
  * ### v2.0.0 breaking changes:
  *
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
- * @param {Date|Number} dateLeft - the later date
- * @param {Date|Number} dateRight - the earlier date
- * @returns {Number} the number of calendar days
+ * @param {Date|Number} dateTo - the target date
+ * @param {Date|Number} dateFrom - the start date
+ * @returns {Number} the number of calendar days from dateFrom to dateTo
  * @throws {TypeError} 2 arguments required
  *
  * @example

--- a/src/differenceInCalendarISOWeekYears/index.ts
+++ b/src/differenceInCalendarISOWeekYears/index.ts
@@ -4,10 +4,10 @@ import requiredArgs from '../_lib/requiredArgs/index'
 /**
  * @name differenceInCalendarISOWeekYears
  * @category ISO Week-Numbering Year Helpers
- * @summary Get the number of calendar ISO week-numbering years between the given dates.
+ * @summary Get the number of calendar ISO week-numbering years to one date from another.
  *
  * @description
- * Get the number of calendar ISO week-numbering years between the given dates.
+ * Get the number of calendar ISO week-numbering years to one date from another.
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
@@ -20,9 +20,9 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *   This change makes the name consistent with
  *   locale-dependent week-numbering year helpers, e.g., `addWeekYears`.
  *
- * @param {Date|Number} dateLeft - the later date
- * @param {Date|Number} dateRight - the earlier date
- * @returns {Number} the number of calendar ISO week-numbering years
+ * @param {Date|Number} dateTo - the target date
+ * @param {Date|Number} dateFrom - the start date
+ * @returns {Number} the number of calendar ISO week-numbering years from dateFrom to dateTo
  * @throws {TypeError} 2 arguments required
  *
  * @example

--- a/src/differenceInCalendarISOWeeks/index.ts
+++ b/src/differenceInCalendarISOWeeks/index.ts
@@ -7,10 +7,10 @@ const MILLISECONDS_IN_WEEK = 604800000
 /**
  * @name differenceInCalendarISOWeeks
  * @category ISO Week Helpers
- * @summary Get the number of calendar ISO weeks between the given dates.
+ * @summary Get the number of calendar ISO weeks to one date from another.
  *
  * @description
- * Get the number of calendar ISO weeks between the given dates.
+ * Get the number of calendar ISO weeks to one date from another.
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
@@ -18,9 +18,9 @@ const MILLISECONDS_IN_WEEK = 604800000
  *
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
- * @param {Date|Number} dateLeft - the later date
- * @param {Date|Number} dateRight - the earlier date
- * @returns {Number} the number of calendar ISO weeks
+ * @param {Date|Number} dateTo - the target date
+ * @param {Date|Number} dateFrom - the start date
+ * @returns {Number} the number of calendar ISO weeks from dateFrom to dateTo
  * @throws {TypeError} 2 arguments required
  *
  * @example

--- a/src/differenceInCalendarMonths/index.ts
+++ b/src/differenceInCalendarMonths/index.ts
@@ -4,18 +4,18 @@ import requiredArgs from '../_lib/requiredArgs/index'
 /**
  * @name differenceInCalendarMonths
  * @category Month Helpers
- * @summary Get the number of calendar months between the given dates.
+ * @summary Get the number of calendar months to one date from another.
  *
  * @description
- * Get the number of calendar months between the given dates.
+ * Get the number of calendar months to one date from another.
  *
  * ### v2.0.0 breaking changes:
  *
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
- * @param {Date|Number} dateLeft - the later date
- * @param {Date|Number} dateRight - the earlier date
- * @returns {Number} the number of calendar months
+ * @param {Date|Number} dateTo - the target date
+ * @param {Date|Number} dateFrom - the start date
+ * @returns {Number} the number of calendar months from dateFrom to dateTo
  * @throws {TypeError} 2 arguments required
  *
  * @example

--- a/src/differenceInCalendarQuarters/index.ts
+++ b/src/differenceInCalendarQuarters/index.ts
@@ -5,18 +5,18 @@ import requiredArgs from '../_lib/requiredArgs/index'
 /**
  * @name differenceInCalendarQuarters
  * @category Quarter Helpers
- * @summary Get the number of calendar quarters between the given dates.
+ * @summary Get the number of calendar quarters to one date from another.
  *
  * @description
- * Get the number of calendar quarters between the given dates.
+ * Get the number of calendar quarters to one date from another.
  *
  * ### v2.0.0 breaking changes:
  *
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
- * @param {Date|Number} dateLeft - the later date
- * @param {Date|Number} dateRight - the earlier date
- * @returns {Number} the number of calendar quarters
+ * @param {Date|Number} dateTo - the target date
+ * @param {Date|Number} dateFrom - the start date
+ * @returns {Number} the number of calendar quarters from dateFrom to dateTo
  * @throws {TypeError} 2 arguments required
  *
  * @example

--- a/src/differenceInCalendarWeeks/index.ts
+++ b/src/differenceInCalendarWeeks/index.ts
@@ -8,21 +8,21 @@ const MILLISECONDS_IN_WEEK = 604800000
 /**
  * @name differenceInCalendarWeeks
  * @category Week Helpers
- * @summary Get the number of calendar weeks between the given dates.
+ * @summary Get the number of calendar weeks to one date from another.
  *
  * @description
- * Get the number of calendar weeks between the given dates.
+ * Get the number of calendar weeks to one date from another.
  *
  * ### v2.0.0 breaking changes:
  *
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
- * @param {Date|Number} dateLeft - the later date
- * @param {Date|Number} dateRight - the earlier date
+ * @param {Date|Number} dateTo - the target date
+ * @param {Date|Number} dateFrom - the start date
  * @param {Object} [options] - an object with options.
  * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
  * @param {0|1|2|3|4|5|6} [options.weekStartsOn=0] - the index of the first day of the week (0 - Sunday)
- * @returns {Number} the number of calendar weeks
+ * @returns {Number} the number of calendar weeks from dateFrom to dateTo
  * @throws {TypeError} 2 arguments required
  * @throws {RangeError} `options.weekStartsOn` must be between 0 and 6
  *

--- a/src/differenceInCalendarYears/index.ts
+++ b/src/differenceInCalendarYears/index.ts
@@ -4,18 +4,18 @@ import requiredArgs from '../_lib/requiredArgs/index'
 /**
  * @name differenceInCalendarYears
  * @category Year Helpers
- * @summary Get the number of calendar years between the given dates.
+ * @summary Get the number of calendar years to one date from another.
  *
  * @description
- * Get the number of calendar years between the given dates.
+ * Get the number of calendar years to one date from another.
  *
  * ### v2.0.0 breaking changes:
  *
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
- * @param {Date|Number} dateLeft - the later date
- * @param {Date|Number} dateRight - the earlier date
- * @returns {Number} the number of calendar years
+ * @param {Date|Number} dateTo - the target date
+ * @param {Date|Number} dateFrom - the start date
+ * @returns {Number} the number of calendar years from dateFrom to dateTo
  * @throws {TypeError} 2 arguments required
  *
  * @example

--- a/src/differenceInDays/index.ts
+++ b/src/differenceInDays/index.ts
@@ -29,10 +29,10 @@ function compareLocalAsc(dateLeft: Date, dateRight: Date): number {
 /**
  * @name differenceInDays
  * @category Day Helpers
- * @summary Get the number of full days between the given dates.
+ * @summary Get the number of full days to one date from another.
  *
  * @description
- * Get the number of full day periods between two dates. Fractional days are
+ * Get the number of full day periods to one date from another. Fractional days are
  * truncated towards zero.
  *
  * One "full day" is the distance between a local time in one day to the same
@@ -47,9 +47,9 @@ function compareLocalAsc(dateLeft: Date, dateRight: Date): number {
  *
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
- * @param {Date|Number} dateLeft - the later date
- * @param {Date|Number} dateRight - the earlier date
- * @returns {Number} the number of full days according to the local timezone
+ * @param {Date|Number} dateTo - the target date
+ * @param {Date|Number} dateFrom - the start date
+ * @returns {Number} the number of full days from dateFrom to dateTo according to the local timezone
  * @throws {TypeError} 2 arguments required
  *
  * @example

--- a/src/differenceInHours/index.ts
+++ b/src/differenceInHours/index.ts
@@ -7,20 +7,20 @@ import { getRoundingMethod } from '../_lib/roundingMethods/index'
 /**
  * @name differenceInHours
  * @category Hour Helpers
- * @summary Get the number of hours between the given dates.
+ * @summary Get the number of hours to one date from another.
  *
  * @description
- * Get the number of hours between the given dates.
+ * Get the number of hours to one date from another.
  *
  * ### v2.0.0 breaking changes:
  *
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
- * @param {Date|Number} dateLeft - the later date
- * @param {Date|Number} dateRight - the earlier date
+ * @param {Date|Number} dateTo - the target date
+ * @param {Date|Number} dateFrom - the start date
  * @param {Object} [options] - an object with options.
  * @param {String} [options.roundingMethod='trunc'] - a rounding method (`ceil`, `floor`, `round` or `trunc`)
- * @returns {Number} the number of hours
+ * @returns {Number} the number of hours from dateFrom to dateTo
  * @throws {TypeError} 2 arguments required
  *
  * @example

--- a/src/differenceInISOWeekYears/index.ts
+++ b/src/differenceInISOWeekYears/index.ts
@@ -7,10 +7,10 @@ import requiredArgs from '../_lib/requiredArgs/index'
 /**
  * @name differenceInISOWeekYears
  * @category ISO Week-Numbering Year Helpers
- * @summary Get the number of full ISO week-numbering years between the given dates.
+ * @summary Get the number of full ISO week-numbering years to one date from another.
  *
  * @description
- * Get the number of full ISO week-numbering years between the given dates.
+ * Get the number of full ISO week-numbering years to one date from another.
  *
  * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
  *
@@ -23,9 +23,9 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *   This change makes the name consistent with
  *   locale-dependent week-numbering year helpers, e.g., `addWeekYears`.
  *
- * @param {Date|Number} dateLeft - the later date
- * @param {Date|Number} dateRight - the earlier date
- * @returns {Number} the number of full ISO week-numbering years
+ * @param {Date|Number} dateTo - the target date
+ * @param {Date|Number} dateFrom - the start date
+ * @returns {Number} the number of full ISO week-numbering years from dateFrom to dateTo
  * @throws {TypeError} 2 arguments required
  *
  * @example

--- a/src/differenceInMilliseconds/index.ts
+++ b/src/differenceInMilliseconds/index.ts
@@ -4,18 +4,18 @@ import requiredArgs from '../_lib/requiredArgs/index'
 /**
  * @name differenceInMilliseconds
  * @category Millisecond Helpers
- * @summary Get the number of milliseconds between the given dates.
+ * @summary Get the number of milliseconds to one date from another.
  *
  * @description
- * Get the number of milliseconds between the given dates.
+ * Get the number of milliseconds to one date from another.
  *
  * ### v2.0.0 breaking changes:
  *
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
- * @param {Date|Number} dateLeft - the later date
- * @param {Date|Number} dateRight - the earlier date
- * @returns {Number} the number of milliseconds
+ * @param {Date|Number} dateTo - the target date
+ * @param {Date|Number} dateFrom - the start date
+ * @returns {Number} the number of milliseconds from dateFrom to dateTo
  * @throws {TypeError} 2 arguments required
  *
  * @example

--- a/src/differenceInMinutes/index.ts
+++ b/src/differenceInMinutes/index.ts
@@ -7,20 +7,20 @@ import { getRoundingMethod } from '../_lib/roundingMethods/index'
 /**
  * @name differenceInMinutes
  * @category Minute Helpers
- * @summary Get the number of minutes between the given dates.
+ * @summary Get the number of minutes to one date from another.
  *
  * @description
- * Get the signed number of full (rounded towards 0) minutes between the given dates.
+ * Get the signed number of full (rounded towards 0) minutes to one date from another.
  *
  * ### v2.0.0 breaking changes:
  *
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
- * @param {Date|Number} dateLeft - the later date
- * @param {Date|Number} dateRight - the earlier date
+ * @param {Date|Number} dateTo - the target date
+ * @param {Date|Number} dateFrom - the start date
  * @param {Object} [options] - an object with options.
  * @param {String} [options.roundingMethod='trunc'] - a rounding method (`ceil`, `floor`, `round` or `trunc`)
- * @returns {Number} the number of minutes
+ * @returns {Number} the number of minutes from dateFrom to dateTo
  * @throws {TypeError} 2 arguments required
  *
  * @example

--- a/src/differenceInMonths/index.ts
+++ b/src/differenceInMonths/index.ts
@@ -7,18 +7,18 @@ import isLastDayOfMonth from '../isLastDayOfMonth/index'
 /**
  * @name differenceInMonths
  * @category Month Helpers
- * @summary Get the number of full months between the given dates.
+ * @summary Get the number of full months to one date from another.
  *
  * @description
- * Get the number of full months between the given dates using trunc as a default rounding method.
+ * Get the number of full months to one date from another using trunc as a default rounding method.
  *
  * ### v2.0.0 breaking changes:
  *
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
- * @param {Date|Number} dateLeft - the later date
- * @param {Date|Number} dateRight - the earlier date
- * @returns {Number} the number of full months
+ * @param {Date|Number} dateTo - the target date
+ * @param {Date|Number} dateFrom - the start date
+ * @returns {Number} the number of full months from dateFrom to dateTo
  * @throws {TypeError} 2 arguments required
  *
  * @example

--- a/src/differenceInQuarters/index.ts
+++ b/src/differenceInQuarters/index.ts
@@ -6,20 +6,20 @@ import { getRoundingMethod } from '../_lib/roundingMethods/index'
 /**
  * @name differenceInQuarters
  * @category Quarter Helpers
- * @summary Get the number of quarters between the given dates.
+ * @summary Get the number of quarters to one date from another.
  *
  * @description
- * Get the number of quarters between the given dates.
+ * Get the number of quarters to one date from another.
  *
  * ### v2.0.0 breaking changes:
  *
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
- * @param {Date|Number} dateLeft - the later date
- * @param {Date|Number} dateRight - the earlier date
+ * @param {Date|Number} dateTo - the target date
+ * @param {Date|Number} dateFrom - the start date
  * @param {Object} [options] - an object with options.
  * @param {String} [options.roundingMethod='trunc'] - a rounding method (`ceil`, `floor`, `round` or `trunc`)
- * @returns {Number} the number of full quarters
+ * @returns {Number} the number of full quarters from dateFrom to dateTo
  * @throws {TypeError} 2 arguments required
  *
  * @example

--- a/src/differenceInSeconds/index.ts
+++ b/src/differenceInSeconds/index.ts
@@ -6,20 +6,20 @@ import { getRoundingMethod } from '../_lib/roundingMethods/index'
 /**
  * @name differenceInSeconds
  * @category Second Helpers
- * @summary Get the number of seconds between the given dates.
+ * @summary Get the number of seconds to one date from another.
  *
  * @description
- * Get the number of seconds between the given dates.
+ * Get the number of seconds to one date from another.
  *
  * ### v2.0.0 breaking changes:
  *
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
- * @param {Date|Number} dateLeft - the later date
- * @param {Date|Number} dateRight - the earlier date
+ * @param {Date|Number} dateTo - the target date
+ * @param {Date|Number} dateFrom - the start date
  * @param {Object} [options] - an object with options.
  * @param {String} [options.roundingMethod='trunc'] - a rounding method (`ceil`, `floor`, `round` or `trunc`)
- * @returns {Number} the number of seconds
+ * @returns {Number} the number of seconds from dateFrom to dateTo
  * @throws {TypeError} 2 arguments required
  *
  * @example

--- a/src/differenceInWeeks/index.ts
+++ b/src/differenceInWeeks/index.ts
@@ -6,10 +6,10 @@ import { getRoundingMethod } from '../_lib/roundingMethods/index'
 /**
  * @name differenceInWeeks
  * @category Week Helpers
- * @summary Get the number of full weeks between the given dates.
+ * @summary Get the number of full weeks to one date from another.
  *
  * @description
- * Get the number of full weeks between two dates. Fractional weeks are
+ * Get the number of full weeks to one date from another. Fractional weeks are
  * truncated towards zero by default.
  *
  * One "full week" is the distance between a local time in one day to the same
@@ -24,11 +24,11 @@ import { getRoundingMethod } from '../_lib/roundingMethods/index'
  *
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
- * @param {Date|Number} dateLeft - the later date
- * @param {Date|Number} dateRight - the earlier date
+ * @param {Date|Number} dateTo - the target date
+ * @param {Date|Number} dateFrom - the start date
  * @param {Object} [options] - an object with options.
  * @param {String} [options.roundingMethod='trunc'] - a rounding method (`ceil`, `floor`, `round` or `trunc`)
- * @returns {Number} the number of full weeks
+ * @returns {Number} the number of full weeks from dateFrom to dateTo
  * @throws {TypeError} 2 arguments required
  *
  * @example

--- a/src/differenceInYears/index.ts
+++ b/src/differenceInYears/index.ts
@@ -6,18 +6,18 @@ import requiredArgs from '../_lib/requiredArgs/index'
 /**
  * @name differenceInYears
  * @category Year Helpers
- * @summary Get the number of full years between the given dates.
+ * @summary Get the number of full years to one date from another.
  *
  * @description
- * Get the number of full years between the given dates.
+ * Get the number of full years to one date from another.
  *
  * ### v2.0.0 breaking changes:
  *
  * - [Changes that are common for the whole library](https://github.com/date-fns/date-fns/blob/master/docs/upgradeGuide.md#Common-Changes).
  *
- * @param {Date|Number} dateLeft - the later date
- * @param {Date|Number} dateRight - the earlier date
- * @returns {Number} the number of full years
+ * @param {Date|Number} dateTo - the target date
+ * @param {Date|Number} dateFrom - the start date
+ * @returns {Number} the number of full years from dateFrom to dateTo
  * @throws {TypeError} 2 arguments required
  *
  * @example


### PR DESCRIPTION
Fixes #2179

I'm open to alternative approaches if preferred, but this should at least get the ball rolling.