### PR TITLE
`intlFormatDistance` improvements

### DIFF
--- a/src/intlFormatDistance/index.ts
+++ b/src/intlFormatDistance/index.ts
@@ -15,7 +15,6 @@ import differenceInCalendarYears from '../differenceInCalendarYears/index'
 import differenceInHours from '../differenceInHours/index'
 import differenceInMinutes from '../differenceInMinutes/index'
 import differenceInSeconds from '../differenceInSeconds/index'
-import toDate from '../toDate/index'
 import type { IntlOptionsUnit } from '../types'
 
 /**
@@ -129,72 +128,59 @@ export default function intlFormatDistance<DateType extends Date>(
   baseDate: DateType | number,
   options?: IntlFormatDistanceOptions
 ): string {
-  let value: number = 0
-  let unit: Intl.RelativeTimeFormatUnit
-  const dateLeft = toDate(date)
-  const dateRight = toDate(baseDate)
+  let unit = options?.unit
 
-  if (!options?.unit) {
-    // Get the unit based on diffInSeconds calculations if no unit is specified
-    const diffInSeconds = differenceInSeconds(dateLeft, dateRight) // The smallest unit
+  // detect the most appropriate unit to use if not specified
+  if (!unit) {
+    const absDiffInSeconds = Math.abs(differenceInSeconds(date, baseDate))
 
-    if (Math.abs(diffInSeconds) < secondsInMinute) {
-      value = differenceInSeconds(dateLeft, dateRight)
+    if (absDiffInSeconds < secondsInMinute) {
       unit = 'second'
-    } else if (Math.abs(diffInSeconds) < secondsInHour) {
-      value = differenceInMinutes(dateLeft, dateRight)
+    } else if (absDiffInSeconds < secondsInHour) {
       unit = 'minute'
     } else if (
-      Math.abs(diffInSeconds) < secondsInDay &&
-      Math.abs(differenceInCalendarDays(dateLeft, dateRight)) < 1
+      absDiffInSeconds < secondsInDay &&
+      Math.abs(differenceInCalendarDays(date, baseDate)) < 1
     ) {
-      value = differenceInHours(dateLeft, dateRight)
       unit = 'hour'
     } else if (
-      Math.abs(diffInSeconds) < secondsInWeek &&
-      (value = differenceInCalendarDays(dateLeft, dateRight)) &&
-      Math.abs(value) < 7
+      absDiffInSeconds < secondsInWeek &&
+      Math.abs(differenceInCalendarDays(date, baseDate)) < 7
     ) {
       unit = 'day'
-    } else if (Math.abs(diffInSeconds) < secondsInMonth) {
-      value = differenceInCalendarWeeks(dateLeft, dateRight)
+    } else if (absDiffInSeconds < secondsInMonth) {
       unit = 'week'
-    } else if (Math.abs(diffInSeconds) < secondsInQuarter) {
-      value = differenceInCalendarMonths(dateLeft, dateRight)
+    } else if (absDiffInSeconds < secondsInQuarter) {
       unit = 'month'
-    } else if (Math.abs(diffInSeconds) < secondsInYear) {
-      if (differenceInCalendarQuarters(dateLeft, dateRight) < 4) {
+    } else if (absDiffInSeconds < secondsInYear) {
+      if (Math.abs(differenceInCalendarQuarters(date, baseDate)) < 4) {
         // To filter out cases that are less than a year but match 4 quarters
-        value = differenceInCalendarQuarters(dateLeft, dateRight)
         unit = 'quarter'
       } else {
-        value = differenceInCalendarYears(dateLeft, dateRight)
         unit = 'year'
       }
     } else {
-      value = differenceInCalendarYears(dateLeft, dateRight)
       unit = 'year'
     }
-  } else {
-    // Get the value if unit is specified
-    unit = options?.unit
-    if (unit === 'second') {
-      value = differenceInSeconds(dateLeft, dateRight)
-    } else if (unit === 'minute') {
-      value = differenceInMinutes(dateLeft, dateRight)
-    } else if (unit === 'hour') {
-      value = differenceInHours(dateLeft, dateRight)
-    } else if (unit === 'day') {
-      value = differenceInCalendarDays(dateLeft, dateRight)
-    } else if (unit === 'week') {
-      value = differenceInCalendarWeeks(dateLeft, dateRight)
-    } else if (unit === 'month') {
-      value = differenceInCalendarMonths(dateLeft, dateRight)
-    } else if (unit === 'quarter') {
-      value = differenceInCalendarQuarters(dateLeft, dateRight)
-    } else if (unit === 'year') {
-      value = differenceInCalendarYears(dateLeft, dateRight)
-    }
+  }
+
+  let value = 0
+  if (unit === 'second') {
+    value = differenceInSeconds(date, baseDate)
+  } else if (unit === 'minute') {
+    value = differenceInMinutes(date, baseDate)
+  } else if (unit === 'hour') {
+    value = differenceInHours(date, baseDate)
+  } else if (unit === 'day') {
+    value = differenceInCalendarDays(date, baseDate)
+  } else if (unit === 'week') {
+    value = differenceInCalendarWeeks(date, baseDate)
+  } else if (unit === 'month') {
+    value = differenceInCalendarMonths(date, baseDate)
+  } else if (unit === 'quarter') {
+    value = differenceInCalendarQuarters(date, baseDate)
+  } else if (unit === 'year') {
+    value = differenceInCalendarYears(date, baseDate)
   }
 
   const rtf = new Intl.RelativeTimeFormat(options?.locale, {

--- a/src/intlFormatDistance/test.ts
+++ b/src/intlFormatDistance/test.ts
@@ -11,7 +11,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 5, 10, 30, 0),
           new Date(1986, 3, 5, 10, 30, 0)
         )
-        assert(result === 'now')
+        assert.strictEqual(result, 'now')
       })
     })
 
@@ -21,7 +21,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 5, 10, 30, 1),
           new Date(1986, 3, 5, 10, 30, 0)
         )
-        assert(result === 'in 1 second')
+        assert.strictEqual(result, 'in 1 second')
       })
 
       it('works with past', () => {
@@ -29,7 +29,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 5, 10, 30, 0),
           new Date(1986, 3, 5, 10, 30, 1)
         )
-        assert(result === '1 second ago')
+        assert.strictEqual(result, '1 second ago')
       })
     })
 
@@ -39,7 +39,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 5, 10, 30, 59),
           new Date(1986, 3, 5, 10, 30, 0)
         )
-        assert(result === 'in 59 seconds')
+        assert.strictEqual(result, 'in 59 seconds')
       })
 
       it('works with past', () => {
@@ -47,7 +47,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 5, 10, 30, 0),
           new Date(1986, 3, 5, 10, 30, 59)
         )
-        assert(result === '59 seconds ago')
+        assert.strictEqual(result, '59 seconds ago')
       })
     })
 
@@ -57,7 +57,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 5, 10, 30, 59),
           new Date(1986, 3, 5, 10, 29, 59)
         )
-        assert(result === 'in 1 minute')
+        assert.strictEqual(result, 'in 1 minute')
       })
 
       it('works with future with over a minute', () => {
@@ -65,7 +65,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 5, 10, 30),
           new Date(1986, 3, 5, 10, 28, 10)
         )
-        assert(result === 'in 1 minute')
+        assert.strictEqual(result, 'in 1 minute')
       })
 
       it('works with past', () => {
@@ -73,7 +73,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 5, 10, 29, 59),
           new Date(1986, 3, 5, 10, 30, 59)
         )
-        assert(result === '1 minute ago')
+        assert.strictEqual(result, '1 minute ago')
       })
 
       it('works with past with over a minute', () => {
@@ -81,7 +81,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 5, 10, 28, 10),
           new Date(1986, 3, 5, 10, 30)
         )
-        assert(result === '1 minute ago')
+        assert.strictEqual(result, '1 minute ago')
       })
     })
 
@@ -91,7 +91,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 5, 10, 30),
           new Date(1986, 3, 5, 10, 28)
         )
-        assert(result === 'in 2 minutes')
+        assert.strictEqual(result, 'in 2 minutes')
       })
 
       it('works with past', () => {
@@ -99,7 +99,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 5, 10, 28),
           new Date(1986, 3, 5, 10, 30)
         )
-        assert(result === '2 minutes ago')
+        assert.strictEqual(result, '2 minutes ago')
       })
     })
 
@@ -109,7 +109,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 4, 11, 30, 0),
           new Date(1986, 3, 4, 10, 30, 0)
         )
-        assert(result === 'in 1 hour')
+        assert.strictEqual(result, 'in 1 hour')
       })
 
       it('works with past', () => {
@@ -117,7 +117,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 4, 10, 30, 0),
           new Date(1986, 3, 4, 11, 30, 0)
         )
-        assert(result === '1 hour ago')
+        assert.strictEqual(result, '1 hour ago')
       })
     })
 
@@ -127,7 +127,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 5, 10),
           new Date(1986, 3, 5, 9)
         )
-        assert(result === 'in 1 hour')
+        assert.strictEqual(result, 'in 1 hour')
       })
 
       it('works with future', () => {
@@ -135,7 +135,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 5, 10, 30),
           new Date(1986, 3, 5, 9)
         )
-        assert(result === 'in 1 hour')
+        assert.strictEqual(result, 'in 1 hour')
       })
 
       it('works with past', () => {
@@ -143,7 +143,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 5, 9),
           new Date(1986, 3, 5, 10)
         )
-        assert(result === '1 hour ago')
+        assert.strictEqual(result, '1 hour ago')
       })
 
       it('works with past with over an hour', () => {
@@ -151,7 +151,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 5, 9),
           new Date(1986, 3, 5, 10, 30)
         )
-        assert(result === '1 hour ago')
+        assert.strictEqual(result, '1 hour ago')
       })
     })
 
@@ -161,7 +161,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 5, 10),
           new Date(1986, 3, 5, 8)
         )
-        assert(result === 'in 2 hours')
+        assert.strictEqual(result, 'in 2 hours')
       })
 
       it('works with future with extra minutes', () => {
@@ -169,7 +169,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 5, 10, 30),
           new Date(1986, 3, 5, 8)
         )
-        assert(result === 'in 2 hours')
+        assert.strictEqual(result, 'in 2 hours')
       })
 
       it('works with past', () => {
@@ -177,7 +177,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 5, 8),
           new Date(1986, 3, 5, 10)
         )
-        assert(result === '2 hours ago')
+        assert.strictEqual(result, '2 hours ago')
       })
 
       it('works with past with extra minutes', () => {
@@ -185,7 +185,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 5, 8),
           new Date(1986, 3, 5, 10)
         )
-        assert(result === '2 hours ago')
+        assert.strictEqual(result, '2 hours ago')
       })
     })
 
@@ -195,7 +195,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 6, 22),
           new Date(1986, 3, 5, 22)
         )
-        assert(result === 'tomorrow')
+        assert.strictEqual(result, 'tomorrow')
       })
 
       it('works with past', () => {
@@ -203,7 +203,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 5, 22),
           new Date(1986, 3, 6, 22)
         )
-        assert(result === 'yesterday')
+        assert.strictEqual(result, 'yesterday')
       })
 
       it('works with past with an extra hour', () => {
@@ -211,7 +211,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 5, 22),
           new Date(1986, 3, 6, 22, 5)
         )
-        assert(result === 'yesterday')
+        assert.strictEqual(result, 'yesterday')
       })
     })
 
@@ -221,7 +221,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 6, 22),
           new Date(1986, 3, 4, 22)
         )
-        assert(result === 'in 2 days')
+        assert.strictEqual(result, 'in 2 days')
       })
 
       it('works with past', () => {
@@ -229,7 +229,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 4, 22),
           new Date(1986, 3, 6, 22)
         )
-        assert(result === '2 days ago')
+        assert.strictEqual(result, '2 days ago')
       })
     })
 
@@ -239,7 +239,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 10, 22),
           new Date(1986, 3, 3, 22)
         )
-        assert(result === 'next week')
+        assert.strictEqual(result, 'next week')
       })
 
       it('works with future with more than a week', () => {
@@ -247,7 +247,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 11, 22),
           new Date(1986, 3, 3, 22)
         )
-        assert(result === 'next week')
+        assert.strictEqual(result, 'next week')
       })
 
       it('works with past', () => {
@@ -255,7 +255,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 3, 22),
           new Date(1986, 3, 10, 22)
         )
-        assert(result === 'last week')
+        assert.strictEqual(result, 'last week')
       })
 
       it('works with past with more than a week', () => {
@@ -263,7 +263,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 3, 22),
           new Date(1986, 3, 11, 22)
         )
-        assert(result === 'last week')
+        assert.strictEqual(result, 'last week')
       })
     })
 
@@ -273,7 +273,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 15),
           new Date(1986, 3, 1)
         )
-        assert(result === 'in 2 weeks')
+        assert.strictEqual(result, 'in 2 weeks')
       })
 
       it('works with future with more than 2 weeks', () => {
@@ -281,7 +281,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 17),
           new Date(1986, 3, 1)
         )
-        assert(result === 'in 2 weeks')
+        assert.strictEqual(result, 'in 2 weeks')
       })
 
       it('works with past', () => {
@@ -289,7 +289,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 1),
           new Date(1986, 3, 15)
         )
-        assert(result === '2 weeks ago')
+        assert.strictEqual(result, '2 weeks ago')
       })
 
       it('works with past with more than 2 weeks', () => {
@@ -297,7 +297,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 1),
           new Date(1986, 3, 17)
         )
-        assert(result === '2 weeks ago')
+        assert.strictEqual(result, '2 weeks ago')
       })
     })
 
@@ -307,7 +307,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 4, 2),
           new Date(1986, 3, 1)
         )
-        assert(result === 'next month')
+        assert.strictEqual(result, 'next month')
       })
 
       it('works with future with more than a month', () => {
@@ -315,7 +315,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 4, 22),
           new Date(1986, 3, 1)
         )
-        assert(result === 'next month')
+        assert.strictEqual(result, 'next month')
       })
 
       it('works with past', () => {
@@ -323,7 +323,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 1),
           new Date(1986, 4, 2)
         )
-        assert(result === 'last month')
+        assert.strictEqual(result, 'last month')
       })
 
       it('works with past with more than a month', () => {
@@ -331,7 +331,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 1),
           new Date(1986, 4, 22)
         )
-        assert(result === 'last month')
+        assert.strictEqual(result, 'last month')
       })
     })
 
@@ -341,7 +341,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 5, 2),
           new Date(1986, 1, 1)
         )
-        assert(result === 'next quarter')
+        assert.strictEqual(result, 'next quarter')
       })
 
       it('works with future with more than a quarter', () => {
@@ -349,7 +349,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 5, 22),
           new Date(1986, 1, 1)
         )
-        assert(result === 'next quarter')
+        assert.strictEqual(result, 'next quarter')
       })
 
       it('works with past', () => {
@@ -357,7 +357,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 1, 1),
           new Date(1986, 5, 2)
         )
-        assert(result === 'last quarter')
+        assert.strictEqual(result, 'last quarter')
       })
 
       it('works with past with more than a quarter', () => {
@@ -365,7 +365,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 1, 1),
           new Date(1986, 5, 22)
         )
-        assert(result === 'last quarter')
+        assert.strictEqual(result, 'last quarter')
       })
     })
 
@@ -375,7 +375,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 6, 2),
           new Date(1986, 1, 1)
         )
-        assert(result === 'in 2 quarters')
+        assert.strictEqual(result, 'in 2 quarters')
       })
 
       it('works with future with more that X quarters', () => {
@@ -383,7 +383,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 6, 22),
           new Date(1986, 1, 1)
         )
-        assert(result === 'in 2 quarters')
+        assert.strictEqual(result, 'in 2 quarters')
       })
 
       it('works with past', () => {
@@ -391,7 +391,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 1, 1),
           new Date(1986, 6, 2)
         )
-        assert(result === '2 quarters ago')
+        assert.strictEqual(result, '2 quarters ago')
       })
 
       it('works with past with more that X quarters', () => {
@@ -399,7 +399,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 1, 1),
           new Date(1986, 6, 22)
         )
-        assert(result === '2 quarters ago')
+        assert.strictEqual(result, '2 quarters ago')
       })
     })
 
@@ -409,7 +409,7 @@ describe('intlFormatDistance', () => {
           new Date(1987, 1, 2),
           new Date(1986, 1, 1)
         )
-        assert(result === 'next year')
+        assert.strictEqual(result, 'next year')
       })
 
       it('works with future with more that a year', () => {
@@ -417,7 +417,7 @@ describe('intlFormatDistance', () => {
           new Date(1987, 10, 2),
           new Date(1986, 1, 1)
         )
-        assert(result === 'next year')
+        assert.strictEqual(result, 'next year')
       })
 
       it('works with past', () => {
@@ -425,7 +425,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 1, 1),
           new Date(1987, 1, 2)
         )
-        assert(result === 'last year')
+        assert.strictEqual(result, 'last year')
       })
 
       it('works with past with more than a year', () => {
@@ -433,7 +433,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 1, 1),
           new Date(1987, 10, 2)
         )
-        assert(result === 'last year')
+        assert.strictEqual(result, 'last year')
       })
     })
 
@@ -443,7 +443,7 @@ describe('intlFormatDistance', () => {
           new Date(1988, 1, 1),
           new Date(1986, 1, 1)
         )
-        assert(result === 'in 2 years')
+        assert.strictEqual(result, 'in 2 years')
       })
 
       it('works with future with x years', () => {
@@ -451,7 +451,7 @@ describe('intlFormatDistance', () => {
           new Date(2088, 1, 1),
           new Date(1986, 1, 1)
         )
-        assert(result === 'in 102 years')
+        assert.strictEqual(result, 'in 102 years')
       })
 
       it('works with past', () => {
@@ -459,7 +459,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 1, 1),
           new Date(1988, 1, 1)
         )
-        assert(result === '2 years ago')
+        assert.strictEqual(result, '2 years ago')
       })
 
       it('works with past with x years', () => {
@@ -467,7 +467,7 @@ describe('intlFormatDistance', () => {
           new Date(1988, 1, 1),
           new Date(2086, 1, 1)
         )
-        assert(result === '98 years ago')
+        assert.strictEqual(result, '98 years ago')
       })
     })
   })
@@ -481,7 +481,7 @@ describe('intlFormatDistance', () => {
             new Date(1987, 3, 4, 10, 30, 0),
             { unit: 'second' }
           )
-          assert(result === 'in 90 seconds')
+          assert.strictEqual(result, 'in 90 seconds')
         })
 
         it('works with past with seconds', () => {
@@ -490,7 +490,7 @@ describe('intlFormatDistance', () => {
             new Date(1987, 3, 4, 10, 31, 30),
             { unit: 'second' }
           )
-          assert(result === '90 seconds ago')
+          assert.strictEqual(result, '90 seconds ago')
         })
 
         it('works with future with quarters', () => {
@@ -499,7 +499,7 @@ describe('intlFormatDistance', () => {
             new Date(1986, 3, 4, 10, 30, 0),
             { unit: 'quarter' }
           )
-          assert(result === 'in 5 quarters')
+          assert.strictEqual(result, 'in 5 quarters')
         })
       })
 
@@ -510,7 +510,7 @@ describe('intlFormatDistance', () => {
             new Date(1986, 3, 4, 10, 30, 0),
             { unit: 'minute' }
           )
-          assert(result === 'in 60 minutes')
+          assert.strictEqual(result, 'in 60 minutes')
         })
 
         it('works with the past', () => {
@@ -519,7 +519,7 @@ describe('intlFormatDistance', () => {
             new Date(1986, 3, 4, 11, 30, 0),
             { unit: 'minute' }
           )
-          assert(result === '60 minutes ago')
+          assert.strictEqual(result, '60 minutes ago')
         })
       })
 
@@ -531,7 +531,7 @@ describe('intlFormatDistance', () => {
 
             { unit: 'hour' }
           )
-          assert(result === 'in 1 hour')
+          assert.strictEqual(result, 'in 1 hour')
         })
 
         it('works with the past', () => {
@@ -541,7 +541,7 @@ describe('intlFormatDistance', () => {
 
             { unit: 'hour' }
           )
-          assert(result === '1 hour ago')
+          assert.strictEqual(result, '1 hour ago')
         })
       })
 
@@ -552,7 +552,7 @@ describe('intlFormatDistance', () => {
             new Date(1987, 3, 4, 10, 30, 0),
             { unit: 'day' }
           )
-          assert(result === 'today')
+          assert.strictEqual(result, 'today')
         })
 
         it('works with the past', () => {
@@ -560,7 +560,7 @@ describe('intlFormatDistance', () => {
             new Date(1986, 3, 5, 10, 30, 0),
             new Date(1986, 3, 4, 10, 30, 0)
           )
-          assert(result === 'tomorrow')
+          assert.strictEqual(result, 'tomorrow')
         })
       })
 
@@ -571,7 +571,7 @@ describe('intlFormatDistance', () => {
             new Date(1986, 3, 4, 10, 30, 0),
             { unit: 'day' }
           )
-          assert(result === 'in 366 days')
+          assert.strictEqual(result, 'in 366 days')
         })
 
         it('works with the past', () => {
@@ -581,7 +581,7 @@ describe('intlFormatDistance', () => {
 
             { unit: 'day' }
           )
-          assert(result === '366 days ago')
+          assert.strictEqual(result, '366 days ago')
         })
       })
 
@@ -592,7 +592,7 @@ describe('intlFormatDistance', () => {
             new Date(1987, 3, 4, 10, 30, 0),
             { unit: 'week' }
           )
-          assert(result === 'next week')
+          assert.strictEqual(result, 'next week')
         })
 
         it('works with the past', () => {
@@ -601,7 +601,7 @@ describe('intlFormatDistance', () => {
             new Date(1987, 3, 11, 10, 30, 0),
             { unit: 'week' }
           )
-          assert(result === 'last week')
+          assert.strictEqual(result, 'last week')
         })
       })
 
@@ -612,7 +612,7 @@ describe('intlFormatDistance', () => {
             new Date(1986, 3, 4, 10, 30, 0),
             { unit: 'week' }
           )
-          assert(result === 'in 53 weeks')
+          assert.strictEqual(result, 'in 53 weeks')
         })
 
         it('works with the past', () => {
@@ -622,7 +622,7 @@ describe('intlFormatDistance', () => {
 
             { unit: 'week' }
           )
-          assert(result === '53 weeks ago')
+          assert.strictEqual(result, '53 weeks ago')
         })
       })
     })
@@ -635,7 +635,7 @@ describe('intlFormatDistance', () => {
             new Date(1986, 3, 10, 22),
             { numeric: 'always' }
           )
-          assert(result === '1 week ago')
+          assert.strictEqual(result, '1 week ago')
         })
 
         it('works with future', () => {
@@ -644,7 +644,7 @@ describe('intlFormatDistance', () => {
             new Date(1986, 3, 3, 22),
             { numeric: 'always' }
           )
-          assert(result === 'in 1 week')
+          assert.strictEqual(result, 'in 1 week')
         })
       })
 
@@ -654,7 +654,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 4, 10, 30, 0),
           { numeric: 'always' }
         )
-        assert(result === 'in 1 day')
+        assert.strictEqual(result, 'in 1 day')
       })
 
       it('works with the same dates', () => {
@@ -663,7 +663,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 5, 10, 30, 0),
           { numeric: 'auto' }
         )
-        assert(result === 'now')
+        assert.strictEqual(result, 'now')
       })
     })
 
@@ -675,7 +675,7 @@ describe('intlFormatDistance', () => {
             new Date(1985, 4, 4, 10, 30, 0),
             { locale: 'es' }
           )
-          assert(result === 'el próximo año')
+          assert.strictEqual(result, 'el próximo año')
         })
       })
     })
@@ -687,7 +687,7 @@ describe('intlFormatDistance', () => {
           new Date(1985, 4, 4, 10, 30, 0),
           { style: 'long' }
         )
-        assert(result === 'next year')
+        assert.strictEqual(result, 'next year')
       })
     })
 
@@ -698,7 +698,7 @@ describe('intlFormatDistance', () => {
           new Date(1986, 3, 5, 10, 30, 0),
           { unit: 'minute', locale: 'de' }
         )
-        assert(result === 'in 60 Minuten')
+        assert.strictEqual(result, 'in 60 Minuten')
       })
     })
 
@@ -709,7 +709,7 @@ describe('intlFormatDistance', () => {
           new Date(1985, 4, 4, 10, 30, 0),
           { style: 'long', numeric: 'auto' }
         )
-        assert(result === 'tomorrow')
+        assert.strictEqual(result, 'tomorrow')
       })
 
       it('handles dates before 100 AD', () => {
@@ -718,7 +718,7 @@ describe('intlFormatDistance', () => {
           new Date(1, 3, 4, 10, 30, 0),
           { unit: 'minute' }
         )
-        assert(result === 'in 60 minutes')
+        assert.strictEqual(result, 'in 60 minutes')
       })
     })
 


### PR DESCRIPTION
I was poking around that file and saw some low-hanging fruits that should help performance, reduce file size and help with readability. I also caught a small bug while detecting negative quarter units.

- Remove unnecessary `toDate()` calls
- Eliminate duplicate `Math.abs(diffInSeconds)` calls
- Remove duplicate difference calculation logic
- Added a missing `Math.abs()` when detecting quarter units
- Updated the unit tests to use `assert.strictEqual()` instead of only `assert()`, which gives better outputs on test failures