### PR TITLE
Update lock file with Bun 1.1.x to include optional win32 binaries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2904,9 +2904,9 @@
       }
     },
     "node_modules/@oven/bun-darwin-aarch64": {
-      "version": "1.0.30",
-      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-aarch64/-/bun-darwin-aarch64-1.0.30.tgz",
-      "integrity": "sha512-QEFQeWUunInL45YQFNOUR0misGKGYzDcnfepXcpIT4dFhEezmUWnThfhybBAauixiMdV/1JSQIPD7Flq/1PanQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-aarch64/-/bun-darwin-aarch64-1.1.5.tgz",
+      "integrity": "sha512-z0k3W2XEfa11OVUW0vp9pWLlpcPKY6TtpwPvREXCA0nFWj9LxbIRr5FZ1U6+M0gCRlx+5XOpSsWQ7+/HJcDgSg==",
       "cpu": [
         "arm64"
       ],
@@ -2917,9 +2917,9 @@
       ]
     },
     "node_modules/@oven/bun-darwin-x64": {
-      "version": "1.0.30",
-      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-x64/-/bun-darwin-x64-1.0.30.tgz",
-      "integrity": "sha512-m3pSNGgmG1CSZsERelpq1ILYBXQRjpWamC/lJoirBfSqWJLILT5vYI98meWlaJt4a80zoIP8IrwL+LymHt8btw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-x64/-/bun-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Pv1QDb69u6JMXfWiAE638aUWzsARGxWDQ1J1YLxOJVzbEe9f8qvMPZX7yP4OcfFMyc1ZcFrd7kDSkXQHZ/DeTg==",
       "cpu": [
         "x64"
       ],
@@ -2930,9 +2930,9 @@
       ]
     },
     "node_modules/@oven/bun-darwin-x64-baseline": {
-      "version": "1.0.30",
-      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-x64-baseline/-/bun-darwin-x64-baseline-1.0.30.tgz",
-      "integrity": "sha512-hx32GA5bMJdOK8WlioiaFjx1vr6ZDBgi4sg50cCJmoK0grg5yNVcOlmRz8g6Q5ngfR8dKC61R7B++hnZtOpTHw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@oven/bun-darwin-x64-baseline/-/bun-darwin-x64-baseline-1.1.5.tgz",
+      "integrity": "sha512-w3bHmbgrU0L8fCzW0uf0MYPo2DMekHG0w2SSQ+ZspkGQ11ppTu7FJZxZMAw8UQAAX3FgltFnaI1p6J9gkv4MMw==",
       "cpu": [
         "x64"
       ],
@@ -2943,9 +2943,9 @@
       ]
     },
     "node_modules/@oven/bun-linux-aarch64": {
-      "version": "1.0.30",
-      "resolved": "https://registry.npmjs.org/@oven/bun-linux-aarch64/-/bun-linux-aarch64-1.0.30.tgz",
-      "integrity": "sha512-32AbJ9Jt2sPNBS27QeWkn4MBYBXY0VqkRnh6M41i70I+IvjUj3vdZMMtushOxYdnlPzn+zv7J+JzyeYydvNJcw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-aarch64/-/bun-linux-aarch64-1.1.5.tgz",
+      "integrity": "sha512-iObapm21/EsuQN3Z3m/DwAyjeGQaYuwC+KocPT29n7Tv+C/bubIEtikrmSGfA2CiSA5n6dFsFGk/t/uFfUuVMA==",
       "cpu": [
         "arm64"
       ],
@@ -2956,9 +2956,9 @@
       ]
     },
     "node_modules/@oven/bun-linux-x64": {
-      "version": "1.0.30",
-      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64/-/bun-linux-x64-1.0.30.tgz",
-      "integrity": "sha512-/8e3xDlaFh1AIpwshnau6+ecrIyLD1U85EqohuSFm8guQ/9aoQ/luxr/V+ujfJHay7taImL3mPXHORL7HYVIoA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64/-/bun-linux-x64-1.1.5.tgz",
+      "integrity": "sha512-KrvxD5sUf0WcdjVJm2LyGJqPzBldYWT4EQy+N5c5gzFnrEKSXOsj5lFE2vPNICS8Zvwzt8zLr0OwKq/WU93xTQ==",
       "cpu": [
         "x64"
       ],
@@ -2969,9 +2969,9 @@
       ]
     },
     "node_modules/@oven/bun-linux-x64-baseline": {
-      "version": "1.0.30",
-      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-baseline/-/bun-linux-x64-baseline-1.0.30.tgz",
-      "integrity": "sha512-dGrT4FJE5GCLPm23drSMHBDzmpwwAkRJLKhfAk0yRGbPcCJqwaBjZpcNuiEyD0ESkiFFRE8aLstOEVhxxjsI0A==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@oven/bun-linux-x64-baseline/-/bun-linux-x64-baseline-1.1.5.tgz",
+      "integrity": "sha512-ENUbLzO/tKpzUp04e9u+jZi+RFIpIJ/RQy7WKTstzce3fZqAsfh65CJE7TqKvFpHEDNxaRqJRg7yUonSCO1BmA==",
       "cpu": [
         "x64"
       ],
@@ -2979,6 +2979,32 @@
       "optional": true,
       "os": [
         "linux"
+      ]
+    },
+    "node_modules/@oven/bun-windows-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@oven/bun-windows-x64/-/bun-windows-x64-1.1.5.tgz",
+      "integrity": "sha512-kLRNRrQhCqXXoc0E6y9lBYbec6Sd7zIZtasoO6V7pYatMEaDB1ufIktmM5YVtCGYqNJ1+zNsENuU9xxPuprPDA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oven/bun-windows-x64-baseline": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@oven/bun-windows-x64-baseline/-/bun-windows-x64-baseline-1.1.5.tgz",
+      "integrity": "sha512-OCkUFyhbLR0kzAzuZg7pAa48TQFukYlaHTPH7ZWJkuS4ewFsDiYE+ET1BFn0LoRPlK/IhR8F6S21cH1elrlWCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@polka/url": {
@@ -3333,12 +3359,12 @@
       }
     },
     "node_modules/@types/bun": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.0.8.tgz",
