### PR TITLE
#3769 longformatter exporter twice

### DIFF
--- a/src/parse/index.ts
+++ b/src/parse/index.ts
@@ -21,7 +21,7 @@ import type { ParseFlags, ParserOptions } from "./_lib/types.js";
 
 // Rexports of internal for libraries to use.
 // See: https://github.com/date-fns/date-fns/issues/3638#issuecomment-1877082874
-export { longFormatters, parsers };
+export { parsers };
 
 /**
  * The {@link parse} function options.


### PR DESCRIPTION
remove one export of longFormatter.

Library users can still export it from the parse file.