### PR TITLE
Improve getMonth docs

### DIFF
--- a/src/getMonth/index.ts
+++ b/src/getMonth/index.ts
@@ -6,14 +6,15 @@ import toDate from '../toDate/index'
  * @summary Get the month of the given date.
  *
  * @description
- * Get the month of the given date.
+ * Get the month of the given date. Months are indexed from 0, like Javascript dates,
+ * so January = 0, February = 1 etc.
  *
  * @param date - the given date
- * @returns the month
+ * @returns the month number, where January = 0 as with standard Javascript Dates
  *
  * @example
  * // Which month is 29 February 2012?
- * const result = getMonth(new Date(2012, 1, 29))
+ * const result = getMonth(new Date("2012-02-29"))
  * //=> 1
  */
 export default function getMonth<DateType extends Date>(

--- a/src/getMonth/index.ts
+++ b/src/getMonth/index.ts
@@ -14,7 +14,7 @@ import toDate from '../toDate/index'
  *
  * @example
  * // Which month is 29 February 2012?
- * const result = getMonth(new Date("2012-02-29"))
+ * const result = getMonth(new Date('2012-02-29'))
  * //=> 1
  */
 export default function getMonth<DateType extends Date>(


### PR DESCRIPTION
I assumed that `getMonth` would return the natural month number, not the Javascript month number. Checking the docs it wasn't super obvious either, as it's not mentioned and `new Date(2012, 1, 29)` in the example reads like the 29th of January. I think this has tripped others up too (#2975 & #768).

This PR makes it clear in the description of the docs that January = 0 and it also updates the example to use `new Date('2012-02-29')` so the date reads more naturally.