### PR TITLE
Fix some urls in the codebase

### DIFF
--- a/docs/i18nContributionGuide.md
+++ b/docs/i18nContributionGuide.md
@@ -51,7 +51,7 @@ To add a new locale:
 - Copy the content of an existing locale (e.g. `en-US`) into the newly created directory.
 
 - Replace the values in the content with yours file-by-file.
-  Use [CLDR data](https://www.unicode.org/cldr/charts/32/summary/root.html)
+  Use [CLDR data](https://www.unicode.org/cldr/charts/44/summary/root.html)
   as a point of reference which values to choose.
 
 All locales contain a number of properties:

--- a/src/_lib/format/lightFormatters/index.ts
+++ b/src/_lib/format/lightFormatters/index.ts
@@ -16,7 +16,7 @@ import { addLeadingZeros } from "../../addLeadingZeros/index.js";
 export const lightFormatters = {
   // Year
   y(date: Date, token: string): string {
-    // From http://www.unicode.org/reports/tr35/tr35-31/tr35-dates.html#Date_Format_tokens
+    // From https://www.unicode.org/reports/tr35/tr35-31/tr35-dates.html#Date_Format_tokens
     // | Year     |     y | yy |   yyy |  yyyy | yyyyy |
     // |----------|-------|----|-------|-------|-------|
     // | AD 1     |     1 | 01 |   001 |  0001 | 00001 |

--- a/src/_lib/protectedTokens/index.ts
+++ b/src/_lib/protectedTokens/index.ts
@@ -23,5 +23,5 @@ export function warnOrThrowProtectedError(
 
 function message(token: string, format: string, input: string) {
   const subject = token[0] === "Y" ? "years" : "days of the month";
-  return `Use \`${token.toLowerCase()}\` instead of \`${token}\` (in \`${format}\`) for formatting ${subject} to the input \`${input}\`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md`;
+  return `Use \`${token.toLowerCase()}\` instead of \`${token}\` (in \`${format}\`) for formatting ${subject} to the input \`${input}\`; see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md`;
 }

--- a/src/addISOWeekYears/index.ts
+++ b/src/addISOWeekYears/index.ts
@@ -9,7 +9,7 @@ import { setISOWeekYear } from "../setISOWeekYear/index.js";
  * @description
  * Add the specified number of ISO week-numbering years to the given date.
  *
- * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ * ISO week-numbering year: https://en.wikipedia.org/wiki/ISO_week_date
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/differenceInCalendarISOWeekYears/index.ts
+++ b/src/differenceInCalendarISOWeekYears/index.ts
@@ -8,7 +8,7 @@ import { getISOWeekYear } from "../getISOWeekYear/index.js";
  * @description
  * Get the number of calendar ISO week-numbering years between the given dates.
  *
- * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ * ISO week-numbering year: https://en.wikipedia.org/wiki/ISO_week_date
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/differenceInCalendarISOWeeks/index.ts
+++ b/src/differenceInCalendarISOWeeks/index.ts
@@ -10,7 +10,7 @@ import { getTimezoneOffsetInMilliseconds } from "../_lib/getTimezoneOffsetInMill
  * @description
  * Get the number of calendar ISO weeks between the given dates.
  *
- * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ * ISO week-numbering year: https://en.wikipedia.org/wiki/ISO_week_date
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/differenceInISOWeekYears/index.ts
+++ b/src/differenceInISOWeekYears/index.ts
@@ -11,7 +11,7 @@ import { toDate } from "../toDate/index.js";
  * @description
  * Get the number of full ISO week-numbering years between the given dates.
  *
- * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ * ISO week-numbering year: https://en.wikipedia.org/wiki/ISO_week_date
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/endOfISOWeek/index.ts
+++ b/src/endOfISOWeek/index.ts
@@ -9,7 +9,7 @@ import { endOfWeek } from "../endOfWeek/index.js";
  * Return the end of an ISO week for the given date.
  * The result will be in the local timezone.
  *
- * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ * ISO week-numbering year: https://en.wikipedia.org/wiki/ISO_week_date
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/endOfISOWeekYear/index.ts
+++ b/src/endOfISOWeekYear/index.ts
@@ -12,7 +12,7 @@ import { constructFrom } from "../constructFrom/index.js";
  * which always starts 3 days before the year's first Thursday.
  * The result will be in the local timezone.
  *
- * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ * ISO week-numbering year: https://en.wikipedia.org/wiki/ISO_week_date
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/format/index.ts
+++ b/src/format/index.ts
@@ -65,7 +65,7 @@ export interface FormatOptions
  * Return the formatted date string in the given format. The result may vary by locale.
  *
  * > ⚠️ Please note that the `format` tokens differ from Moment.js and other libraries.
- * > See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * > See: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
  *
  * The characters wrapped between two single quotes characters (') are escaped.
  * Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.
@@ -301,10 +301,10 @@ export interface FormatOptions
  *    - `p`: long localized time
  *
  * 8. `YY` and `YYYY` tokens represent week-numbering years but they are often confused with years.
- *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
  *
  * 9. `D` and `DD` tokens represent days of the year but they are often confused with days of the month.
- *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *
@@ -317,10 +317,10 @@ export interface FormatOptions
  * @throws `date` must not be Invalid Date
  * @throws `options.locale` must contain `localize` property
  * @throws `options.locale` must contain `formatLong` property
- * @throws use `yyyy` instead of `YYYY` for formatting years using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
- * @throws use `yy` instead of `YY` for formatting years using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
- * @throws use `d` instead of `D` for formatting days of the month using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
- * @throws use `dd` instead of `DD` for formatting days of the month using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * @throws use `yyyy` instead of `YYYY` for formatting years using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
+ * @throws use `yy` instead of `YY` for formatting years using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
+ * @throws use `d` instead of `D` for formatting days of the month using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
+ * @throws use `dd` instead of `DD` for formatting days of the month using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
  * @throws format string contains an unescaped latin alphabet character
  *
  * @example

--- a/src/format/test.ts
+++ b/src/format/test.ts
@@ -64,7 +64,9 @@ describe("format", () => {
 
   it("alias formatDate has same behavior as format", () => {
     const date = new Date(2014, 3, 4, 5);
-    expect(formatDate(date, "yyyy-MM-dd'\n'HH:mm:ss")).toBe(format(date, "yyyy-MM-dd'\n'HH:mm:ss"));
+    expect(formatDate(date, "yyyy-MM-dd'\n'HH:mm:ss")).toBe(
+      format(date, "yyyy-MM-dd'\n'HH:mm:ss"),
+    );
   });
 
   describe("ordinal numbers", () => {
@@ -507,12 +509,16 @@ describe("format", () => {
 
       it("12 PM", () => {
         const date = new Date(1986, 3 /* Apr */, 4, 12, 0, 0, 900);
-        expect(format(date, "b bb bbb bbbb bbbbb")).toBe("noon noon noon noon n");
+        expect(format(date, "b bb bbb bbbb bbbbb")).toBe(
+          "noon noon noon noon n",
+        );
       });
 
       it("12 AM", () => {
         const date = new Date(1986, 3 /* Apr */, 6, 0, 0, 0, 900);
-        expect(format(date, "b bb bbb bbbb bbbbb")).toBe("midnight midnight midnight midnight mi");
+        expect(format(date, "b bb bbb bbbb bbbbb")).toBe(
+          "midnight midnight midnight midnight mi",
+        );
       });
     });
 
@@ -520,7 +526,7 @@ describe("format", () => {
       it("works as expected", () => {
         const result = format(date, "B, BB, BBB, BBBB, BBBBB");
         expect(result).toBe(
-          "in the morning, in the morning, in the morning, in the morning, in the morning"
+          "in the morning, in the morning, in the morning, in the morning, in the morning",
         );
       });
 
@@ -626,7 +632,9 @@ describe("format", () => {
 
       getTimezoneOffsetStub.returns(450);
       const resultNegative30Offset = format(date, "O OO OOO OOOO");
-      expect(resultNegative30Offset).toBe("GMT-7:30 GMT-7:30 GMT-7:30 GMT-07:30");
+      expect(resultNegative30Offset).toBe(
+        "GMT-7:30 GMT-7:30 GMT-7:30 GMT-07:30",
+      );
 
       getTimezoneOffsetStub.restore();
     });
@@ -718,7 +726,9 @@ describe("format", () => {
 
     it("full date + time", () => {
       const result = format(date, "PPPPpppp");
-      expect(result).toBe("Friday, April 4th, 1986 at 10:32:55 AM " + timezoneGMT);
+      expect(result).toBe(
+        "Friday, April 4th, 1986 at 10:32:55 AM " + timezoneGMT,
+      );
     });
 
     it("allows arbitrary combination of date and time", () => {
@@ -729,7 +739,9 @@ describe("format", () => {
 
   describe("edge cases", () => {
     it("throws RangeError if the time value is invalid", () => {
-      expect(format.bind(null, new Date(NaN), "MMMM d, yyyy")).toThrow(RangeError);
+      expect(format.bind(null, new Date(NaN), "MMMM d, yyyy")).toThrow(
+        RangeError,
+      );
     });
 
     it("handles dates before 100 AD", () => {
@@ -869,7 +881,7 @@ describe("format", () => {
         expect(warn).toBeCalledWith(
           "Use `d` instead of `D` (in `yyyy-MM-D`) for formatting days of the month to the input `" +
             date +
-            "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md",
+            "`; see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md",
         );
       });
 
@@ -882,7 +894,7 @@ describe("format", () => {
         expect(warn).toBeCalledWith(
           "Use `dd` instead of `DD` (in `yyyy-MM-DD`) for formatting days of the month to the input `" +
             date +
-            "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md",
+            "`; see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md",
         );
       });
 
@@ -895,7 +907,7 @@ describe("format", () => {
         expect(warn).toBeCalledWith(
           "Use `ddd` instead of `DDD` (in `yyyy-MM-DDD`) for formatting days of the month to the input `" +
             date +
-            "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md",
+            "`; see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md",
         );
       });
 
@@ -908,7 +920,7 @@ describe("format", () => {
         expect(warn).toBeCalledWith(
           "Use `dddd` instead of `DDDD` (in `yyyy-MM-DDDD`) for formatting days of the month to the input `" +
             date +
-            "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md",
+            "`; see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md",
         );
       });
 
@@ -921,7 +933,7 @@ describe("format", () => {
         expect(warn).toBeCalledWith(
           "Use `ddddd` instead of `DDDDD` (in `yyyy-MM-DDDDD`) for formatting days of the month to the input `" +
             date +
-            "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md",
+            "`; see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md",
         );
       });
 
@@ -934,7 +946,7 @@ describe("format", () => {
         expect(warn).toBeCalledWith(
           "Use `y` instead of `Y` (in `Y-MM-dd`) for formatting years to the input `" +
             date +
-            "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md",
+            "`; see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md",
         );
       });
 
@@ -947,7 +959,7 @@ describe("format", () => {
         expect(warn).toBeCalledWith(
           "Use `yy` instead of `YY` (in `YY-MM-dd`) for formatting years to the input `" +
             date +
-            "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md",
+            "`; see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md",
         );
       });
 
@@ -960,7 +972,7 @@ describe("format", () => {
         expect(warn).toBeCalledWith(
           "Use `yyy` instead of `YYY` (in `YYY-MM-dd`) for formatting years to the input `" +
             date +
-            "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md",
+            "`; see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md",
         );
       });
 
@@ -973,7 +985,7 @@ describe("format", () => {
         expect(warn).toBeCalledWith(
           "Use `yyyy` instead of `YYYY` (in `YYYY-MM-dd`) for formatting years to the input `" +
             date +
-            "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md",
+            "`; see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md",
         );
       });
 
@@ -986,7 +998,7 @@ describe("format", () => {
         expect(warn).toBeCalledWith(
           "Use `yyyyy` instead of `YYYYY` (in `YYYYY-MM-dd`) for formatting years to the input `" +
             date +
-            "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md",
+            "`; see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md",
         );
       });
     });

--- a/src/getISODay/index.ts
+++ b/src/getISODay/index.ts
@@ -9,7 +9,7 @@ import { toDate } from "../toDate/index.js";
  * Get the day of the ISO week of the given date,
  * which is 7 for Sunday, 1 for Monday etc.
  *
- * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ * ISO week-numbering year: https://en.wikipedia.org/wiki/ISO_week_date
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/getISOWeek/index.ts
+++ b/src/getISOWeek/index.ts
@@ -11,7 +11,7 @@ import { toDate } from "../toDate/index.js";
  * @description
  * Get the ISO week of the given date.
  *
- * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ * ISO week-numbering year: https://en.wikipedia.org/wiki/ISO_week_date
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/getISOWeekYear/index.ts
+++ b/src/getISOWeekYear/index.ts
@@ -11,7 +11,7 @@ import { toDate } from "../toDate/index.js";
  * Get the ISO week-numbering year of the given date,
  * which always starts 3 days before the year's first Thursday.
  *
- * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ * ISO week-numbering year: https://en.wikipedia.org/wiki/ISO_week_date
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/getISOWeeksInYear/index.ts
+++ b/src/getISOWeeksInYear/index.ts
@@ -10,7 +10,7 @@ import { startOfISOWeekYear } from "../startOfISOWeekYear/index.js";
  * @description
  * Get the number of weeks in an ISO week-numbering year of the given date.
  *
- * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ * ISO week-numbering year: https://en.wikipedia.org/wiki/ISO_week_date
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/isMatch/index.ts
+++ b/src/isMatch/index.ts
@@ -26,7 +26,7 @@ export interface IsMatchOptions
  * will return false.
  *
  * > ⚠️ Please note that the `format` tokens differ from Moment.js and other libraries.
- * > See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * > See: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
  *
  * The characters in the format string wrapped between two single quotes characters (') are escaped.
  * Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.
@@ -249,10 +249,10 @@ export interface IsMatchOptions
  *    - `p`: long localized time
  *
  * 6. `YY` and `YYYY` tokens represent week-numbering years but they are often confused with years.
- *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
  *
  * 7. `D` and `DD` tokens represent days of the year but they are ofthen confused with days of the month.
- *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
  *
  * 8. `P+` tokens do not have a defined priority since they are merely aliases to other tokens based
  *    on the given locale.
@@ -277,16 +277,16 @@ export interface IsMatchOptions
  * @param dateStr - The date string to verify
  * @param format - The string of tokens
  * @param options - An object with options.
- *   see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
- *   see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ *   see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
+ *   see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
  *
  * @returns Is format string a match for date string?
  *
  * @throws `options.locale` must contain `match` property
- * @throws use `yyyy` instead of `YYYY` for formatting years; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
- * @throws use `yy` instead of `YY` for formatting years; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
- * @throws use `d` instead of `D` for formatting days of the month; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
- * @throws use `dd` instead of `DD` for formatting days of the month; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * @throws use `yyyy` instead of `YYYY` for formatting years; see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
+ * @throws use `yy` instead of `YY` for formatting years; see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
+ * @throws use `d` instead of `D` for formatting days of the month; see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
+ * @throws use `dd` instead of `DD` for formatting days of the month; see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
  * @throws format string contains an unescaped latin alphabet character
  *
  * @example

--- a/src/isMatch/index.ts
+++ b/src/isMatch/index.ts
@@ -278,7 +278,6 @@ export interface IsMatchOptions
  * @param format - The string of tokens
  * @param options - An object with options.
  *   see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
- *   see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
  *
  * @returns Is format string a match for date string?
  *

--- a/src/isSameISOWeek/index.ts
+++ b/src/isSameISOWeek/index.ts
@@ -8,7 +8,7 @@ import { isSameWeek } from "../isSameWeek/index.js";
  * @description
  * Are the given dates in the same ISO week (and year)?
  *
- * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ * ISO week-numbering year: https://en.wikipedia.org/wiki/ISO_week_date
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/isSameISOWeekYear/index.ts
+++ b/src/isSameISOWeekYear/index.ts
@@ -8,7 +8,7 @@ import { startOfISOWeekYear } from "../startOfISOWeekYear/index.js";
  * @description
  * Are the given dates in the same ISO week-numbering year?
  *
- * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ * ISO week-numbering year: https://en.wikipedia.org/wiki/ISO_week_date
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/isThisISOWeek/index.ts
+++ b/src/isThisISOWeek/index.ts
@@ -10,7 +10,7 @@ import { isSameISOWeek } from "../isSameISOWeek/index.js";
  * @description
  * Is the given date in the same ISO week as the current date?
  *
- * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ * ISO week-numbering year: https://en.wikipedia.org/wiki/ISO_week_date
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/isValid/index.ts
+++ b/src/isValid/index.ts
@@ -11,7 +11,7 @@ import { toDate } from "../toDate/index.js";
  * Argument is converted to Date using `toDate`. See [toDate](https://date-fns.org/docs/toDate)
  * Invalid Date is a Date, whose time value is NaN.
  *
- * Time value of Date: http://es5.github.io/#x15.9.1.1
+ * Time value of Date: https://es5.github.io/#x15.9.1.1
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/lastDayOfISOWeek/index.ts
+++ b/src/lastDayOfISOWeek/index.ts
@@ -9,7 +9,7 @@ import { lastDayOfWeek } from "../lastDayOfWeek/index.js";
  * Return the last day of an ISO week for the given date.
  * The result will be in the local timezone.
  *
- * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ * ISO week-numbering year: https://en.wikipedia.org/wiki/ISO_week_date
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/lastDayOfISOWeekYear/index.ts
+++ b/src/lastDayOfISOWeekYear/index.ts
@@ -12,7 +12,7 @@ import { constructFrom } from "../constructFrom/index.js";
  * which always starts 3 days before the year's first Thursday.
  * The result will be in the local timezone.
  *
- * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ * ISO week-numbering year: https://en.wikipedia.org/wiki/ISO_week_date
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/lightFormat/index.ts
+++ b/src/lightFormat/index.ts
@@ -36,7 +36,7 @@ type Token = keyof typeof lightFormatters;
  * `lightFormat` doesn't use locales and outputs date using the most popular tokens.
  *
  * > ⚠️ Please note that the `lightFormat` tokens differ from Moment.js and other libraries.
- * > See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * > See: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
  *
  * The characters wrapped between two single quotes characters (') are escaped.
  * Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.

--- a/src/locale/da/_lib/localize/index.ts
+++ b/src/locale/da/_lib/localize/index.ts
@@ -46,7 +46,7 @@ const monthValues = {
 };
 
 // Note that 'Days - abbreviated - Formatting' has periods at the end.
-// https://www.unicode.org/cldr/charts/32/summary/da.html#1760
+// https://www.unicode.org/cldr/charts/44/summary/da.html#f3229b3855261cb
 // This makes grammatical sense in danish, as most abbreviations have periods.
 const dayValues = {
   narrow: ["S", "M", "T", "O", "T", "F", "L"] as const,

--- a/src/locale/de-AT/_lib/localize/index.ts
+++ b/src/locale/de-AT/_lib/localize/index.ts
@@ -84,7 +84,7 @@ const dayValues = {
   ] as const,
 };
 
-// https://www.unicode.org/cldr/charts/32/summary/de.html#1881
+// https://www.unicode.org/cldr/charts/44/summary/de.html#5abbc8f185730579
 const dayPeriodValues = {
   narrow: {
     am: "vm.",

--- a/src/locale/de/_lib/localize/index.ts
+++ b/src/locale/de/_lib/localize/index.ts
@@ -84,7 +84,7 @@ const dayValues = {
   ] as const,
 };
 
-// https://www.unicode.org/cldr/charts/32/summary/de.html#1881
+// https://www.unicode.org/cldr/charts/44/summary/de.html#5abbc8f185730579
 const dayPeriodValues = {
   narrow: {
     am: "vm.",

--- a/src/locale/gu/_lib/formatDistance/index.ts
+++ b/src/locale/gu/_lib/formatDistance/index.ts
@@ -7,7 +7,7 @@ type FormatDistanceTokenValue =
       other: string;
     };
 
-// Source: https://www.unicode.org/cldr/charts/32/summary/gu.html
+// Source: https://www.unicode.org/cldr/charts/44/summary/gu.html
 const formatDistanceLocale: FormatDistanceLocale<FormatDistanceTokenValue> = {
   lessThanXSeconds: {
     one: "હમણાં", // CLDR #1461

--- a/src/locale/gu/_lib/formatLong/index.ts
+++ b/src/locale/gu/_lib/formatLong/index.ts
@@ -1,7 +1,7 @@
 import type { FormatLong } from "../../../types.js";
 import { buildFormatLongFn } from "../../../_lib/buildFormatLongFn/index.js";
 
-//Source: https://www.unicode.org/cldr/charts/32/summary/gu.html
+//Source: https://www.unicode.org/cldr/charts/44/summary/gu.html
 const dateFormats = {
   full: "EEEE, d MMMM, y", // CLDR #1825
   long: "d MMMM, y", // CLDR #1826

--- a/src/locale/gu/_lib/formatRelative/index.ts
+++ b/src/locale/gu/_lib/formatRelative/index.ts
@@ -1,6 +1,6 @@
 import type { FormatRelativeFn } from "../../../types.js";
 
-// Source: https://www.unicode.org/cldr/charts/32/summary/gu.html
+// Source: https://www.unicode.org/cldr/charts/44/summary/gu.html
 
 const formatRelativeLocale = {
   lastWeek: "'પાછલા' eeee p", // CLDR #1384

--- a/src/locale/gu/_lib/localize/index.ts
+++ b/src/locale/gu/_lib/localize/index.ts
@@ -1,7 +1,7 @@
 import type { Localize, LocalizeFn } from "../../../types.js";
 import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.js";
 
-// https://www.unicode.org/cldr/charts/32/summary/gu.html
+// https://www.unicode.org/cldr/charts/44/summary/gu.html
 // #1621 - #1630
 const eraValues = {
   narrow: ["ઈસપૂ", "ઈસ"] as const,
@@ -9,7 +9,7 @@ const eraValues = {
   wide: ["ઈસવીસન પૂર્વે", "ઈસવીસન"] as const,
 };
 
-// https://www.unicode.org/cldr/charts/32/summary/gu.html
+// https://www.unicode.org/cldr/charts/44/summary/gu.html
 // #1631 - #1654
 const quarterValues = {
   narrow: ["1", "2", "3", "4"] as const,
@@ -22,7 +22,7 @@ const quarterValues = {
 // Generally, formatted dates should look like they are in the middle of a sentence,
 // e.g. in Spanish language the weekdays and months should be in the lowercase.
 
-// https://www.unicode.org/cldr/charts/32/summary/gu.html
+// https://www.unicode.org/cldr/charts/44/summary/gu.html
 // #1655 - #1726
 const monthValues = {
   narrow: [
@@ -69,7 +69,7 @@ const monthValues = {
   ] as const,
 };
 
-// https://www.unicode.org/cldr/charts/32/summary/gu.html
+// https://www.unicode.org/cldr/charts/44/summary/gu.html
 // #1727 - #1768
 const dayValues = {
   narrow: ["ર", "સો", "મં", "બુ", "ગુ", "શુ", "શ"] as const,
@@ -86,7 +86,7 @@ const dayValues = {
   ] as const,
 };
 
-// https://www.unicode.org/cldr/charts/32/summary/gu.html
+// https://www.unicode.org/cldr/charts/44/summary/gu.html
 // #1783 - #1824
 const dayPeriodValues = {
   narrow: {

--- a/src/locale/hi/_lib/formatDistance/index.ts
+++ b/src/locale/hi/_lib/formatDistance/index.ts
@@ -1,7 +1,7 @@
 import type { FormatDistanceFn, FormatDistanceLocale } from "../../../types.js";
 import { numberToLocale } from "../localize/index.js";
 
-// Source: https://www.unicode.org/cldr/charts/32/summary/hi.html
+// Source: https://www.unicode.org/cldr/charts/44/summary/hi.html
 
 export type FormatDistanceTokanRelativeValue = {
   one: string;

--- a/src/locale/hi/_lib/localize/index.ts
+++ b/src/locale/hi/_lib/localize/index.ts
@@ -85,7 +85,7 @@ const quarterValues = {
 // If you are making a new locale based on this one, check if the same is true for the language you're working on.
 // Generally, formatted dates should look like they are in the middle of a sentence,
 // e.g. in Spanish language the weekdays and months should be in the lowercase.
-// https://www.unicode.org/cldr/charts/32/summary/hi.html
+// https://www.unicode.org/cldr/charts/44/summary/hi.html
 // CLDR #1617 - #1688
 const monthValues = {
   narrow: [

--- a/src/locale/id/_lib/localize/index.ts
+++ b/src/locale/id/_lib/localize/index.ts
@@ -2,7 +2,7 @@ import type { Localize, LocalizeFn } from "../../../types.js";
 import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.js";
 
 // All data for localization are taken from this page
-// https://www.unicode.org/cldr/charts/32/summary/id.html
+// https://www.unicode.org/cldr/charts/44/summary/id.html
 const eraValues = {
   narrow: ["SM", "M"] as const,
   abbreviated: ["SM", "M"] as const,

--- a/src/locale/kn/_lib/formatLong/index.ts
+++ b/src/locale/kn/_lib/formatLong/index.ts
@@ -1,7 +1,7 @@
 import type { FormatLong } from "../../../types.js";
 import { buildFormatLongFn } from "../../../_lib/buildFormatLongFn/index.js";
 
-// Reference: https://www.unicode.org/cldr/charts/32/summary/kn.html
+// Reference: https://www.unicode.org/cldr/charts/44/summary/kn.html
 
 const dateFormats = {
   full: "EEEE, MMMM d, y", // CLDR 1816

--- a/src/locale/kn/_lib/localize/index.ts
+++ b/src/locale/kn/_lib/localize/index.ts
@@ -1,7 +1,7 @@
 import type { Localize, LocalizeFn } from "../../../types.js";
 import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.js";
 
-// Reference: https://www.unicode.org/cldr/charts/32/summary/kn.html
+// Reference: https://www.unicode.org/cldr/charts/44/summary/kn.html
 
 const eraValues = {
   narrow: ["ಕ್ರಿ.ಪೂ", "ಕ್ರಿ.ಶ"] as const,

--- a/src/locale/ms/_lib/localize/index.ts
+++ b/src/locale/ms/_lib/localize/index.ts
@@ -2,7 +2,7 @@ import type { Localize, LocalizeFn } from "../../../types.js";
 import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.js";
 
 // Most data for localization are taken from this page
-// https://www.unicode.org/cldr/charts/32/summary/ms.html
+// https://www.unicode.org/cldr/charts/44/summary/ms.html
 const eraValues = {
   narrow: ["SM", "M"] as const,
   abbreviated: ["SM", "M"] as const,

--- a/src/locale/sk/_lib/formatLong/index.ts
+++ b/src/locale/sk/_lib/formatLong/index.ts
@@ -1,7 +1,7 @@
 import type { FormatLong } from "../../../types.js";
 import { buildFormatLongFn } from "../../../_lib/buildFormatLongFn/index.js";
 
-// https://www.unicode.org/cldr/charts/32/summary/sk.html?hide#1986
+// https://www.unicode.org/cldr/charts/44/summary/sk.html#4d988ef42af07ea2
 const dateFormats = {
   full: "EEEE d. MMMM y",
   long: "d. MMMM y",
@@ -9,7 +9,7 @@ const dateFormats = {
   short: "d. M. y",
 };
 
-// https://www.unicode.org/cldr/charts/32/summary/sk.html?hide#2149
+// https://www.unicode.org/cldr/charts/44/summary/sk.html#683ddbe8510f73c
 const timeFormats = {
   full: "H:mm:ss zzzz",
   long: "H:mm:ss z",
@@ -17,7 +17,7 @@ const timeFormats = {
   short: "H:mm",
 };
 
-// https://www.unicode.org/cldr/charts/32/summary/sk.html?hide#1994
+// https://www.unicode.org/cldr/charts/44/summary/sk.html#68725f8fff1b6db9
 const dateTimeFormats = {
   full: "{{date}}, {{time}}",
   long: "{{date}}, {{time}}",

--- a/src/locale/sk/_lib/formatRelative/index.ts
+++ b/src/locale/sk/_lib/formatRelative/index.ts
@@ -5,7 +5,7 @@ import type {
   FormatRelativeFnOptions,
 } from "../../../types.js";
 
-// https://www.unicode.org/cldr/charts/32/summary/sk.html?hide#1308
+// https://www.unicode.org/cldr/charts/44/summary/sk.html#282cce0efeef5811
 const accusativeWeekdays = [
   "nedeľu",
   "pondelok",

--- a/src/locale/sk/_lib/localize/index.ts
+++ b/src/locale/sk/_lib/localize/index.ts
@@ -1,21 +1,21 @@
 import type { Localize, LocalizeFn } from "../../../types.js";
 import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.js";
 
-// https://www.unicode.org/cldr/charts/32/summary/sk.html#1772
+// https://www.unicode.org/cldr/charts/44/summary/sk.html#57fb0deb17870cb9
 const eraValues = {
   narrow: ["pred Kr.", "po Kr."] as const,
   abbreviated: ["pred Kr.", "po Kr."] as const,
   wide: ["pred Kristom", "po Kristovi"] as const,
 };
 
-// https://www.unicode.org/cldr/charts/32/summary/sk.html#1780
+// https://www.unicode.org/cldr/charts/44/summary/sk.html#cb664830a41f487
 const quarterValues = {
   narrow: ["1", "2", "3", "4"] as const,
   abbreviated: ["Q1", "Q2", "Q3", "Q4"] as const,
   wide: ["1. štvrťrok", "2. štvrťrok", "3. štvrťrok", "4. štvrťrok"] as const,
 };
 
-// https://www.unicode.org/cldr/charts/32/summary/sk.html#1804
+// https://www.unicode.org/cldr/charts/44/summary/sk.html#2bd0ab9fba1a49d8
 const monthValues = {
   narrow: ["j", "f", "m", "a", "m", "j", "j", "a", "s", "o", "n", "d"] as const,
   abbreviated: [
@@ -79,7 +79,7 @@ const formattingMonthValues = {
   ] as const,
 };
 
-// https://www.unicode.org/cldr/charts/32/summary/sk.html#1876
+// https://www.unicode.org/cldr/charts/44/summary/sk.html#7349f53135bf929c
 const dayValues = {
   narrow: ["n", "p", "u", "s", "š", "p", "s"] as const,
   short: ["ne", "po", "ut", "st", "št", "pi", "so"] as const,
@@ -95,7 +95,7 @@ const dayValues = {
   ] as const,
 };
 
-// https://www.unicode.org/cldr/charts/32/summary/sk.html#1932
+// https://www.unicode.org/cldr/charts/44/summary/sk.html#531768795c3cdb89
 const dayPeriodValues = {
   narrow: {
     am: "AM",

--- a/src/locale/sv/_lib/localize/index.ts
+++ b/src/locale/sv/_lib/localize/index.ts
@@ -65,7 +65,7 @@ const dayValues = {
   ] as const,
 };
 
-// https://www.unicode.org/cldr/charts/32/summary/sv.html#1888
+// https://www.unicode.org/cldr/charts/44/summary/sv.html#1b950d155352ae90
 const dayPeriodValues = {
   narrow: {
     am: "fm",

--- a/src/locale/ta/_lib/formatLong/index.ts
+++ b/src/locale/ta/_lib/formatLong/index.ts
@@ -1,7 +1,7 @@
 import type { FormatLong } from "../../../types.js";
 import { buildFormatLongFn } from "../../../_lib/buildFormatLongFn/index.js";
 
-// Ref: https://www.unicode.org/cldr/charts/32/summary/ta.html
+// Ref: https://www.unicode.org/cldr/charts/44/summary/ta.html
 
 // CLDR #1846 - #1849
 const dateFormats = {

--- a/src/locale/ta/_lib/localize/index.ts
+++ b/src/locale/ta/_lib/localize/index.ts
@@ -1,7 +1,7 @@
 import type { Localize, LocalizeFn } from "../../../types.js";
 import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.js";
 
-// Ref: https://www.unicode.org/cldr/charts/32/summary/ta.html
+// Ref: https://www.unicode.org/cldr/charts/44/summary/ta.html
 
 const eraValues = {
   narrow: ["கி.மு.", "கி.பி."] as const,

--- a/src/locale/te/_lib/formatDistance/index.ts
+++ b/src/locale/te/_lib/formatDistance/index.ts
@@ -1,6 +1,6 @@
 import type { FormatDistanceFn, FormatDistanceLocale } from "../../../types.js";
 
-// Source: https://www.unicode.org/cldr/charts/32/summary/te.html
+// Source: https://www.unicode.org/cldr/charts/44/summary/te.html
 
 type Plural = {
   one: string;

--- a/src/locale/te/_lib/formatLong/index.ts
+++ b/src/locale/te/_lib/formatLong/index.ts
@@ -1,7 +1,7 @@
 import type { FormatLong } from "../../../types.js";
 import { buildFormatLongFn } from "../../../_lib/buildFormatLongFn/index.js";
 
-// Source: https://www.unicode.org/cldr/charts/32/summary/te.html
+// Source: https://www.unicode.org/cldr/charts/44/summary/te.html
 
 // CLDR #1807 - #1811
 const dateFormats = {

--- a/src/locale/te/_lib/formatRelative/index.ts
+++ b/src/locale/te/_lib/formatRelative/index.ts
@@ -1,6 +1,6 @@
 import type { FormatRelativeFn } from "../../../types.js";
 
-// Source: https://www.unicode.org/cldr/charts/32/summary/te.html
+// Source: https://www.unicode.org/cldr/charts/44/summary/te.html
 
 const formatRelativeLocale = {
   lastWeek: "'గత' eeee p", // CLDR #1384

--- a/src/locale/te/_lib/localize/index.ts
+++ b/src/locale/te/_lib/localize/index.ts
@@ -1,7 +1,7 @@
 import type { Localize, LocalizeFn } from "../../../types.js";
 import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.js";
 
-// Source: https://www.unicode.org/cldr/charts/32/summary/te.html
+// Source: https://www.unicode.org/cldr/charts/44/summary/te.html
 // Source: https://dsal.uchicago.edu/dictionaries/brown/
 
 // CLDR #1605 - #1608

--- a/src/locale/vi/_lib/localize/index.ts
+++ b/src/locale/vi/_lib/localize/index.ts
@@ -1,7 +1,7 @@
 import type { Localize, LocalizeFn } from "../../../types.js";
 import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.js";
 
-// Vietnamese locale reference: http://www.localeplanet.com/icu/vi-VN/index.html
+// Vietnamese locale reference: https://www.localeplanet.com/icu/vi-VN/index.html
 // Capitalization reference: http://hcmup.edu.vn/index.php?option=com_content&view=article&id=4106%3Avit-hoa-trong-vn-bn-hanh-chinh&catid=2345%3Atham-kho&Itemid=4103&lang=vi&site=134
 
 const eraValues = {

--- a/src/parse/_lib/parsers/YearParser.ts
+++ b/src/parse/_lib/parsers/YearParser.ts
@@ -8,7 +8,7 @@ export interface YearParserValue {
   isTwoDigitYear: boolean;
 }
 
-// From http://www.unicode.org/reports/tr35/tr35-31/tr35-dates.html#Date_Format_Patterns
+// From https://www.unicode.org/reports/tr35/tr35-31/tr35-dates.html#Date_Format_Patterns
 // | Year     |     y | yy |   yyy |  yyyy | yyyyy |
 // |----------|-------|----|-------|-------|-------|
 // | AD 1     |     1 | 01 |   001 |  0001 | 00001 |

--- a/src/parse/index.ts
+++ b/src/parse/index.ts
@@ -320,7 +320,7 @@ const unescapedLatinCharacterRegExp = /[a-zA-Z]/;
  *
  * If parsing failed, `Invalid Date` will be returned.
  * Invalid Date is a Date, whose time value is NaN.
- * Time value of Date: http://es5.github.io/#x15.9.1.1
+ * Time value of Date: https://es5.github.io/#x15.9.1.1
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/parse/index.ts
+++ b/src/parse/index.ts
@@ -329,7 +329,6 @@ const unescapedLatinCharacterRegExp = /[a-zA-Z]/;
  * @param referenceDate - defines values missing from the parsed dateString
  * @param options - An object with options.
  *   see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
- *   see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
  *
  * @returns The parsed date
  *

--- a/src/parse/index.ts
+++ b/src/parse/index.ts
@@ -65,7 +65,7 @@ const unescapedLatinCharacterRegExp = /[a-zA-Z]/;
  * Return the date parsed from string using the given format string.
  *
  * > ⚠️ Please note that the `format` tokens differ from Moment.js and other libraries.
- * > See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * > See: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
  *
  * The characters in the format string wrapped between two single quotes characters (') are escaped.
  * Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.
@@ -288,10 +288,10 @@ const unescapedLatinCharacterRegExp = /[a-zA-Z]/;
  *    - `p`: long localized time
  *
  * 6. `YY` and `YYYY` tokens represent week-numbering years but they are often confused with years.
- *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
  *
  * 7. `D` and `DD` tokens represent days of the year but they are ofthen confused with days of the month.
- *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
  *
  * 8. `P+` tokens do not have a defined priority since they are merely aliases to other tokens based
  *    on the given locale.
@@ -328,16 +328,16 @@ const unescapedLatinCharacterRegExp = /[a-zA-Z]/;
  * @param formatStr - The string of tokens
  * @param referenceDate - defines values missing from the parsed dateString
  * @param options - An object with options.
- *   see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
- *   see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ *   see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
+ *   see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
  *
  * @returns The parsed date
  *
  * @throws `options.locale` must contain `match` property
- * @throws use `yyyy` instead of `YYYY` for formatting years using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
- * @throws use `yy` instead of `YY` for formatting years using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
- * @throws use `d` instead of `D` for formatting days of the month using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
- * @throws use `dd` instead of `DD` for formatting days of the month using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * @throws use `yyyy` instead of `YYYY` for formatting years using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
+ * @throws use `yy` instead of `YY` for formatting years using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
+ * @throws use `d` instead of `D` for formatting days of the month using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
+ * @throws use `dd` instead of `DD` for formatting days of the month using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/main/docs/unicodeTokens.md
  * @throws format string contains an unescaped latin alphabet character
  *
  * @example

--- a/src/parseISO/index.ts
+++ b/src/parseISO/index.ts
@@ -20,7 +20,7 @@ export interface ParseISOOptions {
  * Parse the given string in ISO 8601 format and return an instance of Date.
  *
  * Function accepts complete ISO 8601 formats as well as partial implementations.
- * ISO 8601: http://en.wikipedia.org/wiki/ISO_8601
+ * ISO 8601: https://en.wikipedia.org/wiki/ISO_8601
  *
  * If the argument isn't a string, the function cannot parse the string or
  * the values are invalid, it returns Invalid Date.

--- a/src/setISOWeek/index.ts
+++ b/src/setISOWeek/index.ts
@@ -9,7 +9,7 @@ import { toDate } from "../toDate/index.js";
  * @description
  * Set the ISO week to the given date, saving the weekday number.
  *
- * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ * ISO week-numbering year: https://en.wikipedia.org/wiki/ISO_week_date
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/setISOWeekYear/index.ts
+++ b/src/setISOWeekYear/index.ts
@@ -12,7 +12,7 @@ import { toDate } from "../toDate/index.js";
  * Set the ISO week-numbering year to the given date,
  * saving the week number and the weekday number.
  *
- * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ * ISO week-numbering year: https://en.wikipedia.org/wiki/ISO_week_date
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/startOfISOWeek/index.ts
+++ b/src/startOfISOWeek/index.ts
@@ -9,7 +9,7 @@ import { startOfWeek } from "../startOfWeek/index.js";
  * Return the start of an ISO week for the given date.
  * The result will be in the local timezone.
  *
- * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ * ISO week-numbering year: https://en.wikipedia.org/wiki/ISO_week_date
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/startOfISOWeekYear/index.ts
+++ b/src/startOfISOWeekYear/index.ts
@@ -12,7 +12,7 @@ import { constructFrom } from "../constructFrom/index.js";
  * which always starts 3 days before the year's first Thursday.
  * The result will be in the local timezone.
  *
- * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ * ISO week-numbering year: https://en.wikipedia.org/wiki/ISO_week_date
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *

--- a/src/subISOWeekYears/index.ts
+++ b/src/subISOWeekYears/index.ts
@@ -8,7 +8,7 @@ import { addISOWeekYears } from "../addISOWeekYears/index.js";
  * @description
  * Subtract the specified number of ISO week-numbering years from the given date.
  *
- * ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
+ * ISO week-numbering year: https://en.wikipedia.org/wiki/ISO_week_date
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *


### PR DESCRIPTION
Just a bit of cleanup in the codebase URLs.

- The version 32 CLDR links didn't work anymore (linked to a zip download oddly enough)
- http -> https
- References to the old `master` branch renamed to `main`
- Removed dupe references to unicode tokens documentation page in the `parse` and `isMatch` function jsdocs