### PR TITLE
Check for leap year when calculating differenceInMonths involving February

### DIFF
--- a/src/differenceInMonths/index.ts
+++ b/src/differenceInMonths/index.ts
@@ -2,6 +2,7 @@ import { compareAsc } from "../compareAsc/index.js";
 import { differenceInCalendarMonths } from "../differenceInCalendarMonths/index.js";
 import { isLastDayOfMonth } from "../isLastDayOfMonth/index.js";
 import { toDate } from "../toDate/index.js";
+import { isLeapYear } from "../isLeapYear/index.js";
 
 /**
  * @name differenceInMonths
@@ -40,7 +41,7 @@ export function differenceInMonths<DateType extends Date>(
   if (difference < 1) {
     result = 0;
   } else {
-    if (_dateLeft.getMonth() === 1 && _dateLeft.getDate() > 27) {
+    if (_dateLeft.getMonth() === 1 && ((_dateLeft.getDate() > 27 && !isLeapYear(_dateLeft)) || (_dateLeft.getDate() > 28 && isLeapYear(_dateLeft)))) {
       // This will check if the date is end of Feb and assign a higher end of month date
       // to compare it with Jan
       _dateLeft.setDate(30);

--- a/src/differenceInMonths/test.ts
+++ b/src/differenceInMonths/test.ts
@@ -46,6 +46,30 @@ describe("differenceInMonths", () => {
       assert(result === 1);
     });
 
+    it("it returns diff of 0 months between Feb 28 and Jan 31 on a leap year", () => {
+      const result = differenceInMonths(
+        new Date(2024, 1 /* Feb */, 28),
+        new Date(2024, 0 /* Jan */, 31),
+      );
+      assert(result === 0);
+    });
+
+    it("it returns diff of 1 month between Feb 28 and Jan 31 on a non-leap year", () => {
+      const result = differenceInMonths(
+        new Date(2023, 1 /* Feb */, 28),
+        new Date(2023, 0 /* Jan */, 31),
+      );
+      assert(result === 1);
+    });
+
+    it("it returns diff of 1 month between Feb 29 and Jan 31 on a leap year", () => {
+      const result = differenceInMonths(
+        new Date(2024, 1 /* Feb */, 29),
+        new Date(2024, 0 /* Jan */, 31),
+      );
+      assert(result === 1);
+    });
+
     it("it returns diff of 1 month between Nov, 30 2021 and Oct, 31 2021", () => {
       const result = differenceInMonths(
         new Date(2021, 10 /* Nov */, 30),

--- a/src/intervalToDuration/test.ts
+++ b/src/intervalToDuration/test.ts
@@ -238,5 +238,41 @@ describe("intervalToDuration", () => {
         assert.deepStrictEqual(duration, expectedDuration);
       });
     });
+
+    it("returns correct duration for Jan 31 to Feb 28 on leap year", () => {
+      const duration = intervalToDuration({
+        start: new Date(2024, 0, 31),
+        end: new Date(2024, 1, 28),
+      });
+      const expectedDuration = {
+        days: 28,
+      };
+
+      assert.deepStrictEqual(duration, expectedDuration);
+    });
+
+    it("returns correct duration for Jan 31 to Feb 28 on non-leap year", () => {
+      const duration = intervalToDuration({
+        start: new Date(2023, 0, 31),
+        end: new Date(2023, 1, 28),
+      });
+      const expectedDuration = {
+        months: 1,
+      };
+
+      assert.deepStrictEqual(duration, expectedDuration);
+    });
+
+    it("returns correct duration for Jan 31 to Feb 29 on leap year", () => {
+      const duration = intervalToDuration({
+        start: new Date(2024, 0, 31),
+        end: new Date(2024, 1, 29),
+      });
+      const expectedDuration = {
+        months: 1,
+      };
+
+      assert.deepStrictEqual(duration, expectedDuration);
+    });
   });
 });


### PR DESCRIPTION
### Problem

When calling `differenceInMonths` from January 31st to February 28th on a leap year, the logic for handling February does not account for the 29th. As a result `intervalToDuration` returns a duration of `1 month, -1 day`.

### Example

```
> differenceInMonths(new Date(2023, 1, 28), new Date(2023, 0, 31))
1
> differenceInMonths(new Date(2024, 1, 28), new Date(2024, 0, 31))
1
> intervalToDuration({ start: new Date(2023, 0, 31), end: new Date(2023, 1, 28) })
{ months: 1 }
> intervalToDuration({ start: new Date(2024, 0, 31), end: new Date(2024, 1, 28) })
{ months: 1, days: -1 }
> intervalToDuration({ start: new Date(2024, 0, 31), end: new Date(2024, 1, 29) })
{ months: 1 }
```
### Expected Output

```
> differenceInMonths(new Date(2023, 1, 28), new Date(2023, 0, 31))
1
> differenceInMonths(new Date(2024, 1, 28), new Date(2024, 0, 31))
0
> intervalToDuration({ start: new Date(2023, 0, 31), end: new Date(2023, 1, 28) })
{ months: 1 }
> intervalToDuration({ start: new Date(2024, 0, 31), end: new Date(2024, 1, 28) })
{ days: 28 }
> intervalToDuration({ start: new Date(2024, 0, 31), end: new Date(2024, 1, 29) })
{ months: 1 }
```

- [x] Ran tests
- [x] Ran linter