### PR TITLE
prepareFormat for preparing format functions

### DIFF
--- a/src/format/index.ts
+++ b/src/format/index.ts
@@ -352,15 +352,15 @@ export function format<DateType extends Date>(
 
 export function prepareFormat<DateType extends Date>(
   _formatStr: string,
-  _options: PrepareFormatOptions<DateType> | undefined
+  _options: PrepareFormatOptions<DateType>
 ): string;
 export function prepareFormat<DateType extends Date>(
   _formatStr: string,
-  _options?: PrepareFormatOptions<DateType>
+  _options?: FormatOptions
 ): (_date: DateType | number) => string;
 export function prepareFormat<DateType extends Date>(
   formatStr: string,
-  options?: PrepareFormatOptions<DateType>
+  options?: PrepareFormatOptions<DateType> | FormatOptions
 ): ((_date: DateType | number) => string) | string {
   const defaultOptions = getDefaultOptions();
   const locale = options?.locale ?? defaultOptions.locale ?? defaultLocale;
@@ -379,7 +379,8 @@ export function prepareFormat<DateType extends Date>(
     defaultOptions.locale?.options?.weekStartsOn ??
     0;
 
-  const originalDate = options?._date;
+  // We don't care for the undefined case, even later
+  const originalDate = (options as PrepareFormatOptions<DateType>)?._date;
 
   const formatterOptions = {
     firstWeekContainsDate: firstWeekContainsDate as FirstWeekContainsDate,
@@ -451,8 +452,8 @@ export function prepareFormat<DateType extends Date>(
         throw new RangeError(
           "Format string contains an unescaped latin alphabet character `" +
             firstCharacter +
-            "`"
-        );
+            '`'
+        )
       }
 
       return substring;

--- a/src/format/index.ts
+++ b/src/format/index.ts
@@ -29,8 +29,7 @@ import {
 //   If there is no matching single quote
 //   then the sequence will continue until the end of the string.
 // - . matches any single character unmatched by previous parts of the RegExps
-const formattingTokensRegExp =
-  /[yYQqMLwIdDecihHKkms]o|(\w)\1*|''|'(''|[^'])+('|$)|./g;
+const formattingTokensRegExp = /[yYQqMLwIdDecihHKkms]o|(\w)\1*|''|'(''|[^'])+('|$)|./g;
 
 // This RegExp catches symbols escaped by quotes, and also
 // sequences of symbols P, p, and the combinations like `PPPPPPPppppp`
@@ -48,6 +47,10 @@ export interface FormatOptions
     WeekOptions,
     FirstWeekContainsDateOptions,
     AdditionalTokensOptions {}
+
+export type PrepareFormatOptions<DateType extends Date> = FormatOptions & {
+  _date: DateType;
+};
 
 /**
  * @name format
@@ -337,8 +340,28 @@ export interface FormatOptions
 export function format<DateType extends Date>(
   date: DateType | number | string,
   formatStr: string,
-  options?: FormatOptions,
+  options?: FormatOptions
 ): string {
+  const originalDate = toDate(date);
+
+  if (!isValid(originalDate)) {
+    throw new RangeError("Invalid time value");
+  }
+  return prepareFormat(formatStr, { ...options, _date: originalDate });
+}
+
+export function prepareFormat<DateType extends Date>(
+  _formatStr: string,
+  _options: PrepareFormatOptions<DateType> | undefined
+): string;
+export function prepareFormat<DateType extends Date>(
+  _formatStr: string,
+  _options?: PrepareFormatOptions<DateType>
+): (_date: DateType | number) => string;
+export function prepareFormat<DateType extends Date>(
+  formatStr: string,
+  options?: PrepareFormatOptions<DateType>
+): ((_date: DateType | number) => string) | string {
   const defaultOptions = getDefaultOptions();
   const locale = options?.locale ?? defaultOptions.locale ?? defaultLocale;
 
@@ -356,11 +379,7 @@ export function format<DateType extends Date>(
     defaultOptions.locale?.options?.weekStartsOn ??
     0;
 
-  const originalDate = toDate(date);
-
-  if (!isValid(originalDate)) {
-    throw new RangeError("Invalid time value");
-  }
+  const originalDate = options?._date;
 
   const formatterOptions = {
     firstWeekContainsDate: firstWeekContainsDate as FirstWeekContainsDate,
@@ -369,7 +388,7 @@ export function format<DateType extends Date>(
     _originalDate: originalDate,
   };
 
-  const result = formatStr
+  const prepared = formatStr
     .match(longFormattingTokensRegExp)!
     .map(function (substring) {
       const firstCharacter = substring[0];
@@ -398,35 +417,63 @@ export function format<DateType extends Date>(
           !options?.useAdditionalWeekYearTokens &&
           isProtectedWeekYearToken(substring)
         ) {
-          throwProtectedError(substring, formatStr, String(date));
+          throwProtectedError(
+            substring,
+            formatStr,
+            String(originalDate ?? "prepared format")
+          );
         }
         if (
           !options?.useAdditionalDayOfYearTokens &&
           isProtectedDayOfYearToken(substring)
         ) {
-          throwProtectedError(substring, formatStr, String(date));
+          throwProtectedError(
+            substring,
+            formatStr,
+            String(originalDate ?? "prepared format")
+          );
         }
-        return formatter(
-          originalDate,
-          substring,
-          locale.localize,
-          formatterOptions,
-        );
+        return originalDate !== undefined
+          ? formatter(
+              originalDate,
+              substring,
+              locale.localize,
+              formatterOptions as Parameters<typeof formatter>[3]
+            )
+          : (date: DateType) =>
+              formatter(date, substring, locale.localize, {
+                ...formatterOptions,
+                _originalDate: date,
+              });
       }
 
       if (firstCharacter.match(unescapedLatinCharacterRegExp)) {
         throw new RangeError(
           "Format string contains an unescaped latin alphabet character `" +
             firstCharacter +
-            "`",
+            "`"
         );
       }
 
       return substring;
-    })
-    .join("");
+    });
 
-  return result;
+  if (originalDate === undefined) {
+    const functions = prepared.map((stringOrFn) =>
+      typeof stringOrFn === "string" ? () => stringOrFn : stringOrFn
+    );
+    return (dirtyDate: DateType | number) => {
+      const originalDate = toDate(dirtyDate);
+
+      if (!isValid(originalDate)) {
+        throw new RangeError("Invalid time value");
+      }
+
+      return functions.map((fn) => fn(originalDate)).join("");
+    };
+  } else {
+    return (prepared as string[]).join("");
+  }
 }
 
 function cleanEscapedString(input: string): string {

--- a/src/format/index.ts
+++ b/src/format/index.ts
@@ -452,8 +452,8 @@ export function prepareFormat<DateType extends Date>(
         throw new RangeError(
           "Format string contains an unescaped latin alphabet character `" +
             firstCharacter +
-            '`'
-        )
+            "`"
+        );
       }
 
       return substring;


### PR DESCRIPTION
This is a solution for fixing #423 

I need help on this, especially on export declarations and needed documentation. Should the function be in its own file?

Anyway, here is the benchmark code:
```ts
import Benchmark from 'benchmark';
const formatNew = require('./src/format')

const date = new Date();

let prepared = formatNew.prepareFormat("y")

const testsFunctions = {
  "old format new lib         ": {
    test: (formatStr) => formatNew.formatOld(date, formatStr)
  },
  "new format one shot prepare": {
    test: (formatStr) => formatNew.default(date, formatStr)
  },
  "new format prepare nooverhead": {
    test: (formatStr) => formatNew.prepareFormat(formatStr, {_date: date})
  },
  "using already prepared     ": {
    init: (formatStr) => prepared = formatNew.prepareFormat(formatStr),
    test: () => prepared(date)
  }
};

const formatStrings = [
  "PPPppp",
  "P",
  "yyyyMMdd'T'HHmmss.SSS",
  "'aloa'",
  "yyyy",
]

formatStrings.forEach(formatStr => {
  const suite = new Benchmark.Suite;

  
  const output = Object.values(testsFunctions).map(test => {
    test.init?.(formatStr)
    return test.test(formatStr)
  })
  const isSame = new Set(output).size <= 1

  console.log('Output for', formatStr, 'is', output[0], isSame ? "✅" : "❌ " + output)
  Object.entries(testsFunctions).forEach(([name, test]) => suite.add(name, () => test.test(formatStr)))
  suite
    .on('cycle', (event) => console.log(String(event.target)))
    .on('complete', () => console.log(''))
    .run();
});
```

Output:
```
❯ yarn node -r ts-node/register benchmark.js
yarn node v1.22.19
Output for PPPppp is January 19th, 2023 at 3:57:46 PM GMT+1 ✅
old format new lib          x 179,903 ops/sec ±2.42% (90 runs sampled)
new format one shot prepare x 158,100 ops/sec ±3.20% (84 runs sampled)
new format prepare nooverhead x 180,275 ops/sec ±2.14% (85 runs sampled)
using already prepared      x 338,978 ops/sec ±2.91% (87 runs sampled)

Output for P is 01/19/2023 ✅
old format new lib          x 478,342 ops/sec ±4.42% (81 runs sampled)
new format one shot prepare x 425,239 ops/sec ±2.56% (80 runs sampled)
new format prepare nooverhead x 711,910 ops/sec ±4.29% (85 runs sampled)
using already prepared      x 778,732 ops/sec ±2.25% (92 runs sampled)

Output for yyyyMMdd'T'HHmmss.SSS is 20230119T155746.685 ✅
old format new lib          x 174,275 ops/sec ±6.63% (62 runs sampled)
new format one shot prepare x 221,499 ops/sec ±3.95% (84 runs sampled)
new format prepare nooverhead x 282,716 ops/sec ±1.95% (89 runs sampled)
using already prepared      x 432,093 ops/sec ±1.43% (90 runs sampled)

Output for 'aloa' is aloa ✅
old format new lib          x 1,210,808 ops/sec ±1.46% (90 runs sampled)
new format one shot prepare x 960,371 ops/sec ±2.80% (83 runs sampled)
new format prepare nooverhead x 1,657,712 ops/sec ±3.53% (85 runs sampled)
using already prepared      x 2,717,344 ops/sec ±2.99% (91 runs sampled)

Output for yyyy is 2023 ✅
old format new lib          x 699,194 ops/sec ±4.87% (75 runs sampled)
new format one shot prepare x 755,738 ops/sec ±3.44% (91 runs sampled)
new format prepare nooverhead x 1,383,233 ops/sec ±2.69% (85 runs sampled)
using already prepared      x 1,218,078 ops/sec ±3.69% (82 runs sampled)
```
