### PR TITLE
Added the right formatting for basic option and updated the test

### DIFF
--- a/src/formatISO/index.ts
+++ b/src/formatISO/index.ts
@@ -82,8 +82,12 @@ export default function formatISO<DateType extends Date>(
       const minuteOffset = addLeadingZeros(absoluteOffset % 60, 2)
       // If less than 0, the sign is +, because it is ahead of time.
       const sign = offset < 0 ? '+' : '-'
-
-      tzOffset = `${sign}${hourOffset}:${minuteOffset}`
+      //check for the basic format option and representation option for formatting the time zone offset
+      if (options?.format === 'basic' && options?.representation !== 'time') {
+        tzOffset = `${sign}${hourOffset}${minuteOffset}`
+      } else {
+        tzOffset = `${sign}${hourOffset}:${minuteOffset}`
+      }
     } else {
       tzOffset = 'Z'
     }

--- a/src/formatISO/test.ts
+++ b/src/formatISO/test.ts
@@ -9,6 +9,7 @@ describe('formatISO', () => {
   it('formats ISO-8601 extended format', () => {
     const date = new Date(2019, 2 /* Mar */, 3, 19, 0, 52, 123)
     const tzOffsetExtended = generateOffset(date)
+
     assert(formatISO(date) === `2019-03-03T19:00:52${tzOffsetExtended}`)
 
     const getTimezoneOffsetStub = sinon.stub(
@@ -35,7 +36,7 @@ describe('formatISO', () => {
 
   it('formats ISO-8601 basic format', () => {
     const date = new Date(2019, 9 /* Oct */, 4, 12, 30, 13, 456)
-    const tzOffsetBasic = generateOffset(date)
+    const tzOffsetBasic = generateOffset(date).replace(/:/g, '')
     assert(
       formatISO(date, { format: 'basic' }) === `20191004T123013${tzOffsetBasic}`
     )


### PR DESCRIPTION
**resolves #3291** 
As discussed in issue it was simple issue with the formatting of output and test was passing as it was also expecting the wrong fomrat.

**Made follwing changes in src/formatISO**
1. Updated the index.ts file in src/formatISO to check for the basic option and format the result without the collon.
2. And updated the src/formatISO/test.ts to check for the right format without collon.