### PR TITLE
roundToNearestMinutes only accepts nearestTo when a factor of sixty

### DIFF
--- a/src/roundToNearestMinutes/index.ts
+++ b/src/roundToNearestMinutes/index.ts
@@ -16,13 +16,13 @@ export interface RoundToNearestMinutesOptions extends RoundingOptions {
  * @summary Rounds the given date to the nearest minute
  *
  * @description
- * Rounds the given date to the nearest minute (or number of minutes).
- * Rounds up when the given date is exactly between the nearest round minutes.
+ * Rounds the given date to the nearest minute (or whole multiple of minutes past the hour).
+ * Rounds up when the given date is exactly between the nearest whole multiple of minutes past the hour.
  *
  * @param date - the date to round
  * @param options - an object with options.
- * @returns the new date rounded to the closest minute
- * @throws {RangeError} `options.nearestTo` must be between 1 and 30
+ * @returns the new date rounded to the closest minute or whole multiple of minutes past the hour
+ * @throws {RangeError} `options.nearestTo` must be a factor of 60
  *
  * @example
  * // Round 10 July 2014 12:12:34 to nearest minute:
@@ -41,8 +41,8 @@ export default function roundToNearestMinutes<DateType extends Date>(
 ): DateType {
   const nearestTo = options?.nearestTo ?? 1
 
-  if (nearestTo < 1 || nearestTo > 30) {
-    throw new RangeError('`options.nearestTo` must be between 1 and 30')
+  if (nearestTo < 1 || 60 % nearestTo !== 0) {
+    throw new RangeError('`options.nearestTo` must be a positive factor of 60')
   }
 
   const date = toDate(dirtyDate)

--- a/src/roundToNearestMinutes/test.ts
+++ b/src/roundToNearestMinutes/test.ts
@@ -81,6 +81,14 @@ describe('roundToNearestMinutes', () => {
     assert.deepStrictEqual(result, new Date(2014, 6 /* Jul */, 10, 12, 20, 0))
   })
 
+  it('wraps round the hour', () => {
+    const result = roundToNearestMinutes(
+      new Date(2014, 6 /* Jul */, 10, 11, 0, 1),
+      { nearestTo: 60, roundingMethod: 'ceil' }
+    )
+    assert.deepStrictEqual(result, new Date(2014, 6 /* Jul */, 10, 12))
+  })
+
   it('rounds according to the passed mode - round - when nearestTo is provided', () => {
     const result = roundToNearestMinutes(
       new Date(2014, 6 /* Jul */, 10, 12, 10, 30, 5),

--- a/src/roundToNearestMinutes/test.ts
+++ b/src/roundToNearestMinutes/test.ts
@@ -102,14 +102,26 @@ describe('roundToNearestMinutes', () => {
     assert(result instanceof Date && isNaN(result.getTime()))
   })
 
-  it('throws `RangeError` if nearestTo is not between 1 and 30', () => {
+  it('throws `RangeError` if nearestTo is not a positive factor of 60', () => {
     const date = new Date(2014, 6 /* Jul */, 10, 12, 10, 30)
     assert.throws(
-      roundToNearestMinutes.bind(null, date, { nearestTo: 31 }),
+      roundToNearestMinutes.bind(null, date, { nearestTo: -1 }),
       RangeError
     )
     assert.throws(
       roundToNearestMinutes.bind(null, date, { nearestTo: 0 }),
+      RangeError
+    )
+    assert.throws(
+      roundToNearestMinutes.bind(null, date, { nearestTo: 120 }),
+      RangeError
+    )
+    assert.throws(
+      roundToNearestMinutes.bind(null, date, { nearestTo: 61 }),
+      RangeError
+    )
+    assert.throws(
+      roundToNearestMinutes.bind(null, date, { nearestTo: 7 }),
       RangeError
     )
   })


### PR DESCRIPTION
Previously, `roundToNearestMinutes` accepted `nearestTo` for any and only whole-number values from 1 to 30 inclusive.

This didn't make much sense, for two reasons: one (#3394), that it unfairly excludes the value 60, which is perfectly reasonable; and two, that it allows values like 23, which are pretty nonsensical.

This PR will mean that `roundToNearestMinutes` will accept all and only positive integer values for `nearestTo` which are factors of 60. This will solve #3394. It also makes some improvements to the documentation for `roundToNearestMinutes`.