### PR TITLE
Add comma to separate date and time for de locale

### DIFF
--- a/src/locale/de/_lib/formatLong/index.ts
+++ b/src/locale/de/_lib/formatLong/index.ts
@@ -19,8 +19,8 @@ const timeFormats = {
 const dateTimeFormats = {
   full: "{{date}} 'um' {{time}}",
   long: "{{date}} 'um' {{time}}",
-  medium: '{{date}} {{time}}',
-  short: '{{date}} {{time}}',
+  medium: '{{date}}, {{time}}',
+  short: '{{date}}, {{time}}',
 }
 
 const formatLong: FormatLong = {


### PR DESCRIPTION
I18n (minor): This reverts a change made in https://github.com/date-fns/date-fns/pull/1105 regarding the comma between date and time for `de` and `de-AT` locales. 

While the DIN-5008 specification was referenced, there is no explicit mention of numeric date and time (specifically, the format `Pp`). A client of mine filed a bug with me because they were missing a comma between date and time, so I did some research and found [sources](https://dict.leo.org/grammatik/deutsch/Rechtschreibung/Regeln/Interpunktion/Komma/Angaben.xml?lang=de) stating that any date and time parts should be joined with a comma, much like e.g. in `en-US`. Also, [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) uses a comma (see [repro in codepen](https://codepen.io/felix-scale/pen/VwBLYWj)).

In my opinion, commas should be added back to align the behavior with user expectations and Intl.DateTimeFormat.