### PR TITLE
stop CI tests from running twice on branches

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,8 +1,9 @@
 name: Coverage report
 
-'on':
+on:
   push:
-    branches: [master]
+    branches:
+      - master
 
 jobs:
   tests:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   tests:
+    if: github.repository_owner == 'date-fns'
+
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,8 +1,9 @@
 name: Deploy
 
-'on':
+on:
   push:
-    branches: [master]
+    branches:
+      - master
 
 jobs:
   tests:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   tests:
+    if: github.repository_owner == 'date-fns'
+
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/main_tests.yaml
+++ b/.github/workflows/main_tests.yaml
@@ -1,6 +1,12 @@
 name: Node.js tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   tests:

--- a/.github/workflows/node_tests.yaml
+++ b/.github/workflows/node_tests.yaml
@@ -1,6 +1,12 @@
 name: Main tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   tests:

--- a/.github/workflows/timezone_step_1.yaml
+++ b/.github/workflows/timezone_step_1.yaml
@@ -1,6 +1,12 @@
 name: Timezones 1/2
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   tests:

--- a/.github/workflows/timezone_step_2.yaml
+++ b/.github/workflows/timezone_step_2.yaml
@@ -1,6 +1,12 @@
 name: Timezones 2/2
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   tests:


### PR DESCRIPTION
- stop CI tests from running twice on branches
- stops forks from running coverage and deploy actions on master, which always results in failures anyways