### PR TITLE
Fix parseISO for sub-ms decimal seconds (#3194)

### DIFF
--- a/src/parseISO/index.ts
+++ b/src/parseISO/index.ts
@@ -58,7 +58,8 @@ export default function parseISO(
   let offset
 
   if (dateStrings.time) {
-    time = parseTime(dateStrings.time)
+    // Round down time to nearest ms to handle sub-ms fractions properly
+    time = Math.floor(parseTime(dateStrings.time))
     if (isNaN(time)) {
       return new Date(NaN)
     }

--- a/src/parseISO/test.ts
+++ b/src/parseISO/test.ts
@@ -180,6 +180,14 @@ describe('parseISO', () => {
         )
       })
 
+      it('rounds float seconds down to nearest millisecond', () => {
+        const result = parseISO('2014-02-11T11:30:30.9999999')
+        assert.deepStrictEqual(
+          result,
+          new Date(2014, 1 /* Feb */, 11, 11, 30, 30, 999)
+        )
+      })
+
       it('parses , as decimal mark', () => {
         const result = parseISO('2014-02-11T11,5')
         assert.deepStrictEqual(result, new Date(2014, 1 /* Feb */, 11, 11, 30))


### PR DESCRIPTION
This fixes #3194 by simply rounding down the fractional seconds to the nearest millisecond. Consider the two cases below:

| ISO string                    | `timestamp` = date part | `time` = milliseconds part | `timestamp`+`time` |
| ----------------------------- | ----------------------: | -------------------------- | ------------------ |
| `2014-02-11T11:30:30.999999`  |           1392076800000 | 41430999.999               | 1392118230999.999  |
| `2014-02-11T11:30:30.9999999` |           1392076800000 | 41430999.9999              | 1392118231000      |

In the second case the sum of `timestamp` and `time` is incorrectly rounded up because of the limited precision of JavaScript numbers. Rounding down the `time` part explicitly ensures consistent handling of such cases. 