### PR TITLE
intlFormat: use single combined options parameter

### DIFF
--- a/src/intlFormat/index.ts
+++ b/src/intlFormat/index.ts
@@ -10,18 +10,32 @@ import type { DateFns } from "../types.js";
 export type IntlFormatLocale = Intl.ResolvedDateTimeFormatOptions["locale"];
 
 /**
+ * The {@link intlFormat} function options.
+ */
+export interface IntlFormatOptions
+  extends Intl.DateTimeFormatOptions {
+  /** The locales to use (see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument) */
+  locale?: DateFns.Utils.MaybeArray<
+    Intl.ResolvedDateTimeFormatOptions["locale"]
+  >;
+}
+
+/**
  * The format options (see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#options)
+ * @deprecated
+ *
+ * [TODO] Remove in v4
  */
 export type IntlFormatFormatOptions = Intl.DateTimeFormatOptions;
 
 /**
  * The locale options.
+ * @deprecated
+ *
+ * [TODO] Remove in v4
  */
 export interface IntlFormatLocaleOptions {
-  /** The locales to use (see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument) */
-  locale: DateFns.Utils.MaybeArray<
-    Intl.ResolvedDateTimeFormatOptions["locale"]
-  >;
+  locale: IntlFormatOptions["locale"];
 }
 
 /**
@@ -57,7 +71,7 @@ export function intlFormat<DateType extends Date>(
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *
  * @param date - The date to format
- * @param localeOptions - An object with locale
+ * @param options - An object with format and locale options
  *
  * @returns The formatted date string
  *
@@ -65,41 +79,16 @@ export function intlFormat<DateType extends Date>(
  *
  * @example
  * // Represent 4 October 2019 in Korean.
- * // Convert the date with locale's options.
+ * // Convert the date with specified format and locale options.
  * const result = intlFormat(new Date(2019, 9, 4, 12, 30, 13, 456), {
+ *   dateStyle: 'short',
  *   locale: 'ko-KR',
  * })
- * //=> 2019. 10. 4.
+ * //=> 19. 10. 4.
  */
 export function intlFormat<DateType extends Date>(
   date: DateType | number | string,
-  localeOptions: IntlFormatLocaleOptions,
-): string;
-
-/**
- * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
- *
- * @param date - The date to format
- * @param formatOptions - The format options
- *
- * @returns The formatted date string
- *
- * @throws `date` must not be Invalid Date
- *
- * @example
- * // Represent 4 October 2019.
- * // Convert the date with format's options.
- * const result = intlFormat.default(new Date(2019, 9, 4, 12, 30, 13, 456), {
- *   year: 'numeric',
- *   month: 'numeric',
- *   day: 'numeric',
- *   hour: 'numeric',
- * })
- * //=> 10/4/2019, 12 PM
- */
-export function intlFormat<DateType extends Date>(
-  date: DateType | number | string,
-  formatOptions: IntlFormatFormatOptions,
+  options: IntlFormatOptions,
 ): string;
 
 /**
@@ -125,6 +114,8 @@ export function intlFormat<DateType extends Date>(
  *   locale: 'de-DE',
  * })
  * //=> Freitag, 4. Oktober 2019
+ *
+ * @deprecated Passing separate arguments for format and locale options is deprecated. Use a single options argument instead.
  */
 export function intlFormat<DateType extends Date>(
   date: DateType | number | string,
@@ -134,24 +125,13 @@ export function intlFormat<DateType extends Date>(
 
 export function intlFormat<DateType extends Date>(
   date: DateType | number | string,
-  formatOrLocale?: IntlFormatFormatOptions | IntlFormatLocaleOptions,
+  options?: IntlFormatOptions,
+  /* [TODO] Remove in v4 */
   localeOptions?: IntlFormatLocaleOptions,
 ): string {
-  let formatOptions: IntlFormatFormatOptions | undefined;
+  const { locale, ...formatOptions } = { ...options, ...localeOptions };
 
-  if (isFormatOptions(formatOrLocale)) {
-    formatOptions = formatOrLocale;
-  } else {
-    localeOptions = formatOrLocale;
-  }
-
-  return new Intl.DateTimeFormat(localeOptions?.locale, formatOptions).format(
+  return new Intl.DateTimeFormat(locale, formatOptions).format(
     toDate(date),
   );
-}
-
-function isFormatOptions(
-  opts: IntlFormatLocaleOptions | IntlFormatFormatOptions | undefined,
-): opts is IntlFormatFormatOptions {
-  return opts !== undefined && !("locale" in opts);
 }

--- a/src/intlFormat/test.ts
+++ b/src/intlFormat/test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { intlFormat } from "./index.js";
+import { intlFormat, type IntlFormatOptions } from "./index.js";
 
 // Before Node version 13.0.0, only the locale data for en-US is available by default.
 const hasFullICU = () => {
@@ -22,7 +22,7 @@ const getOperationSystemLocale = () => {
 describe("intlFormat", () => {
   describe("formats date", () => {
     fullICUOnly(
-      "should work without format's options and locale's options",
+      "should work without options",
       () => {
         const date = new Date(2019, 9 /* Oct */, 4, 12, 30, 13, 456);
         const result = intlFormat(date);
@@ -34,7 +34,7 @@ describe("intlFormat", () => {
       },
     );
 
-    fullICUOnly("should work with only format's options", () => {
+    fullICUOnly("should work with only format options", () => {
       const date = new Date(2019, 9 /* Oct */, 4, 12, 30, 13, 456);
       const formatOptions: Intl.DateTimeFormatOptions = {
         year: "numeric",
@@ -48,40 +48,39 @@ describe("intlFormat", () => {
       };
 
       const result = intlFormat(date, formatOptions);
-      const localeResult = intlFormat(date, formatOptions, {
+      const localeResult = intlFormat(date, {
+        ...formatOptions,
         locale: getOperationSystemLocale(),
       });
 
       expect(result).toBe(localeResult);
     });
 
-    fullICUOnly("should work with only locale's options", () => {
+    fullICUOnly("should work with only locale option", () => {
       const date = new Date(2019, 9 /* Oct */, 4, 12, 30, 13, 456);
       // Korean uses year-month-day order
-      const localeOptions = {
+      const options = {
         locale: "ko-KR",
       };
 
-      const result = intlFormat(date, localeOptions);
+      const result = intlFormat(date, options);
 
       expect(result).toBe("2019. 10. 4.");
     });
 
     fullICUOnly(
-      "should work with format's options and locale's options",
+      "should work with both format and locale options",
       () => {
         const date = new Date(2019, 9 /* Oct */, 4, 12, 30, 13, 456);
-        const formatOptions: Intl.DateTimeFormatOptions = {
+        const options: IntlFormatOptions = {
           weekday: "long",
           year: "numeric",
           month: "long",
           day: "numeric",
-        };
-        const localeOptions = {
           locale: "de-DE",
         };
 
-        const result = intlFormat(date, formatOptions, localeOptions);
+        const result = intlFormat(date, options);
 
         expect(result).toBe("Freitag, 4. Oktober 2019");
       },

--- a/src/intlFormatDistance/index.ts
+++ b/src/intlFormatDistance/index.ts
@@ -152,8 +152,9 @@ export function intlFormatDistance<DateType extends Date>(
   let unit: Intl.RelativeTimeFormatUnit;
   const dateLeft = toDate(date);
   const dateRight = toDate(baseDate);
+  const { locale, unit: selectedUnit, ...formatOptions } = options ?? {};
 
-  if (!options?.unit) {
+  if (!selectedUnit) {
     // Get the unit based on diffInSeconds calculations if no unit is specified
     const diffInSeconds = differenceInSeconds(dateLeft, dateRight); // The smallest unit
 
@@ -196,7 +197,7 @@ export function intlFormatDistance<DateType extends Date>(
     }
   } else {
     // Get the value if unit is specified
-    unit = options?.unit;
+    unit = selectedUnit;
     if (unit === "second") {
       value = differenceInSeconds(dateLeft, dateRight);
     } else if (unit === "minute") {
@@ -216,9 +217,9 @@ export function intlFormatDistance<DateType extends Date>(
     }
   }
 
-  const rtf = new Intl.RelativeTimeFormat(options?.locale, {
+  const rtf = new Intl.RelativeTimeFormat(locale, {
     numeric: "auto",
-    ...options,
+    ...formatOptions,
   });
 
   return rtf.format(value, unit);


### PR DESCRIPTION
The current implementation of intlFormat currently supports three different call signatures for providing options: calling with format options, calling with locale options, or calling with both as separate arguments.

When the newer intlFormatDistance was implemented, it used a much simpler call signature, with all options bundled into one parameter.

Having different paradigms for the two functions seems odd, and so this proposal would change the canonical signature for passing options to intlFormat to
```ts
intlFormat(date: DateType | number | string, options: IntlFormatOptions);
```
where IntlFormatOptions accepts both DateTimeFormat options and the locale property.

This signature is already compatible with both of the old two-parameter signatures, and so just replaces them. The old three-parameter call signature would be deprecated, but remain supported for the time being.

This PR contains a supplementary change to add options destructuring to intlFormatDistance, in the same way that it's used in this update to intlFormat. The current implementation of intlFormatDistance from #3796 doesn't remove the locales and unit properties from the options argument before passing it to Intl.RelativeTimeFormat; although these are ignored by the constructor, it's probably best practice not to include cruft with the passed RelativeTimeFormat options.