### PR TITLE
Refactor `differenceInYears` and use `differenceInMonths` to calculate

### DIFF
--- a/scripts/test/dst.sh
+++ b/scripts/test/dst.sh
@@ -9,6 +9,7 @@ set -ex
 export PATH="$(yarn bin):$PATH"
 export NODE_ENV=test
 
+env TZ=US/Pacific ts-node ./test/dst/differenceInYears/basic.js
 env TZ=America/Sao_Paulo babel-node --extensions .ts,.js ./test/dst/parseISO/basic.js
 env TZ=Australia/Sydney babel-node --extensions .ts,.js ./test/dst/parseISO/sydney.js
 env TZ=Pacific/Apia babel-node --extensions .ts,.js ./test/dst/parseISO/samoa.js

--- a/src/differenceInYears/index.ts
+++ b/src/differenceInYears/index.ts
@@ -1,5 +1,5 @@
 import toDate from '../toDate/index'
-import differenceInCalendarYears from '../differenceInCalendarYears/index'
+import differenceInMonths from '../differenceInMonths/index'
 import compareAsc from '../compareAsc/index'
 import requiredArgs from '../_lib/requiredArgs/index'
 
@@ -31,17 +31,18 @@ export default function differenceInYears(
   const dateRight = toDate(dirtyDateRight)
 
   const sign = compareAsc(dateLeft, dateRight)
-  const difference = Math.abs(differenceInCalendarYears(dateLeft, dateRight))
+  if (sign === 0) {
+    return 0
+  }
 
-  // Set both dates to a valid leap year for accurate comparison when dealing
-  // with leap days
-  dateLeft.setFullYear(1584)
-  dateRight.setFullYear(1584)
+  const diffMonths =
+    sign === -1
+      ? differenceInMonths(dateRight, dateLeft)
+      : differenceInMonths(dateLeft, dateRight)
 
-  // Math.abs(diff in full years - diff in calendar years) === 1 if last calendar year is not full
-  // If so, result must be decreased by 1 in absolute value
-  const isLastYearNotFull = compareAsc(dateLeft, dateRight) === -sign
-  const result = sign * (difference - Number(isLastYearNotFull))
-  // Prevent negative zero
-  return result === 0 ? 0 : result
+  if (diffMonths < 12) {
+    return 0
+  }
+
+  return sign * Math.floor(diffMonths / 12)
 }

--- a/test/dst/differenceInYears/basic.js
+++ b/test/dst/differenceInYears/basic.js
@@ -1,0 +1,19 @@
+// This is basic DST test for differenceInYears
+
+import differenceInYears from '../../../src/differenceInYears'
+import parseISO from '../../../src/parseISO'
+import assert from 'assert'
+
+if (process.env.TZ !== 'US/Pacific')
+  throw new Error('The test must be run with TZ=US/Pacific')
+
+if (parseInt(process.version.match(/^v(\d+)\./)[1]) < 10)
+  throw new Error('The test must be run on Node.js version >= 10')
+
+assert.strictEqual(
+  differenceInYears(
+    parseISO('2021-11-07T08:25:50.904Z'),
+    parseISO('2021-11-07T09:11:45.563Z')
+  ),
+  0
+)


### PR DESCRIPTION
This PR fixes issues with DST dates provided to `differenceInYears`.

The longer explanation with screenshots and demos is available in the issue: https://github.com/date-fns/date-fns/issues/2993