### PR TITLE
add comment to describe rounding options

### DIFF
--- a/src/differenceInHours/index.ts
+++ b/src/differenceInHours/index.ts
@@ -28,6 +28,19 @@ export interface DifferenceInHoursOptions extends RoundingOptions {}
  *   new Date(2014, 6, 2, 6, 50)
  * )
  * //=> 12
+ *
+ * // Different rounding options can result in distinct outputs based on fractional hours in the result.
+ * const result = differenceInHours(
+ *   new Date(2014, 6, 2, 19, 0),
+ *   new Date(2014, 6, 2, 6, 50),
+ *   { roundingMethod: 'ceil' }
+ * )
+ * //=> 13
+ *
+ * // ceil — if there is a fractional piece of an hour in the result, the next highest hour value is used
+ * // floor — if there is a fractional piece of an hour in the result, the next lowest hour value is used
+ * // round — if there is a fractional piece of an hour in the result, the closest hour value is used
+ * // trunc — ignores the fractional element of the result and simply uses the hour value
  */
 export default function differenceInHours<DateType extends Date>(
   dateLeft: DateType | number,


### PR DESCRIPTION
## Summary

The aim of this PR is to add some context around rounding options for the `differenceInHours` function.

There are other functions which use (all or some of) these options, so there might be a need to duplicate them as necessary. I'm happy to facilitate this and I'm also happy to reformat/reword these changes.