### PR TITLE
Add exact digits patterns (#916)

### DIFF
--- a/src/parse/_lib/constants.ts
+++ b/src/parse/_lib/constants.ts
@@ -16,14 +16,25 @@ export const numericPatterns = {
   fourDigits: /^\d{1,4}/, // 0 to 9999
 
   exactTwoDigits: /^\d{2}/, // 00 to 99
-  exactThreeDigits: /^\d{3}/, // 000 to 999
-  exactFourDigits: /^\d{4}/, // 0000 to 9999
+  exactThreeDigits: /^\d{3}/, // 00 to 99
+  exactFourDigits: /^\d{4}/, // 00 to 99
+
+  minSingleDigits: /^(?!0\d)\d+/, // more than 0
+  minTwoDigits: /(^(?!0\d)\d{3,})|(\d{2})/, // more than 00
+  minThreeDigits: /(^(?!0\d)\d{4,})|(\d{3})/, // more than 000
+  minFourDigits: /(^(?!0\d)\d{5,})|(\d{4})/, // more than 0000
 
   anyDigitsSigned: /^-?\d+/,
   singleDigitSigned: /^-?\d/, // 0 to 9, -0 to -9
   twoDigitsSigned: /^-?\d{1,2}/, // 0 to 99, -0 to -99
   threeDigitsSigned: /^-?\d{1,3}/, // 0 to 999, -0 to -999
   fourDigitsSigned: /^-?\d{1,4}/, // 0 to 9999, -0 to -9999
+
+  exactTwoDigitsSigned: /^-?\d{2}/, // 0 to 99, -0 to -99
+  exactThreeDigitsSigned: /^-?\d{3}/, // 0 to 999, -0 to -999
+  exactFourDigitsSigned: /^-?\d{4}/, // 0 to 9999, -0 to -9999
+
+  minSingleDigitSigned: /^-?(?!0\d)\d+/, // more than 0, less than -0, not starting with 0
 };
 
 export const timezonePatterns = {

--- a/src/parse/_lib/constants.ts
+++ b/src/parse/_lib/constants.ts
@@ -15,6 +15,10 @@ export const numericPatterns = {
   threeDigits: /^\d{1,3}/, // 0 to 999
   fourDigits: /^\d{1,4}/, // 0 to 9999
 
+  exactTwoDigits: /^\d{2}/, // 00 to 99
+  exactThreeDigits: /^\d{3}/, // 000 to 999
+  exactFourDigits: /^\d{4}/, // 0000 to 9999
+
   anyDigitsSigned: /^-?\d+/,
   singleDigitSigned: /^-?\d/, // 0 to 9, -0 to -9
   twoDigitsSigned: /^-?\d{1,2}/, // 0 to 99, -0 to -99

--- a/src/parse/_lib/parsers/DateParser.ts
+++ b/src/parse/_lib/parsers/DateParser.ts
@@ -1,10 +1,11 @@
 import type { Match } from "../../../locale/types.js";
 import { numericPatterns } from "../constants.js";
 import { Parser } from "../Parser.js";
-import type { ParseFlags, ParseResult } from "../types.js";
+import type { ParseFlags, ParseResult, ParserOptions } from "../types.js";
 import {
   isLeapYearIndex,
   parseNDigits,
+  parseMinNDigits,
   parseNumericPattern,
 } from "../utils.js";
 
@@ -18,14 +19,25 @@ export class DateParser extends Parser<number> {
   priority = 90;
   subPriority = 1;
 
-  parse(dateString: string, token: string, match: Match): ParseResult<number> {
+  parse(
+    dateString: string,
+    token: string,
+    match: Match,
+    options: ParserOptions,
+  ): ParseResult<number> {
     switch (token) {
-      case "d":
-        return parseNumericPattern(numericPatterns.date, dateString);
+      case "d": {
+        const pattern = options.strict
+          ? numericPatterns.minSingleDigits
+          : numericPatterns.date;
+        return parseNumericPattern(pattern, dateString);
+      }
       case "do":
         return match.ordinalNumber(dateString, { unit: "date" });
-      default:
-        return parseNDigits(token.length, dateString);
+      default: {
+        const parseFn = options.strict ? parseMinNDigits : parseNDigits;
+        return parseFn(token.length, dateString);
+      }
     }
   }
 

--- a/src/parse/_lib/parsers/DayOfYearParser.ts
+++ b/src/parse/_lib/parsers/DayOfYearParser.ts
@@ -1,11 +1,12 @@
 import type { Match } from "../../../locale/types.js";
 import { numericPatterns } from "../constants.js";
 import { Parser } from "../Parser.js";
-import type { ParseFlags, ParseResult } from "../types.js";
+import type { ParseFlags, ParseResult, ParserOptions } from "../types.js";
 import {
   isLeapYearIndex,
   parseNDigits,
   parseNumericPattern,
+  parseMinNDigits,
 } from "../utils.js";
 
 export class DayOfYearParser extends Parser<number> {
@@ -13,15 +14,24 @@ export class DayOfYearParser extends Parser<number> {
 
   subpriority = 1;
 
-  parse(dateString: string, token: string, match: Match): ParseResult<number> {
+  parse(
+    dateString: string,
+    token: string,
+    match: Match,
+    options: ParserOptions,
+  ): ParseResult<number> {
     switch (token) {
       case "D":
       case "DD":
-        return parseNumericPattern(numericPatterns.dayOfYear, dateString);
+        return options.strict
+          ? parseMinNDigits(token.length, dateString)
+          : parseNumericPattern(numericPatterns.dayOfYear, dateString);
       case "Do":
         return match.ordinalNumber(dateString, { unit: "date" });
-      default:
-        return parseNDigits(token.length, dateString);
+      default: {
+        const parseFn = options.strict ? parseMinNDigits : parseNDigits;
+        return parseFn(token.length, dateString);
+      }
     }
   }
 

--- a/src/parse/_lib/parsers/ExtendedYearParser.ts
+++ b/src/parse/_lib/parsers/ExtendedYearParser.ts
@@ -1,16 +1,38 @@
+import type { Match } from "../../../locale/types.js";
 import { Parser } from "../Parser.js";
-import type { ParseFlags, ParseResult } from "../types.js";
-import { parseNDigitsSigned } from "../utils.js";
+import { numericPatterns } from "../constants.js";
+import type { ParseFlags, ParseResult, ParserOptions } from "../types.js";
+import {
+  parseNDigitsSigned,
+  parseExactNDigitsSigned,
+  parseNumericPattern,
+} from "../utils.js";
 
 export class ExtendedYearParser extends Parser<number> {
   priority = 130;
 
-  parse(dateString: string, token: string): ParseResult<number> {
-    if (token === "u") {
-      return parseNDigitsSigned(4, dateString);
-    }
+  parse(
+    dateString: string,
+    token: string,
+    _: Match,
+    options: ParserOptions,
+  ): ParseResult<number> {
+    if (options.strict) {
+      if (token === "u") {
+        return parseNumericPattern(
+          numericPatterns.minSingleDigitSigned,
+          dateString,
+        );
+      }
 
-    return parseNDigitsSigned(token.length, dateString);
+      return parseExactNDigitsSigned(token.length, dateString);
+    } else {
+      if (token === "u") {
+        return parseNDigitsSigned(4, dateString);
+      }
+
+      return parseNDigitsSigned(token.length, dateString);
+    }
   }
 
   set<DateType extends Date>(

--- a/src/parse/_lib/parsers/FractionOfSecondParser.ts
+++ b/src/parse/_lib/parsers/FractionOfSecondParser.ts
@@ -1,14 +1,21 @@
+import type { Match } from "../../../locale/types.js";
 import { Parser } from "../Parser.js";
-import type { ParseFlags, ParseResult } from "../types.js";
-import { mapValue, parseNDigits } from "../utils.js";
+import type { ParseFlags, ParseResult, ParserOptions } from "../types.js";
+import { mapValue, parseNDigits, parseExactNDigits } from "../utils.js";
 
 export class FractionOfSecondParser extends Parser<number> {
   priority = 30;
 
-  parse(dateString: string, token: string): ParseResult<number> {
+  parse(
+    dateString: string,
+    token: string,
+    _: Match,
+    options: ParserOptions,
+  ): ParseResult<number> {
     const valueCallback = (value: number) =>
       Math.trunc(value * Math.pow(10, -token.length + 3));
-    return mapValue(parseNDigits(token.length, dateString), valueCallback);
+    const parseFn = options.strict ? parseExactNDigits : parseNDigits;
+    return mapValue(parseFn(token.length, dateString), valueCallback);
   }
 
   set<DateType extends Date>(

--- a/src/parse/_lib/parsers/Hour0To11Parser.ts
+++ b/src/parse/_lib/parsers/Hour0To11Parser.ts
@@ -1,20 +1,35 @@
 import type { Match } from "../../../locale/types.js";
 import { numericPatterns } from "../constants.js";
 import { Parser } from "../Parser.js";
-import type { ParseFlags, ParseResult } from "../types.js";
-import { parseNDigits, parseNumericPattern } from "../utils.js";
+import type { ParseFlags, ParseResult, ParserOptions } from "../types.js";
+import {
+  parseNDigits,
+  parseMinNDigits,
+  parseNumericPattern,
+} from "../utils.js";
 
 export class Hour0To11Parser extends Parser<number> {
   priority = 70;
 
-  parse(dateString: string, token: string, match: Match): ParseResult<number> {
+  parse(
+    dateString: string,
+    token: string,
+    match: Match,
+    options: ParserOptions,
+  ): ParseResult<number> {
     switch (token) {
-      case "K":
-        return parseNumericPattern(numericPatterns.hour11h, dateString);
+      case "K": {
+        const pattern = options.strict
+          ? numericPatterns.minSingleDigits
+          : numericPatterns.hour11h;
+        return parseNumericPattern(pattern, dateString);
+      }
       case "Ko":
         return match.ordinalNumber(dateString, { unit: "hour" });
-      default:
-        return parseNDigits(token.length, dateString);
+      default: {
+        const parseFn = options.strict ? parseMinNDigits : parseNDigits;
+        return parseFn(token.length, dateString);
+      }
     }
   }
 

--- a/src/parse/_lib/parsers/Hour0to23Parser.ts
+++ b/src/parse/_lib/parsers/Hour0to23Parser.ts
@@ -2,7 +2,7 @@ import type { Match } from "../../../locale/types.js";
 import { numericPatterns } from "../constants.js";
 import { Parser } from "../Parser.js";
 import type { ParseFlags, ParseResult } from "../types.js";
-import { parseNDigits, parseNumericPattern } from "../utils.js";
+import { parseNumericPattern } from "../utils.js";
 
 export class Hour0to23Parser extends Parser<number> {
   priority = 70;
@@ -14,7 +14,7 @@ export class Hour0to23Parser extends Parser<number> {
       case "Ho":
         return match.ordinalNumber(dateString, { unit: "hour" });
       default:
-        return parseNDigits(token.length, dateString);
+        return parseNumericPattern(numericPatterns.exactTwoDigits, dateString);
     }
   }
 

--- a/src/parse/_lib/parsers/Hour0to23Parser.ts
+++ b/src/parse/_lib/parsers/Hour0to23Parser.ts
@@ -1,20 +1,35 @@
 import type { Match } from "../../../locale/types.js";
 import { numericPatterns } from "../constants.js";
 import { Parser } from "../Parser.js";
-import type { ParseFlags, ParseResult } from "../types.js";
-import { parseNumericPattern } from "../utils.js";
+import type { ParseFlags, ParseResult, ParserOptions } from "../types.js";
+import {
+  parseNDigits,
+  parseNumericPattern,
+  parseMinNDigits,
+} from "../utils.js";
 
 export class Hour0to23Parser extends Parser<number> {
   priority = 70;
 
-  parse(dateString: string, token: string, match: Match): ParseResult<number> {
+  parse(
+    dateString: string,
+    token: string,
+    match: Match,
+    options: ParserOptions,
+  ): ParseResult<number> {
     switch (token) {
-      case "H":
-        return parseNumericPattern(numericPatterns.hour23h, dateString);
+      case "H": {
+        const pattern = options.strict
+          ? numericPatterns.minSingleDigits
+          : numericPatterns.hour23h;
+        return parseNumericPattern(pattern, dateString);
+      }
       case "Ho":
         return match.ordinalNumber(dateString, { unit: "hour" });
-      default:
-        return parseNumericPattern(numericPatterns.exactTwoDigits, dateString);
+      default: {
+        const parseFn = options.strict ? parseMinNDigits : parseNDigits;
+        return parseFn(token.length, dateString);
+      }
     }
   }
 

--- a/src/parse/_lib/parsers/Hour1To24Parser.ts
+++ b/src/parse/_lib/parsers/Hour1To24Parser.ts
@@ -1,20 +1,35 @@
 import type { Match } from "../../../locale/types.js";
 import { numericPatterns } from "../constants.js";
 import { Parser } from "../Parser.js";
-import type { ParseFlags, ParseResult } from "../types.js";
-import { parseNDigits, parseNumericPattern } from "../utils.js";
+import type { ParseFlags, ParseResult, ParserOptions } from "../types.js";
+import {
+  parseNDigits,
+  parseMinNDigits,
+  parseNumericPattern,
+} from "../utils.js";
 
 export class Hour1To24Parser extends Parser<number> {
   priority = 70;
 
-  parse(dateString: string, token: string, match: Match): ParseResult<number> {
+  parse(
+    dateString: string,
+    token: string,
+    match: Match,
+    options: ParserOptions,
+  ): ParseResult<number> {
     switch (token) {
-      case "k":
-        return parseNumericPattern(numericPatterns.hour24h, dateString);
+      case "k": {
+        const pattern = options.strict
+          ? numericPatterns.minSingleDigits
+          : numericPatterns.hour24h;
+        return parseNumericPattern(pattern, dateString);
+      }
       case "ko":
         return match.ordinalNumber(dateString, { unit: "hour" });
-      default:
-        return parseNDigits(token.length, dateString);
+      default: {
+        const parseFn = options.strict ? parseMinNDigits : parseNDigits;
+        return parseFn(token.length, dateString);
+      }
     }
   }
 

--- a/src/parse/_lib/parsers/Hour1to12Parser.ts
+++ b/src/parse/_lib/parsers/Hour1to12Parser.ts
@@ -2,7 +2,7 @@ import type { Match } from "../../../locale/types.js";
 import { numericPatterns } from "../constants.js";
 import { Parser } from "../Parser.js";
 import type { ParseFlags, ParseResult } from "../types.js";
-import { parseNDigits, parseNumericPattern } from "../utils.js";
+import { parseNumericPattern } from "../utils.js";
 
 export class Hour1to12Parser extends Parser<number> {
   priority = 70;
@@ -14,7 +14,7 @@ export class Hour1to12Parser extends Parser<number> {
       case "ho":
         return match.ordinalNumber(dateString, { unit: "hour" });
       default:
-        return parseNDigits(token.length, dateString);
+        return parseNumericPattern(numericPatterns.exactTwoDigits, dateString);
     }
   }
 

--- a/src/parse/_lib/parsers/Hour1to12Parser.ts
+++ b/src/parse/_lib/parsers/Hour1to12Parser.ts
@@ -1,20 +1,35 @@
 import type { Match } from "../../../locale/types.js";
 import { numericPatterns } from "../constants.js";
 import { Parser } from "../Parser.js";
-import type { ParseFlags, ParseResult } from "../types.js";
-import { parseNumericPattern } from "../utils.js";
+import type { ParseFlags, ParseResult, ParserOptions } from "../types.js";
+import {
+  parseNDigits,
+  parseNumericPattern,
+  parseMinNDigits,
+} from "../utils.js";
 
 export class Hour1to12Parser extends Parser<number> {
   priority = 70;
 
-  parse(dateString: string, token: string, match: Match): ParseResult<number> {
+  parse(
+    dateString: string,
+    token: string,
+    match: Match,
+    options: ParserOptions,
+  ): ParseResult<number> {
     switch (token) {
-      case "h":
-        return parseNumericPattern(numericPatterns.hour12h, dateString);
+      case "h": {
+        const pattern = options.strict
+          ? numericPatterns.minSingleDigits
+          : numericPatterns.hour12h;
+        return parseNumericPattern(pattern, dateString);
+      }
       case "ho":
         return match.ordinalNumber(dateString, { unit: "hour" });
-      default:
-        return parseNumericPattern(numericPatterns.exactTwoDigits, dateString);
+      default: {
+        const parseFn = options.strict ? parseMinNDigits : parseNDigits;
+        return parseFn(token.length, dateString);
+      }
     }
   }
 

--- a/src/parse/_lib/parsers/ISODayParser.ts
+++ b/src/parse/_lib/parsers/ISODayParser.ts
@@ -1,14 +1,19 @@
 import type { Match } from "../../../locale/types.js";
 import { setISODay } from "../../../setISODay/index.js";
 import { Parser } from "../Parser.js";
-import type { ParseFlags, ParseResult } from "../types.js";
-import { mapValue, parseNDigits } from "../utils.js";
+import type { ParseFlags, ParseResult, ParserOptions } from "../types.js";
+import { mapValue, parseNDigits, parseMinNDigits } from "../utils.js";
 
 // ISO day of week
 export class ISODayParser extends Parser<number> {
   priority = 90;
 
-  parse(dateString: string, token: string, match: Match): ParseResult<number> {
+  parse(
+    dateString: string,
+    token: string,
+    match: Match,
+    options: ParserOptions,
+  ): ParseResult<number> {
     const valueCallback = (value: number) => {
       if (value === 0) {
         return 7;
@@ -20,7 +25,9 @@ export class ISODayParser extends Parser<number> {
       // 2
       case "i":
       case "ii": // 02
-        return parseNDigits(token.length, dateString);
+        return options.strict
+          ? parseMinNDigits(token.length, dateString)
+          : parseNDigits(token.length, dateString);
       // 2nd
       case "io":
         return match.ordinalNumber(dateString, { unit: "day" });

--- a/src/parse/_lib/parsers/ISOWeekParser.ts
+++ b/src/parse/_lib/parsers/ISOWeekParser.ts
@@ -3,21 +3,36 @@ import { setISOWeek } from "../../../setISOWeek/index.js";
 import { startOfISOWeek } from "../../../startOfISOWeek/index.js";
 import { numericPatterns } from "../constants.js";
 import { Parser } from "../Parser.js";
-import type { ParseFlags, ParseResult } from "../types.js";
-import { parseNDigits, parseNumericPattern } from "../utils.js";
+import type { ParseFlags, ParseResult, ParserOptions } from "../types.js";
+import {
+  parseNDigits,
+  parseMinNDigits,
+  parseNumericPattern,
+} from "../utils.js";
 
 // ISO week of year
 export class ISOWeekParser extends Parser<number> {
   priority = 100;
 
-  parse(dateString: string, token: string, match: Match): ParseResult<number> {
+  parse(
+    dateString: string,
+    token: string,
+    match: Match,
+    options: ParserOptions,
+  ): ParseResult<number> {
     switch (token) {
-      case "I":
-        return parseNumericPattern(numericPatterns.week, dateString);
+      case "I": {
+        const pattern = options.strict
+          ? numericPatterns.minSingleDigits
+          : numericPatterns.week;
+        return parseNumericPattern(pattern, dateString);
+      }
       case "Io":
         return match.ordinalNumber(dateString, { unit: "week" });
-      default:
-        return parseNDigits(token.length, dateString);
+      default: {
+        const parseFn = options.strict ? parseMinNDigits : parseNDigits;
+        return parseFn(token.length, dateString);
+      }
     }
   }
 

--- a/src/parse/_lib/parsers/ISOWeekYearParser.ts
+++ b/src/parse/_lib/parsers/ISOWeekYearParser.ts
@@ -1,19 +1,41 @@
+import type { Match } from "../../../locale/types.js";
 import { startOfISOWeek } from "../../../startOfISOWeek/index.js";
 import { constructFrom } from "../../../constructFrom/index.js";
 import { Parser } from "../Parser.js";
-import type { ParseFlags, ParseResult } from "../types.js";
-import { parseNDigitsSigned } from "../utils.js";
+import type { ParseFlags, ParseResult, ParserOptions } from "../types.js";
+import {
+  parseExactNDigitsSigned,
+  parseNDigitsSigned,
+  parseNumericPattern,
+} from "../utils.js";
+import { numericPatterns } from "../constants.js";
 
 // ISO week-numbering year
 export class ISOWeekYearParser extends Parser<number> {
   priority = 130;
 
-  parse(dateString: string, token: string): ParseResult<number> {
-    if (token === "R") {
-      return parseNDigitsSigned(4, dateString);
-    }
+  parse(
+    dateString: string,
+    token: string,
+    _: Match,
+    options: ParserOptions,
+  ): ParseResult<number> {
+    if (options.strict) {
+      if (token === "R") {
+        return parseNumericPattern(
+          numericPatterns.minSingleDigitSigned,
+          dateString,
+        );
+      }
 
-    return parseNDigitsSigned(token.length, dateString);
+      return parseExactNDigitsSigned(token.length, dateString);
+    } else {
+      if (token === "R") {
+        return parseNDigitsSigned(4, dateString);
+      }
+
+      return parseNDigitsSigned(token.length, dateString);
+    }
   }
 
   set<DateType extends Date>(

--- a/src/parse/_lib/parsers/LocalDayParser.ts
+++ b/src/parse/_lib/parsers/LocalDayParser.ts
@@ -2,7 +2,7 @@ import type { Match } from "../../../locale/types.js";
 import { setDay } from "../../../setDay/index.js";
 import { Parser } from "../Parser.js";
 import type { ParseFlags, ParseResult, ParserOptions } from "../types.js";
-import { mapValue, parseNDigits } from "../utils.js";
+import { mapValue, parseNDigits, parseMinNDigits } from "../utils.js";
 
 // Local day of week
 export class LocalDayParser extends Parser<number> {
@@ -21,9 +21,12 @@ export class LocalDayParser extends Parser<number> {
 
     switch (token) {
       // 3
+      // 03
       case "e":
-      case "ee": // 03
-        return mapValue(parseNDigits(token.length, dateString), valueCallback);
+      case "ee": {
+        const parseFn = options.strict ? parseMinNDigits : parseNDigits;
+        return mapValue(parseFn(token.length, dateString), valueCallback);
+      }
       // 3rd
       case "eo":
         return mapValue(

--- a/src/parse/_lib/parsers/LocalWeekParser.ts
+++ b/src/parse/_lib/parsers/LocalWeekParser.ts
@@ -4,20 +4,35 @@ import { startOfWeek } from "../../../startOfWeek/index.js";
 import { numericPatterns } from "../constants.js";
 import { Parser } from "../Parser.js";
 import type { ParseFlags, ParseResult, ParserOptions } from "../types.js";
-import { parseNDigits, parseNumericPattern } from "../utils.js";
+import {
+  parseNDigits,
+  parseMinNDigits,
+  parseNumericPattern,
+} from "../utils.js";
 
 // Local week of year
 export class LocalWeekParser extends Parser<number> {
   priority = 100;
 
-  parse(dateString: string, token: string, match: Match): ParseResult<number> {
+  parse(
+    dateString: string,
+    token: string,
+    match: Match,
+    options: ParserOptions,
+  ): ParseResult<number> {
     switch (token) {
-      case "w":
-        return parseNumericPattern(numericPatterns.week, dateString);
+      case "w": {
+        const pattern = options.strict
+          ? numericPatterns.minSingleDigits
+          : numericPatterns.week;
+        return parseNumericPattern(pattern, dateString);
+      }
       case "wo":
         return match.ordinalNumber(dateString, { unit: "week" });
-      default:
-        return parseNDigits(token.length, dateString);
+      default: {
+        const parseFn = options.strict ? parseMinNDigits : parseNDigits;
+        return parseFn(token.length, dateString);
+      }
     }
   }
 

--- a/src/parse/_lib/parsers/MinuteParser.ts
+++ b/src/parse/_lib/parsers/MinuteParser.ts
@@ -2,7 +2,7 @@ import type { Match } from "../../../locale/types.js";
 import { numericPatterns } from "../constants.js";
 import { Parser } from "../Parser.js";
 import type { ParseFlags, ParseResult } from "../types.js";
-import { parseNDigits, parseNumericPattern } from "../utils.js";
+import { parseNumericPattern } from "../utils.js";
 
 export class MinuteParser extends Parser<number> {
   priority = 60;
@@ -14,7 +14,7 @@ export class MinuteParser extends Parser<number> {
       case "mo":
         return match.ordinalNumber(dateString, { unit: "minute" });
       default:
-        return parseNDigits(token.length, dateString);
+        return parseNumericPattern(numericPatterns.exactTwoDigits, dateString);
     }
   }
 

--- a/src/parse/_lib/parsers/MinuteParser.ts
+++ b/src/parse/_lib/parsers/MinuteParser.ts
@@ -1,20 +1,33 @@
 import type { Match } from "../../../locale/types.js";
 import { numericPatterns } from "../constants.js";
 import { Parser } from "../Parser.js";
-import type { ParseFlags, ParseResult } from "../types.js";
+import type { ParseFlags, ParseResult, ParserOptions } from "../types.js";
 import { parseNumericPattern } from "../utils.js";
 
 export class MinuteParser extends Parser<number> {
   priority = 60;
 
-  parse(dateString: string, token: string, match: Match): ParseResult<number> {
+  parse(
+    dateString: string,
+    token: string,
+    match: Match,
+    options: ParserOptions,
+  ): ParseResult<number> {
     switch (token) {
-      case "m":
-        return parseNumericPattern(numericPatterns.minute, dateString);
+      case "m": {
+        const pattern = options.strict
+          ? numericPatterns.minSingleDigits
+          : numericPatterns.minute;
+        return parseNumericPattern(pattern, dateString);
+      }
       case "mo":
         return match.ordinalNumber(dateString, { unit: "minute" });
-      default:
-        return parseNumericPattern(numericPatterns.exactTwoDigits, dateString);
+      default: {
+        const pattern = options.strict
+          ? numericPatterns.minTwoDigits
+          : numericPatterns.twoDigits;
+        return parseNumericPattern(pattern, dateString);
+      }
     }
   }
 

--- a/src/parse/_lib/parsers/QuarterParser.ts
+++ b/src/parse/_lib/parsers/QuarterParser.ts
@@ -1,17 +1,25 @@
 import type { Match } from "../../../locale/types.js";
 import { Parser } from "../Parser.js";
-import type { ParseFlags, ParseResult } from "../types.js";
-import { parseNDigits } from "../utils.js";
+import type { ParseFlags, ParseResult, ParserOptions } from "../types.js";
+import { parseNDigits, parseMinNDigits } from "../utils.js";
 
 export class QuarterParser extends Parser<number> {
   priority = 120;
 
-  parse(dateString: string, token: string, match: Match): ParseResult<number> {
+  parse(
+    dateString: string,
+    token: string,
+    match: Match,
+    options: ParserOptions,
+  ): ParseResult<number> {
     switch (token) {
       // 1, 2, 3, 4
       case "Q":
-      case "QQ": // 01, 02, 03, 04
-        return parseNDigits(token.length, dateString);
+      case "QQ": {
+        // 01, 02, 03, 04
+        const parseFn = options.strict ? parseMinNDigits : parseNDigits;
+        return parseFn(token.length, dateString);
+      }
       // 1st, 2nd, 3rd, 4th
       case "Qo":
         return match.ordinalNumber(dateString, { unit: "quarter" });

--- a/src/parse/_lib/parsers/SecondParser.ts
+++ b/src/parse/_lib/parsers/SecondParser.ts
@@ -2,7 +2,7 @@ import type { Match } from "../../../locale/types.js";
 import { numericPatterns } from "../constants.js";
 import { Parser } from "../Parser.js";
 import type { ParseFlags, ParseResult } from "../types.js";
-import { parseNDigits, parseNumericPattern } from "../utils.js";
+import { parseNumericPattern } from "../utils.js";
 
 export class SecondParser extends Parser<number> {
   priority = 50;
@@ -14,7 +14,7 @@ export class SecondParser extends Parser<number> {
       case "so":
         return match.ordinalNumber(dateString, { unit: "second" });
       default:
-        return parseNDigits(token.length, dateString);
+        return parseNumericPattern(numericPatterns.exactTwoDigits, dateString);
     }
   }
 

--- a/src/parse/_lib/parsers/SecondParser.ts
+++ b/src/parse/_lib/parsers/SecondParser.ts
@@ -1,20 +1,33 @@
 import type { Match } from "../../../locale/types.js";
 import { numericPatterns } from "../constants.js";
 import { Parser } from "../Parser.js";
-import type { ParseFlags, ParseResult } from "../types.js";
+import type { ParseFlags, ParseResult, ParserOptions } from "../types.js";
 import { parseNumericPattern } from "../utils.js";
 
 export class SecondParser extends Parser<number> {
   priority = 50;
 
-  parse(dateString: string, token: string, match: Match): ParseResult<number> {
+  parse(
+    dateString: string,
+    token: string,
+    match: Match,
+    options: ParserOptions,
+  ): ParseResult<number> {
     switch (token) {
-      case "s":
-        return parseNumericPattern(numericPatterns.second, dateString);
+      case "s": {
+        const pattern = options.strict
+          ? numericPatterns.minSingleDigits
+          : numericPatterns.second;
+        return parseNumericPattern(pattern, dateString);
+      }
       case "so":
         return match.ordinalNumber(dateString, { unit: "second" });
-      default:
-        return parseNumericPattern(numericPatterns.exactTwoDigits, dateString);
+      default: {
+        const pattern = options.strict
+          ? numericPatterns.minTwoDigits
+          : numericPatterns.twoDigits;
+        return parseNumericPattern(pattern, dateString);
+      }
     }
   }
 

--- a/src/parse/_lib/parsers/StandAloneLocalDayParser.ts
+++ b/src/parse/_lib/parsers/StandAloneLocalDayParser.ts
@@ -2,7 +2,7 @@ import type { Match } from "../../../locale/types.js";
 import { setDay } from "../../../setDay/index.js";
 import { Parser } from "../Parser.js";
 import type { ParseFlags, ParseResult, ParserOptions } from "../types.js";
-import { mapValue, parseNDigits } from "../utils.js";
+import { mapValue, parseNDigits, parseMinNDigits } from "../utils.js";
 
 // Stand-alone local day of week
 export class StandAloneLocalDayParser extends Parser<number> {
@@ -22,9 +22,12 @@ export class StandAloneLocalDayParser extends Parser<number> {
 
     switch (token) {
       // 3
+      // 03
       case "c":
-      case "cc": // 03
-        return mapValue(parseNDigits(token.length, dateString), valueCallback);
+      case "cc": {
+        const parseFn = options.strict ? parseMinNDigits : parseNDigits;
+        return mapValue(parseFn(token.length, dateString), valueCallback);
+      }
       // 3rd
       case "co":
         return mapValue(

--- a/src/parse/_lib/parsers/StandAloneMonthParser.ts
+++ b/src/parse/_lib/parsers/StandAloneMonthParser.ts
@@ -1,25 +1,41 @@
 import type { Match } from "../../../locale/types.js";
 import { numericPatterns } from "../constants.js";
 import { Parser } from "../Parser.js";
-import type { ParseFlags, ParseResult } from "../types.js";
-import { mapValue, parseNDigits, parseNumericPattern } from "../utils.js";
+import type { ParseFlags, ParseResult, ParserOptions } from "../types.js";
+import {
+  mapValue,
+  parseNDigits,
+  parseMinNDigits,
+  parseNumericPattern,
+} from "../utils.js";
 
 export class StandAloneMonthParser extends Parser<number> {
   priority = 110;
 
-  parse(dateString: string, token: string, match: Match): ParseResult<number> {
+  parse(
+    dateString: string,
+    token: string,
+    match: Match,
+    options: ParserOptions,
+  ): ParseResult<number> {
     const valueCallback = (value: number) => value - 1;
 
     switch (token) {
       // 1, 2, ..., 12
-      case "L":
+      case "L": {
+        const pattern = options.strict
+          ? numericPatterns.minSingleDigits
+          : numericPatterns.month;
         return mapValue(
-          parseNumericPattern(numericPatterns.month, dateString),
+          parseNumericPattern(pattern, dateString),
           valueCallback,
         );
+      }
       // 01, 02, ..., 12
-      case "LL":
-        return mapValue(parseNDigits(2, dateString), valueCallback);
+      case "LL": {
+        const parseFn = options.strict ? parseMinNDigits : parseNDigits;
+        return mapValue(parseFn(2, dateString), valueCallback);
+      }
       // 1st, 2nd, ..., 12th
       case "Lo":
         return mapValue(

--- a/src/parse/_lib/parsers/StandAloneQuarterParser.ts
+++ b/src/parse/_lib/parsers/StandAloneQuarterParser.ts
@@ -1,17 +1,25 @@
 import type { Match } from "../../../locale/types.js";
 import { Parser } from "../Parser.js";
-import type { ParseFlags, ParseResult } from "../types.js";
-import { parseNDigits } from "../utils.js";
+import type { ParseFlags, ParseResult, ParserOptions } from "../types.js";
+import { parseNDigits, parseMinNDigits } from "../utils.js";
 
 export class StandAloneQuarterParser extends Parser<number> {
   priority = 120;
 
-  parse(dateString: string, token: string, match: Match): ParseResult<number> {
+  parse(
+    dateString: string,
+    token: string,
+    match: Match,
+    options: ParserOptions,
+  ): ParseResult<number> {
     switch (token) {
       // 1, 2, 3, 4
       case "q":
-      case "qq": // 01, 02, 03, 04
-        return parseNDigits(token.length, dateString);
+      case "qq": {
+        // 01, 02, 03, 04
+        const parseFn = options.strict ? parseMinNDigits : parseNDigits;
+        return parseFn(token.length, dateString);
+      }
       // 1st, 2nd, 3rd, 4th
       case "qo":
         return match.ordinalNumber(dateString, { unit: "quarter" });

--- a/src/parse/_lib/types.ts
+++ b/src/parse/_lib/types.ts
@@ -9,8 +9,15 @@ export interface ParseFlags {
   era?: number;
 }
 
+export type StrictModeOptions = {
+  strict?: boolean;
+};
+
 export type ParserOptions = Required<
-  LocalizedOptions<"options"> & FirstWeekContainsDateOptions & WeekOptions
+  LocalizedOptions<"options"> &
+    FirstWeekContainsDateOptions &
+    WeekOptions &
+    StrictModeOptions
 >;
 
 export type ParseResult<TValue> = { value: TValue; rest: string } | null;

--- a/src/parse/_lib/utils.ts
+++ b/src/parse/_lib/utils.ts
@@ -92,6 +92,46 @@ export function parseNDigits(
   }
 }
 
+export function parseMinNDigits(
+  n: number,
+  dateString: string,
+): ParseResult<number> {
+  switch (n) {
+    case 1:
+      return parseNumericPattern(numericPatterns.minSingleDigits, dateString);
+    case 2:
+      return parseNumericPattern(numericPatterns.minTwoDigits, dateString);
+    case 3:
+      return parseNumericPattern(numericPatterns.minThreeDigits, dateString);
+    case 4:
+      return parseNumericPattern(numericPatterns.minFourDigits, dateString);
+    default: {
+      return parseNumericPattern(
+        new RegExp(`(^(?!0\\d)\\d{${n + 1},})|(\\d{${n}})`),
+        dateString,
+      );
+    }
+  }
+}
+
+export function parseExactNDigits(
+  n: number,
+  dateString: string,
+): ParseResult<number> {
+  switch (n) {
+    case 1:
+      return parseNumericPattern(numericPatterns.singleDigit, dateString);
+    case 2:
+      return parseNumericPattern(numericPatterns.exactTwoDigits, dateString);
+    case 3:
+      return parseNumericPattern(numericPatterns.exactThreeDigits, dateString);
+    case 4:
+      return parseNumericPattern(numericPatterns.exactFourDigits, dateString);
+    default:
+      return parseNumericPattern(new RegExp(`^\\d{${n}}`), dateString);
+  }
+}
+
 export function parseNDigitsSigned(
   n: number,
   dateString: string,
@@ -107,6 +147,33 @@ export function parseNDigitsSigned(
       return parseNumericPattern(numericPatterns.fourDigitsSigned, dateString);
     default:
       return parseNumericPattern(new RegExp("^-?\\d{1," + n + "}"), dateString);
+  }
+}
+
+export function parseExactNDigitsSigned(
+  n: number,
+  dateString: string,
+): ParseResult<number> {
+  switch (n) {
+    case 1:
+      return parseNumericPattern(numericPatterns.singleDigitSigned, dateString);
+    case 2:
+      return parseNumericPattern(
+        numericPatterns.exactTwoDigitsSigned,
+        dateString,
+      );
+    case 3:
+      return parseNumericPattern(
+        numericPatterns.exactThreeDigitsSigned,
+        dateString,
+      );
+    case 4:
+      return parseNumericPattern(
+        numericPatterns.exactFourDigitsSigned,
+        dateString,
+      );
+    default:
+      return parseNumericPattern(new RegExp("^-?\\d{" + n + "}"), dateString);
   }
 }
 

--- a/src/parse/index.ts
+++ b/src/parse/index.ts
@@ -17,7 +17,11 @@ import {
 import { parsers } from "./_lib/parsers/index.js";
 import type { Setter } from "./_lib/Setter.js";
 import { DateToSystemTimezoneSetter } from "./_lib/Setter.js";
-import type { ParseFlags, ParserOptions } from "./_lib/types.js";
+import type {
+  ParseFlags,
+  ParserOptions,
+  StrictModeOptions,
+} from "./_lib/types.js";
 
 // Rexports of internal for libraries to use.
 // See: https://github.com/date-fns/date-fns/issues/3638#issuecomment-1877082874
@@ -30,7 +34,8 @@ export interface ParseOptions
   extends LocalizedOptions<"options" | "match" | "formatLong">,
     FirstWeekContainsDateOptions,
     WeekOptions,
-    AdditionalTokensOptions {}
+    AdditionalTokensOptions,
+    StrictModeOptions {}
 
 // This RegExp consists of three parts separated by `|`:
 // - [yYQqMLwIdDecihHKkms]o matches any available ordinal number token
@@ -376,6 +381,8 @@ export function parse<DateType extends Date>(
     defaultOptions.locale?.options?.weekStartsOn ??
     0;
 
+  const strict = options?.strict ?? false;
+
   if (formatStr === "") {
     if (dateStr === "") {
       return toDate(referenceDate);
@@ -388,6 +395,7 @@ export function parse<DateType extends Date>(
     firstWeekContainsDate,
     weekStartsOn,
     locale,
+    strict,
   };
 
   // If timezone isn't specified, it will be set to the system timezone

--- a/src/parse/test.ts
+++ b/src/parse/test.ts
@@ -2259,6 +2259,13 @@ describe("parse", () => {
       expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
     });
 
+    it("H, h, m, s parsers returns Invalid Date if the digits of `formatString` does not match exactly that of the `datestring`", () => {
+      ["HH", "hh", "mm", "ss"].forEach((token) => {
+        const result = parse("1", token, referenceDate);
+        assert(result instanceof Date && isNaN(result.getTime()));
+      });
+    });
+
     it("parses normally if the remaining input is just whitespace", () => {
       const result = parse("2016-11-05   \n", "yyyy-MM-dd", referenceDate);
       expect(result).toEqual(new Date(2016, 10 /* Nov */, 5));


### PR DESCRIPTION
description
- Issue fixes #916
- Added a new pattern: `exactNDigits`
- Modified `HH`, `mm`, `ss` parser to use exact digits patterns.

comment

- I feagured out that the original flexible digit patterns (twoDigits, threeDigits, fourDigits) are pretty universally used, including `y` and `Y`, as well as the thing kind of `mm`.
- It seems that a new pattern needs to be added to make the `y`, `Y` format also check the digit strictly as they said in the issue.
- But first of all, I wanted to ask your opinion, so I modified only the pattern of `mm`, `ss`, and `hh` format that people need the most in that issue.
- Do you agree to be revised in this direction?

Plus
- In moment.js, strictly can be chosen with a third argument.
```
moment('04:3:00', 'HH:mm:ss', true) // strict
moment('04:3:00', 'HH:mm:ss') // not strict

```
- I think it's better for backward compatibility
- what do think of it?