### PR TITLE
format ISO doesnt support milliseconds

### DIFF
--- a/src/_lib/fractionalDigits/index.ts
+++ b/src/_lib/fractionalDigits/index.ts
@@ -1,0 +1,16 @@
+import addLeadingZeros from '../addLeadingZeros'
+
+export default function fractionDigits(
+  fractionDigits: number,
+  originalDate: Date
+): string {
+  let fractionalSecond = ''
+  if (fractionDigits > 0) {
+    const milliseconds = originalDate.getMilliseconds()
+    const fractionalSeconds = Math.floor(
+      milliseconds * Math.pow(10, fractionDigits - 3)
+    )
+    fractionalSecond = '.' + addLeadingZeros(fractionalSeconds, fractionDigits)
+  }
+  return fractionalSecond
+}

--- a/src/_lib/fractionalDigits/test.ts
+++ b/src/_lib/fractionalDigits/test.ts
@@ -1,0 +1,24 @@
+/* eslint-env mocha */
+
+import assert from 'assert'
+import fractionalDigits from '.'
+
+describe('fractionalDigits', () => {
+  it('it adds fractional 4 digits', () => {
+    const date = new Date(2019, 2 /* Mar */, 3, 19, 0, 52, 123)
+    const fraction = fractionalDigits(4, date)
+    assert(fraction === '.1230')
+  })
+
+  it('it only show 2 fractional digits', () => {
+    const date = new Date(2019, 2 /* Mar */, 3, 19, 0, 52, 123)
+    const fraction = fractionalDigits(2, date)
+    assert(fraction === '.12')
+  })
+
+  it('it doesnt show any digits', () => {
+    const date = new Date(2019, 2 /* Mar */, 3, 19, 0, 52, 123)
+    const fraction = fractionalDigits(0, date)
+    assert(fraction === '')
+  })
+})

--- a/src/formatISO/index.ts
+++ b/src/formatISO/index.ts
@@ -24,23 +24,23 @@ export interface FormatISOOptions
  *
  * @example
  * // Represent 18 September 2019 in ISO 8601 format (local time zone is UTC):
- * const result = formatISO(new Date(2019, 8, 18, 19, 0, 52))
- * //=> '2019-09-18T19:00:52Z'
+ * const result = formatISO(new Date(2019, 8, 18, 19, 0, 52, 123))
+ * //=> '2019-09-18T19:00:52.123Z'
  *
  * @example
  * // Represent 18 September 2019 in ISO 8601, short format (local time zone is UTC):
- * const result = formatISO(new Date(2019, 8, 18, 19, 0, 52), { format: 'basic' })
- * //=> '20190918T190052'
+ * const result = formatISO(new Date(2019, 8, 18, 19, 0, 52, 123), { format: 'basic' })
+ * //=> '20190918T190052.123'
  *
  * @example
  * // Represent 18 September 2019 in ISO 8601 format, date only:
- * const result = formatISO(new Date(2019, 8, 18, 19, 0, 52), { representation: 'date' })
+ * const result = formatISO(new Date(2019, 8, 18, 19, 0, 52, 123), { representation: 'date' })
  * //=> '2019-09-18'
  *
  * @example
  * // Represent 18 September 2019 in ISO 8601 format, time only (local time zone is UTC):
