### PR TITLE
Update formatRelative et locale implementation

### DIFF
--- a/src/locale/et/_lib/formatRelative/index.ts
+++ b/src/locale/et/_lib/formatRelative/index.ts
@@ -5,7 +5,7 @@ const formatRelativeLocale = {
   yesterday: "'eile kell' p",
   today: "'täna kell' p",
   tomorrow: "'homme kell' p",
-  nextWeek: "'järgmine' eeee 'kell' p",
+  nextWeek: "eeee 'kell' p",
   other: 'P',
 }
 


### PR DESCRIPTION
This pull request is to align the Estonian locale (et) implementation of `formatRelative` with the English one, more precisely the `nextWeek` case.

For an English locale, the `nextWeek` case would output for example `Sunday at 12:00 PM`.
The current et locale version outputs `järgmine pühapäev kell 12:00`, which in direct translation is `next Sunday at 12:00 PM`.

This in my opinion is not what I'd expect following the docs, as this is misunderstood as the *next* Sunday as in the next week, not the *upcoming* Sunday in the current week.

My proposal is to remove the "järgmine" word so that the output aligns more with the default locale.
So the output would be "pühapäev kell 12:00".

_Note: as Estonian speakers know, this part of the language is pretty subjective. For example "järgmine reede" can be interpreted differently by each speaker, it's more of a cultural thing. My proposed variant is less subjective (which is a good thing imo), but makes combining the output of formatRelative a bit harder to use in a sentence that answers "Millal?". But I'd say it's a net positive tradeoff._