### PR TITLE
Update behavior of add when duration params are NaN #3209

### DIFF
--- a/src/add/index.ts
+++ b/src/add/index.ts
@@ -56,6 +56,9 @@ export default function add<DateType extends Date>(
     seconds = 0,
   } = duration
 
+  if (isNaN(years) || isNaN(months) || isNaN(weeks) || isNaN(days))
+    return constructFrom(dirtyDate, NaN)
+
   // Add years and months
   const date = toDate(dirtyDate)
   const dateWithMonths =

--- a/src/add/test.ts
+++ b/src/add/test.ts
@@ -97,4 +97,29 @@ describe('add', () => {
     const result = add(new Date(NaN), { hours: 5 })
     assert(result instanceof Date && isNaN(result.getTime()))
   })
+
+  it('returns `Invalid Date` if any of the given duration parameter is NaN', () => {
+    const date = new Date(2020, 5 /* Jun */, 11)
+
+    const yearsNaN = add(date, { years: NaN })
+    assert(yearsNaN instanceof Date && isNaN(yearsNaN.getTime()))
+
+    const monthsNaN = add(date, { months: NaN })
+    assert(monthsNaN instanceof Date && isNaN(monthsNaN.getTime()))
+
+    const weeksNaN = add(date, { weeks: NaN })
+    assert(weeksNaN instanceof Date && isNaN(weeksNaN.getTime()))
+
+    const daysNaN = add(date, { days: NaN })
+    assert(daysNaN instanceof Date && isNaN(daysNaN.getTime()))
+
+    const hoursNaN = add(date, { hours: NaN })
+    assert(hoursNaN instanceof Date && isNaN(hoursNaN.getTime()))
+
+    const minutesNaN = add(date, { minutes: NaN })
+    assert(minutesNaN instanceof Date && isNaN(minutesNaN.getTime()))
+
+    const secondsNaN = add(date, { seconds: NaN })
+    assert(secondsNaN instanceof Date && isNaN(secondsNaN.getTime()))
+  })
 })


### PR DESCRIPTION
Will fix #3209 

Aligned behavior of `add` to be consistent with the implementation of addYears, addMonths, addWeeks, and addDays, when any of the duration parameters are set to NaN

```
add(new Date('2020-06-11T00:00:00.000Z'), {
      years: NaN
    })
   
=> Date { NaN } 

...

add(new Date('2020-06-11T00:00:00.000Z'), {
      seconds: NaN
    })
    
=> Date { NaN } 
```

