### PR TITLE
Fix zh-tw translations

### DIFF
--- a/src/locale/zh-TW/_lib/localize/index.ts
+++ b/src/locale/zh-TW/_lib/localize/index.ts
@@ -3,15 +3,15 @@ import type { Localize, LocalizeFn } from '../../../types'
 import buildLocalizeFn from '../../../_lib/buildLocalizeFn/index'
 
 const eraValues = {
-  narrow: ['前', '公元'] as const,
-  abbreviated: ['前', '公元'] as const,
-  wide: ['公元前', '公元'] as const,
+  narrow: ['前', '西元'] as const,
+  abbreviated: ['前', '西元'] as const,
+  wide: ['西元前', '西元'] as const,
 }
 
 const quarterValues = {
   narrow: ['1', '2', '3', '4'] as const,
-  abbreviated: ['第一刻', '第二刻', '第三刻', '第四刻'] as const,
-  wide: ['第一刻鐘', '第二刻鐘', '第三刻鐘', '第四刻鐘'] as const,
+  abbreviated: ['第一季', '第二季', '第三季', '第四季'] as const,
+  wide: ['第一季度', '第二季度', '第三季度', '第四季度'] as const,
 }
 
 const monthValues = {

--- a/src/locale/zh-TW/_lib/match/index.ts
+++ b/src/locale/zh-TW/_lib/match/index.ts
@@ -9,16 +9,16 @@ const parseOrdinalNumberPattern = /\d+/i
 const matchEraPatterns = {
   narrow: /^(前)/i,
   abbreviated: /^(前)/i,
-  wide: /^(公元前|公元)/i,
+  wide: /^(西元前|西元)/i,
 }
 const parseEraPatterns = {
-  any: [/^(前)/i, /^(公元)/i] as const,
+  any: [/^(前)/i, /^(西元)/i] as const,
 }
 
 const matchQuarterPatterns = {
   narrow: /^[1234]/i,
-  abbreviated: /^第[一二三四]刻/i,
-  wide: /^第[一二三四]刻鐘/i,
+  abbreviated: /^第[一二三四]季/i,
+  wide: /^第[一二三四]季度/i,
 }
 const parseQuarterPatterns = {
   any: [/(1|一)/i, /(2|二)/i, /(3|三)/i, /(4|四)/i] as const,


### PR DESCRIPTION
The zh-tw translation about quarter is totally wrong. 
And the vocabulary about anno is old style way, so I adjust it to modern style