### PR TITLE
feat(formatter): week of month - Hacktoberfest 2022

### DIFF
--- a/src/_lib/format/formatters/index.ts
+++ b/src/_lib/format/formatters/index.ts
@@ -3,6 +3,7 @@ import getISOWeek from '../../../getISOWeek/index'
 import getISOWeekYear from '../../../getISOWeekYear/index'
 import getWeek from '../../../getWeek/index'
 import getWeekYear from '../../../getWeekYear/index'
+import getWeekOfMonth from '../../../getWeekOfMonth/index'
 import type { LocaleDayPeriod, Localize } from '../../../locale/types'
 import type {
   Day,
@@ -63,7 +64,7 @@ type Formatter = (
  * |  t! | Seconds timestamp              |  T! | Milliseconds timestamp         |
  * |  u  | Extended year                  |  U* | Cyclic year                    |
  * |  v* | Timezone (generic non-locat.)  |  V* | Timezone (location)            |
- * |  w  | Local week of year             |  W* | Week of month                  |
+ * |  w  | Local week of year             |  W  | Week of month                  |
  * |  x  | Timezone (ISO-8601 w/o Z)      |  X  | Timezone (ISO-8601)            |
  * |  y  | Year (abs)                     |  Y  | Local week-numbering year      |
  * |  z  | Timezone (specific non-locat.) |  Z* | Timezone (aliases)             |
@@ -283,6 +284,17 @@ const formatters: { [token: string]: Formatter } = {
       default:
         return localize.month(month, { width: 'wide', context: 'standalone' })
     }
+  },
+
+  // Week of month
+  W: function (date, token, localize, options) {
+    var isoWeek = getWeekOfMonth(date, options)
+
+    if (token === 'Wo') {
+      return localize.ordinalNumber(isoWeek, { unit: 'week' })
+    }
+
+    return addLeadingZeros(isoWeek, token.length)
   },
 
   // Local week of year

--- a/src/format/index.ts
+++ b/src/format/index.ts
@@ -19,7 +19,7 @@ import {
 } from '../_lib/protectedTokens/index'
 
 // This RegExp consists of three parts separated by `|`:
-// - [yYQqMLwIdDecihHKkms]o matches any available ordinal number token
+// - [yYQqMLwWIdDecihHKkms]o matches any available ordinal number token
 //   (one of the certain letters followed by `o`)
 // - (\w)\1* matches any sequences of the same letter
 // - '' matches two quote characters in a row
@@ -29,7 +29,7 @@ import {
 //   If there is no matching single quote
 //   then the sequence will continue until the end of the string.
 // - . matches any single character unmatched by previous parts of the RegExps
-const formattingTokensRegExp = /[yYQqMLwIdDecihHKkms]o|(\w)\1*|''|'(''|[^'])+('|$)|./g
+const formattingTokensRegExp = /[yYQqMLwWIdDecihHKkms]o|(\w)\1*|''|'(''|[^'])+('|$)|./g
 
 // This RegExp catches symbols escaped by quotes, and also
 // sequences of symbols P, p, and the combinations like `PPPPPPPppppp`
@@ -119,6 +119,9 @@ export interface FormatOptions
  * |                                 | LLL     | Jan, Feb, ..., Dec                |       |
  * |                                 | LLLL    | January, February, ..., December  | 2     |
  * |                                 | LLLLL   | J, F, ..., D                      |       |
+ * | Week of month                   | W       | 1, 2, ..., 5                      |       |
+ * |                                 | Wo      | 1st, 2nd, ..., 5th                | 7     |
+ * |                                 | WW      | 01, 02, ..., 5                    |       |
  * | Local week of year              | w       | 1, 2, ..., 53                     |       |
  * |                                 | wo      | 1st, 2nd, ..., 53th               | 7     |
  * |                                 | ww      | 01, 02, ..., 53                   |       |

--- a/src/format/test.ts
+++ b/src/format/test.ts
@@ -300,6 +300,22 @@ describe('format', () => {
   })
 
   describe('week', () => {
+    describe('local week of the month', () => {
+      it('works as expected', () => {
+        const date = new Date(1986, 3 /* Apr */, 6) // 2nd week of the month
+        const result = format(date, 'W Wo WW')
+        assert(result === '2 2nd 02')
+      })
+
+      it('allows to specify `weekStartsOn` in options', () => {
+        const date = new Date(1986, 3 /* Apr */, 6)
+        const result = format(date, 'W Wo WW', {
+          weekStartsOn: 1,
+        })
+        assert(result === '1 1st 01')
+      })
+    })
+
     describe('local week of year', () => {
       it('works as expected', () => {
         const date = new Date(1986, 3 /* Apr */, 6)


### PR DESCRIPTION
Added a new formatter to get week of the month.

closes #1134

### Usage
```
var format = require('date-fns/format')
const date = new Date(1986, 3 /* Apr */, 6) // 2nd week of the month
console.log(format(date, 'W Wo WW')) // 2 2nd 02
console.log(format(date, "Wo 'week of' MMMM YYY")) // 2nd week of April 1986
```

Hacktoberfest 2022