-      "integrity": "sha512-E6UWZuN4ymAxzUBWVIGDHJ3Zey7I8cMzDZ+cB1BqhZsmd1uPb9iAQzpWMruY1mKzsuD3R+dZPoBkZz8QL1KhSA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.1.0.tgz",
+      "integrity": "sha512-QGK0yU4jh0OK1A7DyhPkQuKjHQCC5jSJa3dpWIEhHv/rPfb6zLfdArc4/uUUZBMTcjilsafRXnPWO+1owb572Q==",
       "dev": true,
       "dependencies": {
-        "bun-types": "1.0.29"
+        "bun-types": "1.1.0"
       }
     },
     "node_modules/@types/connect": {
@@ -4442,9 +4468,9 @@
       "dev": true
     },
     "node_modules/bun": {
-      "version": "1.0.30",
-      "resolved": "https://registry.npmjs.org/bun/-/bun-1.0.30.tgz",
-      "integrity": "sha512-E83G/1f0VjJFmud3899lJ6eWKH4kzHKLrvP7DvwkSnV4Aou5p/JvLinHWNTyRl0yyWytAv+rMdsTgJaRbmw8tA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bun/-/bun-1.1.5.tgz",
+      "integrity": "sha512-9gVjgPLGQqKEAcuTL1x/hn7PUYvWHlx/tm3//xIRkJk55IVWXcmFM6kQtV+Jn9k5x3wvtAd8a3RRyk2alyKPjA==",
       "cpu": [
         "arm64",
         "x64"
@@ -4453,25 +4479,28 @@
       "hasInstallScript": true,
       "os": [
         "darwin",
-        "linux"
+        "linux",
+        "win32"
       ],
       "bin": {
-        "bun": "bin/bun",
-        "bunx": "bin/bun"
+        "bun": "bin/bun.exe",
+        "bunx": "bin/bun.exe"
       },
       "optionalDependencies": {
-        "@oven/bun-darwin-aarch64": "1.0.30",
-        "@oven/bun-darwin-x64": "1.0.30",
-        "@oven/bun-darwin-x64-baseline": "1.0.30",
-        "@oven/bun-linux-aarch64": "1.0.30",
-        "@oven/bun-linux-x64": "1.0.30",
-        "@oven/bun-linux-x64-baseline": "1.0.30"
+        "@oven/bun-darwin-aarch64": "1.1.5",
+        "@oven/bun-darwin-x64": "1.1.5",
+        "@oven/bun-darwin-x64-baseline": "1.1.5",
+        "@oven/bun-linux-aarch64": "1.1.5",
+        "@oven/bun-linux-x64": "1.1.5",
+        "@oven/bun-linux-x64-baseline": "1.1.5",
+        "@oven/bun-windows-x64": "1.1.5",
+        "@oven/bun-windows-x64-baseline": "1.1.5"
       }
     },
     "node_modules/bun-types": {
-      "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.0.29.tgz",
-      "integrity": "sha512-Z+U1ORr/2UCwxelIZxE83pyPLclviYL9UewQCNEUmGeLObY8ao+3WF3D8N1+NMv2+S+hUWsdBJam+4GoPEz35g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.1.0.tgz",
+      "integrity": "sha512-GhMDD7TosdJzQPGUOcQD5PZshvXVxDfwGAZs2dq+eSaPsRn3iUCzvpFlsg7Q51bXVzLAUs+FWHlnmpgZ5UggIg==",
       "dev": true,
       "dependencies": {
         "@types/node": "~20.11.3",


### PR DESCRIPTION
The lock file is using Bun 1.0.30, which is before they started shipping Windows binaries. This is causing `npm install` errors for new contributors on Windows.

I believe simply updating the `bun` and `@types/bun` deps should fix the problem.

see #3785 for reference