### PR TITLE
Added optional flag removeZeros to remove values with 0 from formatISODuration

### DIFF
--- a/src/formatISODuration/index.ts
+++ b/src/formatISODuration/index.ts
@@ -10,6 +10,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  * Format a duration object according to the ISO 8601 duration standard (https://www.digi.com/resources/documentation/digidocs/90001437-13/reference/r_iso_8601_duration_format.htm)
  *
  * @param {Duration} duration - the duration to format
+ * @param {boolean} removeZeros - if true, values with 0 are removed from the formatted string
  *
  * @returns {String} The ISO 8601 duration string
  * @throws {TypeError} Requires 1 argument
@@ -26,8 +27,21 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *   seconds: 0
  * })
  * //=> 'P39Y2M20DT0H0M0S'
+ *
+ * @example
+ * // Format the given duration as ISO 8601 string with trailing zeros removed
+ * const result = formatISODuration({
+ *   years: 39,
+ *   months: 0,
+ *   days: 0,
+ *   hours: 7
+ * });
+ * //=> 'P39Y7H'
  */
-export default function formatISODuration(duration: Duration): string {
+export default function formatISODuration(
+  duration: Duration,
+  removeZeros: boolean = false
+): string {
   requiredArgs(1, arguments)
 
   if (typeof duration !== 'object')
@@ -42,5 +56,36 @@ export default function formatISODuration(duration: Duration): string {
     seconds = 0,
   } = duration
 
-  return `P${years}Y${months}M${days}DT${hours}H${minutes}M${seconds}S`
+  if (removeZeros === true) {
+    const chunks = [
+      { suffix: 'Y', value: years },
+      { suffix: 'M', value: months },
+      { suffix: 'DT', value: days },
+      { suffix: 'H', value: hours },
+      { suffix: 'M', value: minutes },
+      { suffix: 'S', value: seconds },
+    ]
+
+    if (
+      years === 0 &&
+      months === 0 &&
+      days === 0 &&
+      hours === 0 &&
+      seconds === 0 &&
+      minutes !== 0
+    ) {
+      // Remove ambiguity between months/minutes when only minutes are present
+      return `PT${minutes}M`
+    } else {
+      return (
+        'P' +
+        chunks
+          .filter(({ value }) => value > 0)
+          .map(({ suffix, value }) => `${value}${suffix}`)
+          .join('')
+      )
+    }
+  } else {
+    return `P${years}Y${months}M${days}DT${hours}H${minutes}M${seconds}S`
+  }
 }

--- a/src/formatISODuration/index.ts
+++ b/src/formatISODuration/index.ts
@@ -57,15 +57,6 @@ export default function formatISODuration(
   } = duration
 
   if (removeZeros === true) {
-    const chunks = [
-      { suffix: 'Y', value: years },
-      { suffix: 'M', value: months },
-      { suffix: 'DT', value: days },
-      { suffix: 'H', value: hours },
-      { suffix: 'M', value: minutes },
-      { suffix: 'S', value: seconds },
-    ]
-
     if (
       years === 0 &&
       months === 0 &&
@@ -77,6 +68,15 @@ export default function formatISODuration(
       // Remove ambiguity between months/minutes when only minutes are present
       return `PT${minutes}M`
     } else {
+      const chunks: { suffix: string; value: number }[] = [
+        { suffix: 'Y', value: years },
+        { suffix: 'M', value: months },
+        { suffix: 'DT', value: days },
+        { suffix: 'H', value: hours },
+        { suffix: 'M', value: minutes },
+        { suffix: 'S', value: seconds },
+      ]
+
       return (
         'P' +
         chunks

--- a/src/formatISODuration/index.ts
+++ b/src/formatISODuration/index.ts
@@ -57,34 +57,30 @@ export default function formatISODuration(
   } = duration
 
   if (removeZeros === true) {
-    if (
-      years === 0 &&
-      months === 0 &&
-      days === 0 &&
-      hours === 0 &&
-      seconds === 0 &&
-      minutes !== 0
-    ) {
-      // Remove ambiguity between months/minutes when only minutes are present
-      return `PT${minutes}M`
-    } else {
-      const chunks: { suffix: string; value: number }[] = [
-        { suffix: 'Y', value: years },
-        { suffix: 'M', value: months },
-        { suffix: 'DT', value: days },
-        { suffix: 'H', value: hours },
-        { suffix: 'M', value: minutes },
-        { suffix: 'S', value: seconds },
-      ]
+    type Chunk = { suffix: string; value: number }
 
-      return (
-        'P' +
-        chunks
-          .filter(({ value }) => value > 0)
-          .map(({ suffix, value }) => `${value}${suffix}`)
-          .join('')
-      )
-    }
+    const formatPart = (chunks: Chunk[]): string =>
+      chunks
+        .filter(({ value }) => value > 0)
+        .map(({ suffix, value }) => `${value}${suffix}`)
+        .join('')
+
+    const dateChunks: Chunk[] = [
+      { suffix: 'Y', value: years },
+      { suffix: 'M', value: months },
+      { suffix: 'D', value: days },
+    ]
+
+    const timeChunks: Chunk[] = [
+      { suffix: 'H', value: hours },
+      { suffix: 'M', value: minutes },
+      { suffix: 'S', value: seconds },
+    ]
+
+    const datePart = formatPart(dateChunks)
+    const timePart = formatPart(timeChunks)
+
+    return `P${datePart}${timePart.length > 0 ? `T${timePart}` : ''}`
   } else {
     return `P${years}Y${months}M${days}DT${hours}H${minutes}M${seconds}S`
   }

--- a/src/formatISODuration/index.ts
+++ b/src/formatISODuration/index.ts
@@ -36,7 +36,7 @@ import requiredArgs from '../_lib/requiredArgs/index'
  *   days: 0,
  *   hours: 7
  * });
- * //=> 'P39Y7H'
+ * //=> 'P39YT7H'
  */
 export default function formatISODuration(
   duration: Duration,

--- a/src/formatISODuration/test.ts
+++ b/src/formatISODuration/test.ts
@@ -68,10 +68,40 @@ describe('formatISODuration', () => {
 
     assert(result === 'P1Y0M0DT0H0M0S')
   })
-
   it('returns P0Y0M0DT0H0M0S when given an empty object', () => {
     const result = formatISODuration({})
 
     assert(result === 'P0Y0M0DT0H0M0S')
+  })
+})
+
+describe('formatISODuration with the removeZeros flag active', () => {
+  it('Returns correct duration for arbitrary dates', () => {
+    const start = new Date(1929, 0, 15, 12, 0, 0)
+    const end = new Date(1968, 3, 4, 19, 5, 0)
+    const result = formatISODuration(intervalToDuration({ start, end }), true)
+
+    assert(result === 'P39Y2M20DT7H5M')
+  })
+  it('Removes values with zero', () => {
+    const start = new Date(2020, 2, 5, 12, 0, 0)
+    const end = new Date(2021, 2, 1, 12, 0, 0)
+    const result = formatISODuration(intervalToDuration({ start, end }), true)
+
+    assert(result === 'P11M24DT')
+  })
+  it('Handles ambiguity when only minutes are present', () => {
+    const start = new Date(2020, 2, 5, 12, 0, 0)
+    const end = new Date(2020, 2, 5, 12, 15, 0)
+    const result = formatISODuration(intervalToDuration({ start, end }), true)
+
+    assert(result === 'PT15M')
+  })
+  it('Handles ambiguity when only months are present', () => {
+    const start = new Date(2020, 2, 5, 12, 0, 0)
+    const end = new Date(2020, 4, 5, 12, 0, 0)
+    const result = formatISODuration(intervalToDuration({ start, end }), true)
+
+    assert(result === 'P2M')
   })
 })

--- a/src/formatISODuration/test.ts
+++ b/src/formatISODuration/test.ts
@@ -84,11 +84,11 @@ describe('formatISODuration with the removeZeros flag active', () => {
     assert(result === 'P39Y2M20DT7H5M')
   })
   it('Removes values with zero', () => {
-    const start = new Date(2020, 2, 5, 12, 0, 0)
-    const end = new Date(2021, 2, 1, 12, 0, 0)
+    const start = new Date(2020, 2, 1, 12, 0, 0)
+    const end = new Date(2021, 2, 5, 12, 0, 11)
     const result = formatISODuration(intervalToDuration({ start, end }), true)
 
-    assert(result === 'P11M24DT')
+    assert(result === 'P1Y4DT11S')
   })
   it('Handles ambiguity when only minutes are present', () => {
     const start = new Date(2020, 2, 5, 12, 0, 0)
@@ -103,5 +103,12 @@ describe('formatISODuration with the removeZeros flag active', () => {
     const result = formatISODuration(intervalToDuration({ start, end }), true)
 
     assert(result === 'P2M')
+  })
+  it('Get rid of the T if time is not present', () => {
+    const start = new Date(2020, 2, 5, 12, 0, 0)
+    const end = new Date(2021, 2, 11, 12, 0, 0)
+    const result = formatISODuration(intervalToDuration({ start, end }), true)
+
+    assert(result === 'P1Y6D')
   })
 })


### PR DESCRIPTION
This PR fixes #3060.

Added an optional flag that gets rid of all the values with 0 to have a shorter (but still valid) ISO duration string.

The case where only `minutes` are present is also handled, rendering them with `TxM` instead of the usual `xM` to avoid ambiguity with `months`.