- * const result = formatISO(new Date(2019, 8, 18, 19, 0, 52), { representation: 'time' })
- * //=> '19:00:52Z'
+ * const result = formatISO(new Date(2019, 8, 18, 19, 0, 52, 123), { representation: 'time' })
+ * //=> '19:00:52.123Z'
  */
 export default function formatISO<DateType extends Date>(
   date: DateType | number,
@@ -91,6 +91,7 @@ export default function formatISO<DateType extends Date>(
     const hour = addLeadingZeros(originalDate.getHours(), 2)
     const minute = addLeadingZeros(originalDate.getMinutes(), 2)
     const second = addLeadingZeros(originalDate.getSeconds(), 2)
+    const milliseconds = addLeadingZeros(originalDate.getMilliseconds(), 3)
 
     // If there's also date, separate it with time with 'T'
     const separator = result === '' ? '' : 'T'
@@ -99,7 +100,7 @@ export default function formatISO<DateType extends Date>(
     const time = [hour, minute, second].join(timeDelimiter)
 
     // HHmmss or HH:mm:ss.
-    result = `${result}${separator}${time}${tzOffset}`
+    result = `${result}${separator}${time}.${milliseconds}${tzOffset}`
   }
 
   return result

--- a/src/formatISO/index.ts
+++ b/src/formatISO/index.ts
@@ -1,13 +1,7 @@
 import toDate from '../toDate/index'
 import type { FormatOptions, RepresentationOptions } from '../types'
 import addLeadingZeros from '../_lib/addLeadingZeros/index'
-
-/**
- * The {@link formatISO} function options.
- */
-export interface FormatISOOptions
-  extends FormatOptions,
-    RepresentationOptions {}
+import fractionalDigits from '../_lib/fractionalDigits'
 
 export interface FormatISOoptions extends FormatOptions, RepresentationOptions {
   fractionDigits?: 0 | 1 | 2 | 3 | 4 | 5 | 6
@@ -128,16 +122,7 @@ export default function formatISO(
     const minute = addLeadingZeros(originalDate.getMinutes(), 2)
     const second = addLeadingZeros(originalDate.getSeconds(), 2)
 
-    let fractionalSecond = ''
-    if (fractionDigits > 0) {
-      const milliseconds = originalDate.getMilliseconds()
-      const fractionalSeconds = Math.floor(
-        milliseconds * Math.pow(10, fractionDigits - 3)
-      )
-      fractionalSecond =
-        '.' + addLeadingZeros(fractionalSeconds, fractionDigits)
-    }
-
+    const fractionalSecond = fractionalDigits(fractionDigits, originalDate)
     // If there's also date, separate it with time with 'T'
     const separator = result === '' ? '' : 'T'
 

--- a/src/formatISO/index.ts
+++ b/src/formatISO/index.ts
@@ -51,7 +51,7 @@ export interface FormatISOoptions extends FormatOptions, RepresentationOptions {
  * @example
  * // Represent 18 September 2019 in ISO 8601 format, with 4 number of seconds after the decimal point
  * const result = formatISO(new Date(2019, 8, 18, 19, 0, 52, 123), { fractionDigits: 3 })
- * //=> '2019-09-18T19:00:52.1230Z'
+ * //=> '2019-09-18T19:00:52.123Z'
  */
 export default function formatISO(
   date: Date | number,

--- a/src/formatISO/test.ts
+++ b/src/formatISO/test.ts
@@ -9,7 +9,7 @@ describe('formatISO', () => {
   it('formats ISO-8601 extended format', () => {
     const date = new Date(2019, 2 /* Mar */, 3, 19, 0, 52, 123)
     const tzOffsetExtended = generateOffset(date)
-    assert(formatISO(date) === `2019-03-03T19:00:52${tzOffsetExtended}`)
+    assert(formatISO(date) === `2019-03-03T19:00:52.123${tzOffsetExtended}`)
 
     const getTimezoneOffsetStub = sinon.stub(
       Date.prototype,
@@ -18,11 +18,13 @@ describe('formatISO', () => {
 
     getTimezoneOffsetStub.returns(480)
     const tzNegativeOffsetExtended = generateOffset(date)
-    assert(formatISO(date) === `2019-03-03T19:00:52${tzNegativeOffsetExtended}`)
+    assert(
+      formatISO(date) === `2019-03-03T19:00:52.123${tzNegativeOffsetExtended}`
+    )
 
     getTimezoneOffsetStub.returns(0)
     const tzZOffsetExtended = generateOffset(date)
-    assert(formatISO(date) === `2019-03-03T19:00:52${tzZOffsetExtended}`)
+    assert(formatISO(date) === `2019-03-03T19:00:52.123${tzZOffsetExtended}`)
 
     getTimezoneOffsetStub.restore()
   })
@@ -30,14 +32,15 @@ describe('formatISO', () => {
   it('accepts a timestamp', () => {
     const date = new Date(2019, 2 /* Mar */, 3, 19, 0, 52, 123).getTime()
     const tzOffsetExtended = generateOffset(new Date(date))
-    assert(formatISO(date) === `2019-03-03T19:00:52${tzOffsetExtended}`)
+    assert(formatISO(date) === `2019-03-03T19:00:52.123${tzOffsetExtended}`)
   })
 
   it('formats ISO-8601 basic format', () => {
     const date = new Date(2019, 9 /* Oct */, 4, 12, 30, 13, 456)
     const tzOffsetBasic = generateOffset(date)
     assert(
-      formatISO(date, { format: 'basic' }) === `20191004T123013${tzOffsetBasic}`
+      formatISO(date, { format: 'basic' }) ===
+        `20191004T123013.456${tzOffsetBasic}`
     )
   })
 
@@ -60,12 +63,58 @@ describe('formatISO', () => {
 
     assert(
       formatISO(date, { representation: 'time', format: 'extended' }) ===
-        `19:00:52${tzOffset}`
+        `19:00:52.123${tzOffset}`
     )
     assert(
       formatISO(date, { representation: 'time', format: 'basic' }) ===
-        `190052${tzOffset}`
+        `190052.123${tzOffset}`
     )
+  })
+
+  describe('implicitly converts options', () => {
+    it('`format`', () => {
+      // eslint-disable-next-line no-new-wrappers
+      const format = new String('basic')
+      const date = new Date(2019, 9 /* Oct */, 4, 12, 30, 13, 456)
+      const tzOffsetExtended = generateOffset(date)
+
+      const result = formatISO(date, {
+        // @ts-expect-error
+        format: format,
+      })
+      assert(result === `20191004T123013.456${tzOffsetExtended}`)
+    })
+
+    it('`representation`', () => {
+      // eslint-disable-next-line no-new-wrappers
+      const representation = new String('time')
+      const date = new Date(2019, 9 /* Oct */, 4, 12, 30, 13, 456)
+      const tzOffsetExtended = generateOffset(date)
+
+      const result = formatISO(date, {
+        // @ts-expect-error
+        representation: representation,
+      })
+      assert(result === `12:30:13.456${tzOffsetExtended}`)
+    })
+  })
+
+  it("throws `RangeError` if `options.format` is not 'extended' or 'basic'", () => {
+    const block = () =>
+      formatISO(new Date(2019, 2 /* Mar */, 3), {
+        // @ts-expect-error
+        format: 'something else',
+      })
+    assert.throws(block, RangeError)
+  })
+
+  it("throws `RangeError` if `options.representation` is not 'date', 'time' or 'complete'", () => {
+    const block = () =>
+      formatISO(new Date(2019, 2 /* Mar */, 3), {
+        // @ts-expect-error
+        representation: 'something else',
+      })
+    assert.throws(block, RangeError)
   })
 
   it('throws RangeError if the time value is invalid', () => {

--- a/src/formatISO/test.ts
+++ b/src/formatISO/test.ts
@@ -9,7 +9,7 @@ describe('formatISO', () => {
   it('formats ISO-8601 extended format', () => {
     const date = new Date(2019, 2 /* Mar */, 3, 19, 0, 52, 123)
     const tzOffsetExtended = generateOffset(date)
-    assert(formatISO(date) === `2019-03-03T19:00:52.123${tzOffsetExtended}`)
+    assert(formatISO(date) === `2019-03-03T19:00:52${tzOffsetExtended}`)
 
     const getTimezoneOffsetStub = sinon.stub(
       Date.prototype,
@@ -18,13 +18,11 @@ describe('formatISO', () => {
 
     getTimezoneOffsetStub.returns(480)
     const tzNegativeOffsetExtended = generateOffset(date)
-    assert(
-      formatISO(date) === `2019-03-03T19:00:52.123${tzNegativeOffsetExtended}`
-    )
+    assert(formatISO(date) === `2019-03-03T19:00:52${tzNegativeOffsetExtended}`)
 
     getTimezoneOffsetStub.returns(0)
     const tzZOffsetExtended = generateOffset(date)
-    assert(formatISO(date) === `2019-03-03T19:00:52.123${tzZOffsetExtended}`)
+    assert(formatISO(date) === `2019-03-03T19:00:52${tzZOffsetExtended}`)
 
     getTimezoneOffsetStub.restore()
   })
@@ -32,15 +30,14 @@ describe('formatISO', () => {
   it('accepts a timestamp', () => {
     const date = new Date(2019, 2 /* Mar */, 3, 19, 0, 52, 123).getTime()
     const tzOffsetExtended = generateOffset(new Date(date))
-    assert(formatISO(date) === `2019-03-03T19:00:52.123${tzOffsetExtended}`)
+    assert(formatISO(date) === `2019-03-03T19:00:52${tzOffsetExtended}`)
   })
 
   it('formats ISO-8601 basic format', () => {
     const date = new Date(2019, 9 /* Oct */, 4, 12, 30, 13, 456)
     const tzOffsetBasic = generateOffset(date)
     assert(
-      formatISO(date, { format: 'basic' }) ===
-        `20191004T123013.456${tzOffsetBasic}`
+      formatISO(date, { format: 'basic' }) === `20191004T123013${tzOffsetBasic}`
     )
   })
 
@@ -63,11 +60,38 @@ describe('formatISO', () => {
 
     assert(
       formatISO(date, { representation: 'time', format: 'extended' }) ===
-        `19:00:52.123${tzOffset}`
+        `19:00:52${tzOffset}`
     )
     assert(
       formatISO(date, { representation: 'time', format: 'basic' }) ===
-        `190052.123${tzOffset}`
+        `190052${tzOffset}`
+    )
+  })
+
+  it('format with fractional digits', () => {
+    const date = new Date(2019, 2 /* Mar */, 3, 19, 0, 52, 123)
+    const tzOffset = generateOffset(date)
+
+    assert(
+      formatISO(date, {
+        fractionDigits: 4,
+      }) === `2019-03-03T19:00:52.1230${tzOffset}`
+    )
+
+    assert(
+      formatISO(date, {
+        representation: 'time',
+        format: 'extended',
+        fractionDigits: 3,
+      }) === `19:00:52.123${tzOffset}`
+    )
+
+    assert(
+      formatISO(date, {
+        representation: 'time',
+        format: 'basic',
+        fractionDigits: 3,
+      }) === `190052.123${tzOffset}`
     )
   })
 
@@ -82,7 +106,7 @@ describe('formatISO', () => {
         // @ts-expect-error
         format: format,
       })
-      assert(result === `20191004T123013.456${tzOffsetExtended}`)
+      assert(result === `20191004T123013${tzOffsetExtended}`)
     })
 
     it('`representation`', () => {
@@ -95,7 +119,7 @@ describe('formatISO', () => {
         // @ts-expect-error
         representation: representation,
       })
-      assert(result === `12:30:13.456${tzOffsetExtended}`)
+      assert(result === `12:30:13${tzOffsetExtended}`)
     })
   })
 
@@ -115,6 +139,22 @@ describe('formatISO', () => {
         representation: 'something else',
       })
     assert.throws(block, RangeError)
+  })
+
+  it('throws `RangeError` if `options.fractionDigits` is not range 0 to 6', () => {
+    const block = () =>
+      formatISO(new Date(2019, 2 /* Mar */, 3), {
+        // @ts-expect-error
+        fractionDigits: 7,
+      })
+    assert.throws(block, RangeError)
+
+    const block2 = () =>
+      formatISO(new Date(2019, 2 /* Mar */, 3), {
+        // @ts-expect-error
+        fractionDigits: -1,
+      })
+    assert.throws(block2, RangeError)
   })
 
   it('throws RangeError if the time value is invalid', () => {

--- a/src/formatRFC3339/index.ts
+++ b/src/formatRFC3339/index.ts
@@ -1,6 +1,7 @@
 import isValid from '../isValid/index'
 import toDate from '../toDate/index'
 import addLeadingZeros from '../_lib/addLeadingZeros/index'
+import fractionalDigits from '../_lib/fractionalDigits'
 
 /**
  * The {@link formatRFC3339} function options.
@@ -68,14 +69,7 @@ export default function formatRFC3339(
   const minute = addLeadingZeros(originalDate.getMinutes(), 2)
   const second = addLeadingZeros(originalDate.getSeconds(), 2)
 
-  let fractionalSecond = ''
-  if (fractionDigits > 0) {
-    const milliseconds = originalDate.getMilliseconds()
-    const fractionalSeconds = Math.floor(
-      milliseconds * Math.pow(10, fractionDigits - 3)
-    )
-    fractionalSecond = '.' + addLeadingZeros(fractionalSeconds, fractionDigits)
-  }
+  const fractionalSecond = fractionalDigits(fractionDigits, originalDate)
 
   let offset = ''
   const tzOffset = originalDate.getTimezoneOffset()

--- a/src/formatRFC3339/index.ts
+++ b/src/formatRFC3339/index.ts
@@ -37,17 +37,28 @@ export interface FormatRFC3339Options {
  * const result = formatRFC3339(new Date(2019, 8, 18, 19, 0, 52, 234), { fractionDigits: 3 })
  * //=> '2019-09-18T19:00:52.234Z'
  */
-export default function formatRFC3339<DateType extends Date>(
-  dirtyDate: DateType | number,
-  options?: FormatRFC3339Options
+export default function formatRFC3339(
+  dirtyDate: Date | number,
+  dirtyOptions?: FormatRFC3339Options
 ): string {
+  if (arguments.length < 1) {
+    throw new TypeError(
+      `1 arguments required, but only ${arguments.length} present`
+    )
+  }
+
   const originalDate = toDate(dirtyDate)
 
   if (!isValid(originalDate)) {
     throw new RangeError('Invalid time value')
   }
 
-  const fractionDigits = options?.fractionDigits ?? 0
+  const { fractionDigits = 0 } = dirtyOptions || {}
+
+  // Test if fractionDigits is between 0 and 3 _and_ is not NaN
+  if (!(fractionDigits >= 0 && fractionDigits <= 3)) {
+    throw new RangeError('fractionDigits must be between 0 and 3 inclusively')
+  }
 
   const day = addLeadingZeros(originalDate.getDate(), 2)
   const month = addLeadingZeros(originalDate.getMonth() + 1, 2)


### PR DESCRIPTION
Issue #2968 mentioning `formatISO` doesn't support millisecond yet. The JS `Date.toISOString()` return millisecond with `.` (dot)

```
new Date().toISOString() // 2022-02-27T14:26:49.139Z
```

But after reading from Wikipedia https://en.wikipedia.org/wiki/ISO_8601, I can't find any implementation on millisecond. Should we do this by default? Or we can use options?

```
formatISO(date, { withMillisecond: true })
```