### PR TITLE
formatDuration: Include undefined values if formatting with zero option set to true

### DIFF
--- a/src/formatDuration/index.ts
+++ b/src/formatDuration/index.ts
@@ -105,7 +105,7 @@ export function formatDuration(
       const token = `x${unit.replace(/(^.)/, (m) =>
         m.toUpperCase(),
       )}` as FormatDistanceToken;
-      const value = duration[unit];
+      const value = duration[unit] ?? (zero ? 0 : undefined);
       if (value !== undefined && (zero || duration[unit])) {
         return acc.concat(locale.formatDistance(token, value));
       }

--- a/src/formatDuration/test.ts
+++ b/src/formatDuration/test.ts
@@ -77,4 +77,38 @@ describe("formatDuration", () => {
         "9 months, 2 days",
     );
   });
+
+  it("allows to provide a custom locale formatter", () => {
+    assert(
+      formatDuration(
+        {
+          hours: 1,
+          minutes: 10,
+          seconds: 30,
+        },
+        {
+          delimiter: ":",
+          format: ["hours", "minutes", "seconds"],
+          locale: {
+            formatDistance: (_, count) => String(count).padStart(2, "0"),
+          },
+          zero: true,
+        },
+      ) === "01:10:30",
+    );
+  });
+
+  it("includes undefined duration values when formatting if zero is true", () => {
+    assert(
+      formatDuration(
+        {
+          seconds: 10,
+        },
+        {
+          format: ["hours", "minutes", "seconds"],
+          zero: true,
+        },
+      ) === "0 hours 0 minutes 10 seconds",
+    );
+  });
 });


### PR DESCRIPTION
If I provide format values in `FormatDurationOptions` and set `zero` to `true`, I'm expecting also undefined  `Duration` values to be considered in the output.

Example

#### Input

```
formatDuration(
  {
    seconds: 10,
  },
  {
    format: ["hours", "minutes", "seconds"],
    zero: true,
  }
```

#### Actual output:

`10 seconds`

#### Expected output:
Since I've explicitly set hours, minutes, and seconds I'm expecting to see them as 0 in the output.

`0 hours 0 minutes 10 seconds
`

Note: It seems this was working like expected in 2.x but it is not working anymore in 3.x. 
If this is the wanted behaviour instead, I suggest to update the relative [doc](https://date-fns.org/v3.3.1/docs/formatDuration) in order to avoid misleading interpretations of `zero` param.