### PR TITLE
Fixes the formatDistanceStrict/formatDistanceToNowStrict that returns '60 minutes ago' rather than '1 hour ago' #2957

### DIFF
--- a/src/formatDistanceStrict/index.ts
+++ b/src/formatDistanceStrict/index.ts
@@ -186,7 +186,7 @@ export default function formatDistanceStrict<DateType extends Date>(
       ? locale.formatDistance('xDays', 1, localizeOptions)
       : locale.formatDistance('xHours', hours, localizeOptions)
 
-    // 1 up to 29 days
+    // 1 up to 30 days
   } else if (unit === 'day') {
     const days = roundingMethod(dstNormalizedMinutes / minutesInDay)
     return locale.formatDistance('xDays', days, localizeOptions)

--- a/src/formatDistanceStrict/index.ts
+++ b/src/formatDistanceStrict/index.ts
@@ -175,18 +175,18 @@ export default function formatDistanceStrict<DateType extends Date>(
   } else if (unit === 'minute') {
     const roundedMinutes = roundingMethod(minutes)
 
-    if (roundedMinutes === 60) {
-      return locale.formatDistance('xHours', 1, localizeOptions)
-    }
-
-    return locale.formatDistance('xMinutes', roundedMinutes, localizeOptions)
+    return roundedMinutes === 60 && options?.unit !== 'minute'
+      ? locale.formatDistance('xHours', 1, localizeOptions)
+      : locale.formatDistance('xMinutes', roundedMinutes, localizeOptions)
 
     // 1 up to 24 hours
   } else if (unit === 'hour') {
     const hours = roundingMethod(minutes / 60)
-    return locale.formatDistance('xHours', hours, localizeOptions)
+    return hours === 24 && options?.unit !== 'hour'
+      ? locale.formatDistance('xDays', 1, localizeOptions)
+      : locale.formatDistance('xHours', hours, localizeOptions)
 
-    // 1 up to 30 days
+    // 1 up to 29 days
   } else if (unit === 'day') {
     const days = roundingMethod(dstNormalizedMinutes / minutesInDay)
     return locale.formatDistance('xDays', days, localizeOptions)

--- a/src/formatDistanceStrict/index.ts
+++ b/src/formatDistanceStrict/index.ts
@@ -176,8 +176,7 @@ export default function formatDistanceStrict<DateType extends Date>(
     const roundedMinutes = roundingMethod(minutes)
 
     if (roundedMinutes === 60) {
-      const hours = roundingMethod(roundedMinutes / 60)
-      return locale.formatDistance('xHours', hours, localizeOptions)
+      return locale.formatDistance('xHours', 1, localizeOptions)
     }
 
     return locale.formatDistance('xMinutes', roundedMinutes, localizeOptions)

--- a/src/formatDistanceStrict/index.ts
+++ b/src/formatDistanceStrict/index.ts
@@ -174,6 +174,12 @@ export default function formatDistanceStrict<DateType extends Date>(
     // 1 up to 60 mins
   } else if (unit === 'minute') {
     const roundedMinutes = roundingMethod(minutes)
+
+    if (roundedMinutes === 60) {
+      const hours = roundingMethod(roundedMinutes / 60)
+      return locale.formatDistance('xHours', hours, localizeOptions)
+    }
+
     return locale.formatDistance('xMinutes', roundedMinutes, localizeOptions)
 
     // 1 up to 24 hours

--- a/src/formatDistanceStrict/test.ts
+++ b/src/formatDistanceStrict/test.ts
@@ -41,6 +41,14 @@ describe('formatDistanceStrict', () => {
       )
       assert(result === '3 minutes')
     })
+
+    it("doesn't return 60 minutes - issue 2957", () => {
+      const result = formatDistanceStrict(
+        new Date(2020, 1, 1, 1, 0, 30),
+        new Date(2020, 1, 1, 2, 0, 0)
+      )
+      assert(result === '1 hour')
+    })
   })
 
   describe('hours', () => {

--- a/src/formatDistanceStrict/test.ts
+++ b/src/formatDistanceStrict/test.ts
@@ -15,12 +15,20 @@ describe('formatDistanceStrict', () => {
         assert(result === '0 seconds')
       })
 
-      it('5 seconds', () => {
+      it('n seconds', () => {
         const result = formatDistanceStrict(
           new Date(1986, 3, 4, 10, 32, 0),
           new Date(1986, 3, 4, 10, 32, 5)
         )
         assert(result === '5 seconds')
+      })
+
+      it("doesn't return 60 seconds - issue 2957", () => {
+        const result = formatDistanceStrict(
+          new Date(1986, 3, 4, 10, 31, 30),
+          new Date(1986, 3, 4, 10, 32, 30)
+        )
+        assert(result === '1 minute')
       })
     })
   })
@@ -43,11 +51,23 @@ describe('formatDistanceStrict', () => {
     })
 
     it("doesn't return 60 minutes - issue 2957", () => {
-      const result = formatDistanceStrict(
-        new Date(2020, 1, 1, 1, 0, 30),
-        new Date(2020, 1, 1, 2, 0, 0)
+      assert(
+        formatDistanceStrict(
+          new Date(2020, 1, 1, 1, 0, 30),
+          new Date(2020, 1, 1, 2, 0, 0)
+        ) === '1 hour'
       )
-      assert(result === '1 hour')
+
+      // Allow to force a 'minute' unit if specified in options
+      assert(
+        formatDistanceStrict(
+          new Date(2020, 1, 1, 1, 0, 1),
+          new Date(2020, 1, 1, 2, 0, 0),
+          {
+            unit: 'minute',
+          }
+        ) === '60 minutes'
+      )
     })
   })
 
@@ -67,6 +87,25 @@ describe('formatDistanceStrict', () => {
       )
       assert(result === '3 hours')
     })
+
+    it("doesn't return 24 hours - issue 2957", () => {
+      assert(
+        formatDistanceStrict(
+          new Date(1986, 3, 4, 0, 0, 0),
+          new Date(1986, 3, 4, 23, 40, 0)
+        ) === '1 day'
+      )
+
+      assert(
+        formatDistanceStrict(
+          new Date(1986, 3, 4, 0, 0, 0),
+          new Date(1986, 3, 4, 23, 40, 0),
+          {
+            unit: 'hour',
+          }
+        ) === '24 hours'
+      )
+    })
   })
 
   describe('days', () => {
@@ -84,6 +123,21 @@ describe('formatDistanceStrict', () => {
         new Date(1986, 3, 7, 10, 32, 0)
       )
       assert(result === '3 days')
+    })
+
+    it('returns 1 month for more than 29 days', () => {
+      assert(
+        formatDistanceStrict(
+          new Date(1986, 8, 0, 10, 32, 0),
+          new Date(1986, 8, 29, 10, 32, 0)
+        ) === '29 days'
+      )
+      assert(
+        formatDistanceStrict(
+          new Date(1986, 8, 0, 10, 32, 0),
+          new Date(1986, 8, 30, 10, 32, 0)
+        ) === '1 month'
+      )
     })
   })
 


### PR DESCRIPTION
Fixes https://github.com/date-fns/date-fns/issues/2957 