### PR TITLE
Update short date format for nl-BE

### DIFF
--- a/src/locale/nl-BE/_lib/formatLong/index.ts
+++ b/src/locale/nl-BE/_lib/formatLong/index.ts
@@ -5,7 +5,7 @@ const dateFormats = {
   full: 'EEEE d MMMM y',
   long: 'd MMMM y',
   medium: 'd MMM y',
-  short: 'dd.MM.y',
+  short: 'dd/MM/y',
 }
 
 const timeFormats = {


### PR DESCRIPTION
Short date format for nl-BE uses slash `/` instead of `.`. 

source: https://www.ibm.com/docs/en/db2/11.5?topic=considerations-date-time-formats-by-territory-code