### PR TITLE
fix: Arabic time formats should use h12 hour cycle with meridiem and timezones for full and long

### DIFF
--- a/src/locale/ar/_lib/formatLong/index.ts
+++ b/src/locale/ar/_lib/formatLong/index.ts
@@ -9,8 +9,8 @@ const dateFormats = {
 }
 
 const timeFormats = {
-  full: 'hh:mm:ss a',
-  long: 'hh:mm:ss a',
+  full: 'hh:mm:ss a zzzz',
+  long: 'hh:mm:ss a z',
   medium: 'hh:mm:ss a',
   short: 'hh:mm a',
 }

--- a/src/locale/ar/_lib/formatLong/index.ts
+++ b/src/locale/ar/_lib/formatLong/index.ts
@@ -9,10 +9,10 @@ const dateFormats = {
 }
 
 const timeFormats = {
-  full: 'HH:mm:ss',
-  long: 'HH:mm:ss',
-  medium: 'HH:mm:ss',
-  short: 'HH:mm',
+  full: 'hh:mm:ss a',
+  long: 'hh:mm:ss a',
+  medium: 'hh:mm:ss a',
+  short: 'hh:mm a',
 }
 
 const dateTimeFormats = {


### PR DESCRIPTION
Related Issue: #3380 

This PR fixes the issue where Arabic time formats aren't parsed correctly.  

Verified this fix in the date-fns REPL:

<img width="1290" alt="image" src="https://user-images.githubusercontent.com/821864/227591629-c686409b-1fbf-49f1-80cf-fe34e8b187cf.png">

This is what `parse` returns for a standard Arabic time expression before this fix:

<img width="331" alt="image" src="https://user-images.githubusercontent.com/821864/227386264-66fbb018-a599-4a23-b7b3-77138003a6b8.png">

