### PR TITLE
feat: add decimals options to monthsToYears()

### DIFF
--- a/src/_lib/useDecimals/index.ts
+++ b/src/_lib/useDecimals/index.ts
@@ -1,0 +1,30 @@
+export interface DecimalsOptions {
+  decimals?: boolean
+  digits?: number
+}
+
+export function useDecimals(
+  num: number,
+  options?: DecimalsOptions
+): {
+  isDecimals: boolean
+  num: number
+} {
+  //get whether you use decimals
+  const isDecimals = !!(options && options?.decimals)
+  //get whether you set digits number, default be 2
+  let digits = options && options?.digits ? options.digits : 2
+  const str = num.toString()
+  if (str.includes('.')) {
+    digits = Math.min(str.split('.')[1].length, digits)
+  } else {
+    digits = 0
+  }
+  if (isDecimals) {
+    num = parseFloat(num.toFixed(digits))
+  }
+  return {
+    isDecimals: isDecimals,
+    num: num,
+  }
+}

--- a/src/_lib/useDecimals/test.ts
+++ b/src/_lib/useDecimals/test.ts
@@ -1,0 +1,26 @@
+/* eslint-env mocha */
+
+import assert from 'assert'
+import { useDecimals } from '.'
+
+describe('useDecimals', () => {
+  it('does not change num when does not set options', () => {
+    const result = useDecimals(14)
+    assert(!result.isDecimals)
+    assert(result.num === 14)
+  })
+
+  it('set isDecimals and does not set digit, should default less than 2', () => {
+    let result = useDecimals(14.1, { decimals: true })
+    assert(result.isDecimals)
+    assert(result.num === 14.1)
+
+    result = useDecimals(14.13245, { decimals: true })
+    assert(result.num === 14.13)
+  })
+
+  it('set isDecimals and digits', () => {
+    const result = useDecimals(14.13245, { decimals: true, digits: 3 })
+    assert(result.num === 14.132)
+  })
+})

--- a/src/monthsToYears/index.ts
+++ b/src/monthsToYears/index.ts
@@ -1,5 +1,6 @@
 import requiredArgs from '../_lib/requiredArgs/index'
 import { monthsInYear } from '../constants/index'
+import { DecimalsOptions, useDecimals } from '../_lib/useDecimals'
 
 /**
  * @name monthsToYears
@@ -10,6 +11,7 @@ import { monthsInYear } from '../constants/index'
  * Convert a number of months to a full number of years.
  *
  * @param {number} months - number of months to be converted
+ * @param {Object} [options] - an object with options.
  *
  * @returns {number} the number of months converted in years
  * @throws {TypeError} 1 argument required
@@ -19,12 +21,28 @@ import { monthsInYear } from '../constants/index'
  * const result = monthsToYears(36)
  * //=> 3
  *
- * // It uses floor rounding:
+ * // It uses floor rounding by default:
  * const result = monthsToYears(40)
  * //=> 3
+ *
+ * // It can be set to show decimals(displays 2 digits after the decimal point by default):
+ * const result = monthsToYears(40, {decimals: true})
+ * //=> 3.33
+ * result = monthsToYears(40, {decimals: true, digits: 4})
+ * //=> 3.3333
  */
-export default function monthsToYears(months: number): number {
+export default function monthsToYears(
+  months: number,
+  options: DecimalsOptions = {}
+): number {
   requiredArgs(1, arguments)
   const years = months / monthsInYear
-  return Math.floor(years)
+
+  const result = useDecimals(years, options)
+
+  if (result.isDecimals) {
+    return result.num
+  } else {
+    return Math.floor(years)
+  }
 }

--- a/src/monthsToYears/test.ts
+++ b/src/monthsToYears/test.ts
@@ -18,4 +18,13 @@ describe('monthsToYears', () => {
     assert(monthsToYears(12.5) === 1)
     assert(monthsToYears(0) === 0)
   })
+
+  it('use Decimals', () => {
+    assert(monthsToYears(36, { decimals: true }) === 3)
+    assert(monthsToYears(40, { decimals: true }) === 3.33)
+  })
+
+  it('use Decimals and digits', () => {
+    assert(monthsToYears(40, { decimals: true, digits: 4 }) === 3.3333)
+  })
 })

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -883,7 +883,13 @@ declare module 'date-fns' {
   function monthsToQuarters(months: number): number
   namespace monthsToQuarters {}
 
-  function monthsToYears(months: number): number
+  function monthsToYears(
+    months: number,
+    options?: {
+      decimals?: boolean
+      digits?: number
+    }
+  ): number
   namespace monthsToYears {}
 
   function nextDay(date: Date | number, day: Day): Date
@@ -5546,7 +5552,11 @@ declare module 'date-fns/fp' {
   const monthsToQuarters: CurriedFn1<number, number>
   namespace monthsToQuarters {}
 
-  const monthsToYears: CurriedFn1<number, number>
+  const monthsToYears: CurriedFn2<
+    number,
+    { decimals?: boolean; digits?: number },
+    number
+  >
   namespace monthsToYears {}
 
   const nextDay: CurriedFn2<Day, Date | number, Date>
@@ -10455,7 +10465,13 @@ declare module 'date-fns/esm' {
   function monthsToQuarters(months: number): number
   namespace monthsToQuarters {}
 
-  function monthsToYears(months: number): number
+  function monthsToYears(
+    months: number,
+    options?: {
+      decimals?: boolean
+      digits?: number
+    }
+  ): number
   namespace monthsToYears {}
 
   function nextDay(date: Date | number, day: Day): Date
@@ -15118,7 +15134,11 @@ declare module 'date-fns/esm/fp' {
   const monthsToQuarters: CurriedFn1<number, number>
   namespace monthsToQuarters {}
 
-  const monthsToYears: CurriedFn1<number, number>
+  const monthsToYears: CurriedFn2<
+    number,
+    { decimals?: boolean; digits?: number },
+    number
+  >
   namespace monthsToYears {}
 
   const nextDay: CurriedFn2<Day, Date | number, Date>
@@ -23112,7 +23132,13 @@ interface dateFns {
 
   monthsToQuarters(months: number): number
 
-  monthsToYears(months: number): number
+  monthsToYears(
+    months: number,
+    options?: {
+      decimals?: boolean
+      digits?: number
+    }
+  ): number
 
   nextDay(date: Date | number, day: Day): Date
 


### PR DESCRIPTION
linked #2926 
add options let users can get number include decimals point，also can set digits after the decimal point.

```
 * const result = monthsToYears(40, {decimals: true})
 * //=> 3.33
 * result = monthsToYears(40, {decimals: true, digits: 4})
 * //=> 3.3333
```

pr is add a new options, so this change will not affect any existing code