### PR TITLE
Fixed formatISO to conditionally include milliseconds in string.

### DIFF
--- a/src/formatISO/index.ts
+++ b/src/formatISO/index.ts
@@ -43,6 +43,7 @@ export interface FormatISOOptions extends ISOFormatOptions {}
  * // Represent 18 September 2019 in ISO 8601 format, time only (local time zone is UTC):
  * const result = formatISO(new Date(2019, 8, 18, 19, 0, 52), { representation: 'time' })
  * //=> '19:00:52Z'
+ * 
  */
 export function formatISO<DateType extends Date>(
   date: DateType | number | string,
@@ -93,15 +94,20 @@ export function formatISO<DateType extends Date>(
     const hour = addLeadingZeros(_date.getHours(), 2);
     const minute = addLeadingZeros(_date.getMinutes(), 2);
     const second = addLeadingZeros(_date.getSeconds(), 2);
+    const millisecond = addLeadingZeros(_date.getMilliseconds(), 3);
 
     // If there's also date, separate it with time with 'T'
     const separator = result === "" ? "" : "T";
+    
 
     // Creates a time string consisting of hour, minute, and second, separated by delimiters, if defined.
     const time = [hour, minute, second].join(timeDelimiter);
 
+    // If milliseconds are zero, exclude from string
+    const precisionTime = millisecond === '000' ? '' : `${timeDelimiter === '' ? '' : '.'}${millisecond}`
+
     // HHmmss or HH:mm:ss.
-    result = `${result}${separator}${time}${tzOffset}`;
+    result = `${result}${separator}${time}${precisionTime}${tzOffset}`;
   }
 
   return result;

--- a/src/formatISO/test.ts
+++ b/src/formatISO/test.ts
@@ -4,8 +4,8 @@ import { formatISO } from "./index.js";
 import { generateOffset } from "../_lib/test/index.js";
 
 describe("formatISO", () => {
-  it("formats ISO-8601 extended format", () => {
-    const date = new Date(2019, 2 /* Mar */, 3, 19, 0, 52, 123);
+  it("formats ISO-8601 extended format excluding milliseconds", () => {
+    const date = new Date(2019, 2 /* Mar */, 3, 19, 0, 52, 0);
     const tzOffsetExtended = generateOffset(date);
     expect(formatISO(date)).toBe(`2019-03-03T19:00:52${tzOffsetExtended}`);
 
@@ -25,16 +25,43 @@ describe("formatISO", () => {
     getTimezoneOffsetStub.restore();
   });
 
+  it("formats ISO-8601 extended format including milliseconds", () => {
+    const date = new Date(2019, 2 /* Mar */, 3, 19, 0, 52, 123);
+    const tzOffsetExtended = generateOffset(date);
+    expect(formatISO(date)).toBe(`2019-03-03T19:00:52.123${tzOffsetExtended}`);
+
+    const getTimezoneOffsetStub = sinon.stub(
+      Date.prototype,
+      "getTimezoneOffset",
+    );
+
+    getTimezoneOffsetStub.returns(480);
+    const tzNegativeOffsetExtended = generateOffset(date);
+    expect(formatISO(date)).toBe(`2019-03-03T19:00:52.123${tzNegativeOffsetExtended}`);
+
+    getTimezoneOffsetStub.returns(0);
+    const tzZOffsetExtended = generateOffset(date);
+    expect(formatISO(date)).toBe(`2019-03-03T19:00:52.123${tzZOffsetExtended}`);
+
+    getTimezoneOffsetStub.restore();
+  });
+
   it("accepts a timestamp", () => {
     const date = new Date(2019, 2 /* Mar */, 3, 19, 0, 52, 123).getTime();
     const tzOffsetExtended = generateOffset(new Date(date));
-    expect(formatISO(date)).toBe(`2019-03-03T19:00:52${tzOffsetExtended}`);
+    expect(formatISO(date)).toBe(`2019-03-03T19:00:52.123${tzOffsetExtended}`);
   });
 
-  it("formats ISO-8601 basic format", () => {
-    const date = new Date(2019, 9 /* Oct */, 4, 12, 30, 13, 456);
+  it("formats ISO-8601 basic format without milliseconds", () => {
+    const date = new Date(2019, 9 /* Oct */, 4, 12, 30, 13, 0);
     const tzOffsetBasic = generateOffset(date);
     expect(formatISO(date, { format: "basic" })).toBe(`20191004T123013${tzOffsetBasic}`);
+  });
+
+  it("formats ISO-8601 basic format with milliseconds", () => {
+    const date = new Date(2019, 9 /* Oct */, 4, 12, 30, 13, 456);
+    const tzOffsetBasic = generateOffset(date);
+    expect(formatISO(date, { format: "basic" })).toBe(`20191004T123013456${tzOffsetBasic}`);
   });
 
   it("formats only date", () => {
@@ -44,13 +71,42 @@ describe("formatISO", () => {
     expect(formatISO(date, { representation: "date", format: "basic" })).toBe("20191211");
   });
 
-  it("formats only time", () => {
-    const date = new Date(2019, 2 /* Mar */, 3, 19, 0, 52, 123);
+  it("formats only time without milliseconds", () => {
+    const date = new Date(2019, 2 /* Mar */, 3, 19, 0, 52, 0);
     const tzOffset = generateOffset(date);
 
     expect(formatISO(date, { representation: "time", format: "extended" })).toBe(`19:00:52${tzOffset}`);
     expect(formatISO(date, { representation: "time", format: "basic" })).toBe(`190052${tzOffset}`);
   });
+
+  it("formats only time with milliseconds", () => {
+    const date = new Date(2019, 2 /* Mar */, 3, 19, 0, 52, 123);
+    const tzOffset = generateOffset(date);
+
+    expect(formatISO(date, { representation: "time", format: "extended" })).toBe(`19:00:52.123${tzOffset}`);
+    expect(formatISO(date, { representation: "time", format: "basic" })).toBe(`190052123${tzOffset}`);
+  });
+
+  it('can yield an ISO string parsable by Date to the same value as the Date provided', () => {
+    const dateStr = '2015-11-21T12:14:43+04:00';
+    const date = new Date(dateStr);
+    const isoString = formatISO(date);
+    expect(new Date(isoString).getTime()).toBe(date.getTime());
+
+    const shortDateString = '20151121T121443' + generateOffset(date);
+    console.log(shortDateString);
+    const shortDate = new Date(shortDateString);
+    console.log(shortDate.getTime());
+    const shortISOString = formatISO(shortDate, {format: 'basic'});
+    expect(new Date(shortISOString).getTime()).toBe(shortDate.getTime());
+  })
+
+  it("can yield an ISO string parsable to the same time value as the date provided, lossless to 1 millisecond", () => {
+    const dateStr = '9999-07-27T06:11:15.001Z'
+    const date = new Date(dateStr);
+    const isoString = formatISO(date);
+    expect(new Date(isoString).getTime()).toBe(date.getTime())
+  })
 
   it("throws RangeError if the time value is invalid", () => {
     expect(formatISO.bind(null, new Date(NaN))).toThrow(RangeError);


### PR DESCRIPTION
Addresses issue #3819. 

Updated `formatISO` to include millisecond values in ISO strings including time in all instances where the millisecond value was not equal to `000`. This was done to minimize changes to return values out of consideration of current users. Test cases were updated to reflect the change, and several new ones were added. All existing tests successfully passed.

Alternatively, `formatISO` could be easily altered to include milliseconds in the ISO string, or an additional property such as `precision = 'millisecond'` could be added to `FormatISOOptions` to allow users to explicitly opt-in to this changed behavior. Directive on the appropriate behavior from a maintainer would be appreciated.