### PR TITLE
fix: I save the initial full time and set the final result with #1757 

### DIFF
--- a/src/addISOWeekYears/index.ts
+++ b/src/addISOWeekYears/index.ts
@@ -23,7 +23,6 @@ import { toDate } from "../toDate";
  * // Add 5 ISO week-numbering years to 2 July 2010:
  * const result = addISOWeekYears(new Date(2010, 6, 2), 5)
  * //=> Fri Jn 26 2015 00:00:00
- * I save the initial full time and set the final result with that initial time
  */
 export function addISOWeekYears<DateType extends Date>(
   date: DateType | number | string,

--- a/src/addISOWeekYears/index.ts
+++ b/src/addISOWeekYears/index.ts
@@ -1,5 +1,6 @@
 import { getISOWeekYear } from "../getISOWeekYear/index.js";
 import { setISOWeekYear } from "../setISOWeekYear/index.js";
+import { toDate } from "../toDate";
 
 /**
  * @name addISOWeekYears
@@ -22,10 +23,20 @@ import { setISOWeekYear } from "../setISOWeekYear/index.js";
  * // Add 5 ISO week-numbering years to 2 July 2010:
  * const result = addISOWeekYears(new Date(2010, 6, 2), 5)
  * //=> Fri Jn 26 2015 00:00:00
+ * I save the initial full time and set the final result with that initial time
  */
 export function addISOWeekYears<DateType extends Date>(
   date: DateType | number | string,
   amount: number,
 ): DateType {
-  return setISOWeekYear(date, getISOWeekYear(date) + amount);
+  const _date = toDate(date);
+  const hours: number = _date.getHours();
+  const minutes = _date.getMinutes();
+  const seconds = _date.getSeconds();
+  const milliseconds = _date.getMilliseconds();
+
+  const result = setISOWeekYear(date, getISOWeekYear(date) + amount);
+  result.setHours(hours, minutes, seconds, milliseconds);
+
+  return result;
 }

--- a/src/addISOWeekYears/test.ts
+++ b/src/addISOWeekYears/test.ts
@@ -24,10 +24,10 @@ describe("addISOWeekYears", () => {
   it("handles dates before 100 AD", () => {
     const initialDate = new Date(0);
     initialDate.setFullYear(10, 6 /* Jul */, 2);
-    initialDate.setHours(0, 0, 0, 0);
+    initialDate.setHours(2, 30, 30, 0);
     const expectedResult = new Date(0);
     expectedResult.setFullYear(15, 5 /* Jun */, 26);
-    expectedResult.setHours(0, 0, 0, 0);
+    expectedResult.setHours(2, 30, 30, 0);
     const result = addISOWeekYears(initialDate, 5);
     expect(result).toEqual(expectedResult);
   });


### PR DESCRIPTION
Solving issue #1757 which was returning the time to zero.
Now I save the start time and then set the final result with the start time.

close: #1757