### PR TITLE
`differenceInBusinessDays` improvements (docs and options)

### DIFF
--- a/src/differenceInBusinessDays/test.ts
+++ b/src/differenceInBusinessDays/test.ts
@@ -402,7 +402,7 @@ describe('differenceInBusinessDays', () => {
         new Date(NaN),
         new Date(2017, 0 /* Jan */, 1)
       )
-      assert.strictEqual(result, NaN)
+      assert(isNaN(result))
     })
 
     it('returns NaN if the second date is `Invalid Date`', () => {
@@ -410,12 +410,12 @@ describe('differenceInBusinessDays', () => {
         new Date(2017, 0 /* Jan */, 1),
         new Date(NaN)
       )
-      assert.strictEqual(result, NaN)
+      assert(isNaN(result))
     })
 
     it('returns NaN if the both dates are `Invalid Date`', () => {
       const result = differenceInBusinessDays(new Date(NaN), new Date(NaN))
-      assert.strictEqual(result, NaN)
+      assert(isNaN(result))
     })
 
     it('throws TypeError exception if passed less than 2 arguments', () => {

--- a/src/differenceInBusinessDays/test.ts
+++ b/src/differenceInBusinessDays/test.ts
@@ -9,7 +9,7 @@ describe('differenceInBusinessDays', () => {
       new Date(2014, 6 /* Jul */, 18),
       new Date(2014, 0 /* Jan */, 10)
     )
-    assert(result === 135)
+    assert.strictEqual(result, 135)
   })
 
   it('can handle long ranges', () => {
@@ -22,39 +22,39 @@ describe('differenceInBusinessDays', () => {
       new Date(15000, 0 /* Jan */, 1),
       new Date(2014, 0 /* Jan */, 1)
     )
-    assert(result === 3387885)
+    assert.strictEqual(result, 3387885)
   })
 
   it('the same except given first date falls on a weekend', () => {
     const result = differenceInBusinessDays(
-      new Date(2019, 6 /* Jul */, 20),
-      new Date(2019, 6 /* Jul */, 18)
+      new Date(2019, 6 /* Jul */, 20), // Sat
+      new Date(2019, 6 /* Jul */, 18) // Thu
     )
-    assert(result === 2)
+    assert.strictEqual(result, 2)
   })
 
   it('the same except given second date falls on a weekend', () => {
     const result = differenceInBusinessDays(
-      new Date(2019, 6 /* Jul */, 23),
-      new Date(2019, 6 /* Jul */, 20)
+      new Date(2019, 6 /* Jul */, 23), // Tue
+      new Date(2019, 6 /* Jul */, 20) // Sat
     )
-    assert(result === 1)
+    assert.strictEqual(result, 1)
   })
 
   it('the same except both given dates fall on a weekend', () => {
     const result = differenceInBusinessDays(
-      new Date(2019, 6 /* Jul */, 28),
-      new Date(2019, 6 /* Jul */, 20)
+      new Date(2019, 6 /* Jul */, 28), // Sun
+      new Date(2019, 6 /* Jul */, 20) // Sat
     )
-    assert(result === 5)
+    assert.strictEqual(result, 5)
   })
 
-  it('returns a negative number if the time value of the first date is smaller', () => {
+  it('returns a negative number if the first date is earlier', () => {
     const result = differenceInBusinessDays(
       new Date(2014, 0 /* Jan */, 10),
       new Date(2014, 6 /* Jul */, 20)
     )
-    assert(result === -135)
+    assert.strictEqual(result, -135)
   })
 
   it('accepts timestamps', () => {
@@ -62,7 +62,306 @@ describe('differenceInBusinessDays', () => {
       new Date(2014, 6, 18).getTime(),
       new Date(2014, 0, 10).getTime()
     )
-    assert(result === 135)
+    assert.strictEqual(result, 135)
+  })
+
+  describe('options', () => {
+    const sat15 = new Date(2022, 0, 15)
+    const sun16 = new Date(2022, 0, 16)
+    const mon17 = new Date(2022, 0, 17)
+    const tue18 = new Date(2022, 0, 18)
+    const fri21 = new Date(2022, 0, 21)
+    const mon24 = new Date(2022, 0, 24)
+
+    describe('include start date, exclude end date (default)', () => {
+      it('Sat 15 -> Sun 16', () => {
+        const result = differenceInBusinessDays(sun16, sat15)
+        assert.strictEqual(result, 0)
+      })
+
+      it('Sun 16 -> Sat 15', () => {
+        const result = differenceInBusinessDays(sat15, sun16)
+        assert.strictEqual(result, 0)
+      })
+
+      it('Sat 15 -> Sat 15', () => {
+        const result = differenceInBusinessDays(sat15, sat15)
+        assert.strictEqual(result, 0)
+      })
+
+      it('Mon 17 -> Mon 17', () => {
+        const result = differenceInBusinessDays(mon17, mon17)
+        assert.strictEqual(result, 0)
+      })
+
+      it('Sun 16 -> Mon 17', () => {
+        const result = differenceInBusinessDays(mon17, sun16)
+        assert.strictEqual(result, 0)
+      })
+
+      it('Mon 17 -> Sun 16', () => {
+        const result = differenceInBusinessDays(sun16, mon17)
+        assert.strictEqual(result, -1)
+      })
+
+      it('Mon 17 -> Mon 24', () => {
+        const result = differenceInBusinessDays(mon24, mon17)
+        assert.strictEqual(result, 5)
+      })
+
+      it('Mon 17 -> Tue 18', () => {
+        const result = differenceInBusinessDays(tue18, mon17)
+        assert.strictEqual(result, 1)
+      })
+
+      it('Mon 17 -> Fri 21', () => {
+        const result = differenceInBusinessDays(fri21, mon17)
+        assert.strictEqual(result, 4)
+      })
+
+      it('Fri 21 -> Mon 17', () => {
+        const result = differenceInBusinessDays(mon17, fri21)
+        assert.strictEqual(result, -4)
+      })
+
+      it('Sun 16 -> Fri 21', () => {
+        const result = differenceInBusinessDays(fri21, sun16)
+        assert.strictEqual(result, 4)
+      })
+
+      it('Fri 21 -> Sun 16', () => {
+        const result = differenceInBusinessDays(sun16, fri21)
+        assert.strictEqual(result, -5)
+      })
+    })
+
+    describe('exclude start date, include end date', () => {
+      const options = { includeStartDate: false, includeEndDate: true }
+
+      it('Sat 15 -> Sun 16', () => {
+        const result = differenceInBusinessDays(sun16, sat15, options)
+        assert.strictEqual(result, 0)
+      })
+
+      it('Sun 16 -> Sat 15', () => {
+        const result = differenceInBusinessDays(sat15, sun16, options)
+        assert.strictEqual(result, 0)
+      })
+
+      it('Sat 15 -> Sat 15', () => {
+        const result = differenceInBusinessDays(sat15, sat15, options)
+        assert.strictEqual(result, 0)
+      })
+
+      it('Mon 17 -> Mon 17', () => {
+        const result = differenceInBusinessDays(mon17, mon17, options)
+        assert.strictEqual(result, 0)
+      })
+
+      it('Sun 16 -> Mon 17', () => {
+        const result = differenceInBusinessDays(mon17, sun16, options)
+        assert.strictEqual(result, 1)
+      })
+
+      it('Mon 17 -> Sun 16', () => {
+        const result = differenceInBusinessDays(sun16, mon17, options)
+        assert.strictEqual(result, 0)
+      })
+
+      it('Mon 17 -> Mon 24', () => {
+        const result = differenceInBusinessDays(mon24, mon17, options)
+        assert.strictEqual(result, 5)
+      })
+
+      it('Mon 17 -> Tue 18', () => {
+        const result = differenceInBusinessDays(tue18, mon17, options)
+        assert.strictEqual(result, 1)
+      })
+
+      it('Mon 17 -> Fri 21', () => {
+        const result = differenceInBusinessDays(fri21, mon17, options)
+        assert.strictEqual(result, 4)
+      })
+
+      it('Fri 21 -> Mon 17', () => {
+        const result = differenceInBusinessDays(mon17, fri21, options)
+        assert.strictEqual(result, -4)
+      })
+
+      it('Sun 16 -> Fri 21', () => {
+        const result = differenceInBusinessDays(fri21, sun16, options)
+        assert.strictEqual(result, 5)
+      })
+
+      it('Fri 21 -> Sun 16', () => {
+        const result = differenceInBusinessDays(sun16, fri21, options)
+        assert.strictEqual(result, -4)
+      })
+    })
+
+    describe('include both start and end date', () => {
+      const options = { includeEndDate: true }
+
+      it('Sat 15 -> Sun 16', () => {
+        const result = differenceInBusinessDays(sun16, sat15, options)
+        assert.strictEqual(result, 0)
+      })
+
+      it('Sun 16 -> Sat 15', () => {
+        const result = differenceInBusinessDays(sat15, sun16, options)
+        assert.strictEqual(result, 0)
+      })
+
+      it('Sat 15 -> Sat 15', () => {
+        const result = differenceInBusinessDays(sat15, sat15, options)
+        assert.strictEqual(result, 0)
+      })
+
+      it('Mon 17 -> Mon 17', () => {
+        // only counting the day once
+        const result = differenceInBusinessDays(mon17, mon17, options)
+        assert.strictEqual(result, 1)
+      })
+
+      it('Sun 16 -> Mon 17', () => {
+        const result = differenceInBusinessDays(mon17, sun16, options)
+        assert.strictEqual(result, 1)
+      })
+
+      it('Mon 17 -> Sun 16', () => {
+        const result = differenceInBusinessDays(sun16, mon17, options)
+        assert.strictEqual(result, -1)
+      })
+
+      it('Mon 17 -> Mon 24', () => {
+        const result = differenceInBusinessDays(mon24, mon17, options)
+        assert.strictEqual(result, 6)
+      })
+
+      it('Mon 17 -> Tue 18', () => {
+        const result = differenceInBusinessDays(tue18, mon17, options)
+        assert.strictEqual(result, 2)
+      })
+
+      it('Mon 17 -> Fri 21', () => {
+        const result = differenceInBusinessDays(fri21, mon17, options)
+        assert.strictEqual(result, 5)
+      })
+
+      it('Fri 21 -> Mon 17', () => {
+        const result = differenceInBusinessDays(mon17, fri21, options)
+        assert.strictEqual(result, -5)
+      })
+
+      it('Sun 16 -> Fri 21', () => {
+        const result = differenceInBusinessDays(fri21, sun16, options)
+        assert.strictEqual(result, 5)
+      })
+
+      it('Fri 21 -> Sun 16', () => {
+        const result = differenceInBusinessDays(sun16, fri21, options)
+        assert.strictEqual(result, -5)
+      })
+    })
+
+    describe('exclude both start and end date', () => {
+      const options = { includeStartDate: false }
+
+      it('Sat 15 -> Sun 16', () => {
+        const result = differenceInBusinessDays(sun16, sat15, options)
+        assert.strictEqual(result, 0)
+      })
+
+      it('Sun 16 -> Sat 15', () => {
+        const result = differenceInBusinessDays(sat15, sun16, options)
+        assert.strictEqual(result, 0)
+      })
+
+      it('Sat 15 -> Sat 15', () => {
+        const result = differenceInBusinessDays(sat15, sat15, options)
+        assert.strictEqual(result, 0)
+      })
+
+      it('Mon 17 -> Mon 17', () => {
+        const result = differenceInBusinessDays(mon17, mon17, options)
+        assert.strictEqual(result, 0)
+      })
+
+      it('Sun 16 -> Mon 17', () => {
+        const result = differenceInBusinessDays(mon17, sun16, options)
+        assert.strictEqual(result, 0)
+      })
+
+      it('Mon 17 -> Sun 16', () => {
+        const result = differenceInBusinessDays(sun16, mon17, options)
+        assert.strictEqual(result, 0)
+      })
+
+      it('Mon 17 -> Mon 24', () => {
+        const result = differenceInBusinessDays(mon24, mon17, options)
+        assert.strictEqual(result, 4)
+      })
+
+      it('Mon 17 -> Tue 18', () => {
+        const result = differenceInBusinessDays(tue18, mon17, options)
+        assert.strictEqual(result, 0)
+      })
+
+      it('Mon 17 -> Fri 21', () => {
+        const result = differenceInBusinessDays(fri21, mon17, options)
+        assert.strictEqual(result, 3)
+      })
+
+      it('Fri 21 -> Mon 17', () => {
+        const result = differenceInBusinessDays(mon17, fri21, options)
+        assert.strictEqual(result, -3)
+      })
+
+      it('Sun 16 -> Fri 21', () => {
+        const result = differenceInBusinessDays(fri21, sun16, options)
+        assert.strictEqual(result, 4)
+      })
+
+      it('Fri 21 -> Sun 16', () => {
+        const result = differenceInBusinessDays(sun16, fri21, options)
+        assert.strictEqual(result, -4)
+      })
+    })
+  })
+
+  describe('docs examples', () => {
+    it('example 1', () => {
+      const result = differenceInBusinessDays(
+        new Date(2022, 0, 19), // Wed
+        new Date(2022, 0, 16) // Sun
+      )
+      assert.strictEqual(result, 2)
+    })
+
+    it('example 2', () => {
+      const result = differenceInBusinessDays(
+        new Date(2022, 0, 14), // Fri
+        new Date(2022, 0, 19) // Wed
+      )
+      assert.strictEqual(result, -3)
+    })
+
+    it('example 3', () => {
+      const result = differenceInBusinessDays(
+        new Date(2022, 0, 19), // Wed
+        new Date(2022, 0, 19) // Wed
+      )
+      assert.strictEqual(result, 0)
+    })
+
+    it('example 4', () => {
+      const result = differenceInBusinessDays(
+        new Date(2022, 0, 19), // Wed
+        new Date(2022, 0, 14), // Fri
+        { includeStartDate: false, includeEndDate: true }
+      )
+      assert.strictEqual(result, 3)
+    })
   })
 
   describe('edge cases', () => {
@@ -71,7 +370,7 @@ describe('differenceInBusinessDays', () => {
         new Date(2014, 8 /* Sep */, 5, 0, 0),
         new Date(2014, 8 /* Sep */, 4, 23, 59)
       )
-      assert(result === 1)
+      assert.strictEqual(result, 1)
     })
 
     it('the same for the swapped dates', () => {
@@ -79,37 +378,23 @@ describe('differenceInBusinessDays', () => {
         new Date(2014, 8 /* Sep */, 4, 23, 59),
         new Date(2014, 8 /* Sep */, 5, 0, 0)
       )
-      assert(result === -1)
+      assert.strictEqual(result, -1)
     })
 
     it('the time values of the given dates are the same', () => {
       const result = differenceInBusinessDays(
-        new Date(2014, 8 /* Sep */, 5, 0, 0),
-        new Date(2014, 8 /* Sep */, 4, 0, 0)
+        new Date(2014, 8 /* Sep */, 5),
+        new Date(2014, 8 /* Sep */, 4)
       )
-      assert(result === 1)
+      assert.strictEqual(result, 1)
     })
 
-    it('the given dates are the same', () => {
+    it('the given dates are the same, and the function does not return -0', () => {
       const result = differenceInBusinessDays(
-        new Date(2014, 8 /* Sep */, 5, 0, 0),
-        new Date(2014, 8 /* Sep */, 5, 0, 0)
+        new Date(2014, 8 /* Sep */, 5),
+        new Date(2014, 8 /* Sep */, 5)
       )
-      assert(result === 0)
-    })
-
-    it('does not return -0 when the given dates are the same', () => {
-      function isNegativeZero(x: number) {
-        return x === 0 && 1 / x < 0
-      }
-
-      const result = differenceInBusinessDays(
-        new Date(2014, 8 /* Sep */, 5, 0, 0),
-        new Date(2014, 8 /* Sep */, 5, 0, 0)
-      )
-
-      const resultIsNegative = isNegativeZero(result)
-      assert(resultIsNegative === false)
+      assert.strictEqual(result, 0)
     })
 
     it('returns NaN if the first date is `Invalid Date`', () => {
@@ -117,7 +402,7 @@ describe('differenceInBusinessDays', () => {
         new Date(NaN),
         new Date(2017, 0 /* Jan */, 1)
       )
-      assert(isNaN(result))
+      assert.strictEqual(result, NaN)
     })
 
     it('returns NaN if the second date is `Invalid Date`', () => {
@@ -125,12 +410,12 @@ describe('differenceInBusinessDays', () => {
         new Date(2017, 0 /* Jan */, 1),
         new Date(NaN)
       )
-      assert(isNaN(result))
+      assert.strictEqual(result, NaN)
     })
 
     it('returns NaN if the both dates are `Invalid Date`', () => {
       const result = differenceInBusinessDays(new Date(NaN), new Date(NaN))
-      assert(isNaN(result))
+      assert.strictEqual(result, NaN)
     })
 
     it('throws TypeError exception if passed less than 2 arguments', () => {

--- a/src/differenceInBusinessDays/test.ts
+++ b/src/differenceInBusinessDays/test.ts
@@ -389,12 +389,24 @@ describe('differenceInBusinessDays', () => {
       assert.strictEqual(result, 1)
     })
 
-    it('the given dates are the same, and the function does not return -0', () => {
+    it('the given dates are the same', () => {
       const result = differenceInBusinessDays(
         new Date(2014, 8 /* Sep */, 5),
         new Date(2014, 8 /* Sep */, 5)
       )
       assert.strictEqual(result, 0)
+    })
+
+    it('does not return -0 when the given dates are the same', () => {
+      const isNegativeZero = (x: number) => x === 0 && 1 / x < 0
+
+      const result = differenceInBusinessDays(
+        new Date(2014, 8 /* Sep */, 5),
+        new Date(2014, 8 /* Sep */, 5)
+      )
+
+      const resultIsNegative = isNegativeZero(result)
+      assert.strictEqual(resultIsNegative, false)
     })
 
     it('returns NaN if the first date is `Invalid Date`', () => {


### PR DESCRIPTION
Following the discussion and troubleshooting here [#1268#issuecomment-1024893923](https://github.com/date-fns/date-fns/issues/1268#issuecomment-1024893923), this PR tries to improve the function's documentation and give better examples.

It also introduces an options object to customize whether the start and end dates should be included in the calculation. Defaults remain the same, so this is not a breaking change.