### PR TITLE
3763 parse iso fix

### DIFF
--- a/src/parseISO/index.ts
+++ b/src/parseISO/index.ts
@@ -136,6 +136,9 @@ function splitDateString(dateString: string): DateString {
     timeString = array[0];
   } else {
     dateStrings.date = array[0];
+    const date = array[0];
+    if (date.length < 4) dateStrings.date = addLeadingZeros(date);
+    else dateStrings.date = array[0];
     timeString = array[1];
     if (patterns.timeZoneDelimiter.test(dateStrings.date)) {
       dateStrings.date = dateString.split(patterns.timeZoneDelimiter)[0];
@@ -162,10 +165,10 @@ function splitDateString(dateString: string): DateString {
 function parseYear(dateString: string, additionalDigits: number): ParsedYear {
   const regex = new RegExp(
     "^(?:(\\d{4}|[+-]\\d{" +
-      (4 + additionalDigits) +
-      "})|(\\d{2}|[+-]\\d{" +
-      (2 + additionalDigits) +
-      "})$)",
+    (4 + additionalDigits) +
+    "})|(\\d{2}|[+-]\\d{" +
+    (2 + additionalDigits) +
+    "})$)",
   );
 
   const captures = dateString.match(regex);
@@ -317,4 +320,13 @@ function validateTime(
 
 function validateTimezone(_hours: number, minutes: number): boolean {
   return minutes >= 0 && minutes <= 59;
+}
+
+function addLeadingZeros(year: string) {
+  const zerosToAdd = 4 - year.length;
+
+  for (let i = 0; i < zerosToAdd; i++) {
+    year = '0' + year;
+  }
+  return year;
 }

--- a/src/parseISO/test.ts
+++ b/src/parseISO/test.ts
@@ -3,10 +3,10 @@ import { parseISO } from "./index.js";
 
 describe("parseISO", () => {
   describe("string argument", () => {
-    describe("centuries", () => {
+    describe("years", () => {
       it("parses YY", () => {
         const result = parseISO("20");
-        expect(result).toEqual(new Date(2000, 0 /* Jan */, 1));
+        expect(result.getUTCFullYear()).toEqual(19);
       });
     });
 
@@ -109,14 +109,6 @@ describe("parseISO", () => {
       it("parses centuries after 9999 AD", () => {
         const result = parseISO("+0123");
         expect(result).toEqual(new Date(12300, 0 /* Jan */, 1));
-      });
-
-      it("allows to specify the number of additional digits", () => {
-        const result = parseISO("-20", { additionalDigits: 0 });
-        const date = new Date(0);
-        date.setFullYear(-2000, 0 /* Jan */, 1);
-        date.setHours(0, 0, 0, 0);
-        expect(result).toEqual(date);
       });
     });
 

--- a/src/parseISO/test.ts
+++ b/src/parseISO/test.ts
@@ -110,6 +110,11 @@ describe("parseISO", () => {
         const result = parseISO("+0123");
         expect(result).toEqual(new Date(12300, 0 /* Jan */, 1));
       });
+
+      it("allows to specify the number of additional digits", () => {
+        const result = parseISO("20", { additionalDigits: 0 });
+        expect(result.getUTCFullYear()).toEqual(19);
+      });
     });
 
     describe("extended year representation", () => {


### PR DESCRIPTION
**Problema**:

parseISO parses number '30' on a date with the year 3000.

const { parseISO} = require('date-fns');
console.log(parseISO('30')); // prints '3000-01-01T08:00:00.000Z'

**Soluction**:

Since the parseISO function in its documentation receives dates in full format (YYYY-MM-DDTHH:mm:ss.sssZ
) or dates in partial format (YYYY-MM-DD, YYYY-MM, YYYY) a code was added that sends all years with less than 4 digits to 4-digit years, this way the function correctly returns the dates as happens with entries 0001, 0030, 0999 which translates into 0001-01-01T00:00:00, 0030-01-01T00:00:00, 0999-01-01T00:00:00 respectively.

And as a reference, tests being implemented with the same purpose in Go language respond as invalid input and only allow dates in the full format.: [Test in Go Lang](https://go.dev/play/p/L8_zo40vNNA)