### PR TITLE
test: add some edge case tests for parsing

### DIFF
--- a/src/parse/test.ts
+++ b/src/parse/test.ts
@@ -1289,6 +1289,16 @@ describe('parse', () => {
       assert.deepStrictEqual(result, new Date(1986, 3 /* Apr */, 4, 17))
     })
 
+    it('supports morning keyword', () => {
+      const result = parse('in the morning', 'B', referenceDate)
+      assert.deepStrictEqual(result, new Date(1986, 3 /* Apr */, 4, 4))
+    })
+
+    it('supports evening keyword', () => {
+      const result = parse('in the evening', 'B', referenceDate)
+      assert.deepStrictEqual(result, new Date(1986, 3 /* Apr */, 4, 17))
+    })
+
     describe('validation', () => {
       ;[
         ['a', 'AM'],

--- a/src/toDate/test.ts
+++ b/src/toDate/test.ts
@@ -33,5 +33,11 @@ describe('toDate', () => {
       assert(result instanceof Date)
       assert(isNaN(result.getTime()))
     })
+
+    it('returns Invalid Date if argument is not a number', () => {
+      const result = toDate(('abc' as unknown) as number)
+      assert(result instanceof Date)
+      assert(isNaN(result.getTime()))
+    })
   })
 })


### PR DESCRIPTION
i was just getting my head around the repo so here's a test or two from while i was in there.

although the typescript types enforce we pass a number or date to `toDate`, non-ts consumers could pass invalid types.

the source accounts for this but the tests don't, so i went ahead and added one.

the other two are trying to test that the available day periods are supported, not sure if thats the best way to test those (or the right place).