### PR TITLE
formatRFC822 

### DIFF
--- a/src/formatRFC822/index.ts
+++ b/src/formatRFC822/index.ts
@@ -1,0 +1,94 @@
+import { isValid } from "../isValid/index.js";
+import { toDate } from "../toDate/index.js";
+import { addLeadingZeros } from "../_lib/addLeadingZeros/index.js";
+
+/**
+ * The {@link formatRFC822} function options.
+ */
+export interface FormatRFC822Options {
+  /** Day is optional see Section 5.1 : https://datatracker.ietf.org/doc/html/rfc822#section-5.1)
+ */
+  includeDay?: boolean;
+}
+/**
+ * @name formatRFC822
+ * @category Common Helpers
+ * @summary Format the date according to the RFC 822 standard (https://datatracker.ietf.org/doc/html/rfc822#section-5).
+ *
+ * @description
+ * Return the formatted date string in RFC 822 format.
+ *
+ * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. 
+ * 
+ * 
+ * @param date - The original date
+ * @param options - An object with options.
+ *
+ * @returns The formatted date string
+ *
+ * @throws `date` must not be Invalid Date
+ *
+ * @example
+ * // Represent 18 September 2019 in RFC 822 format:
+ * formatRFC822(new Date(2019, 8, 18, 19, 0, 52)));
+ * //=> '19 Sep 2019 00:00:52 -05:00'
+ * 
+ * @example
+ * // Represent 18 September 2019 in RFC 822 format, optional day included
+ * formatRFC822(new Date(2019, 8, 18, 19, 0, 52), {includeDay: true}))
+ * //=> 'Thu, 19 Sep 2019 00:00:52 -05:00"
+ */
+const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+const months = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+export function formatRFC822<DateType extends Date>(
+  date: DateType | number | string,
+  options?: FormatRFC822Options, 
+): string {
+  const _date = toDate(date);
+
+  if (!isValid(_date)) {
+    throw new RangeError("Invalid time value");
+  }
+
+  const dayName = days[_date.getUTCDay()];
+  const dayOfMonth = addLeadingZeros(_date.getUTCDate(), 2);
+  const monthName = months[_date.getUTCMonth()];
+  const year = _date.getUTCFullYear();
+
+  console.log("year",year)
+
+  const hour = addLeadingZeros(_date.getUTCHours(), 2);
+  const minute = addLeadingZeros(_date.getUTCMinutes(), 2);
+  const second = addLeadingZeros(_date.getUTCSeconds(), 2);
+
+  let offset = "";
+  const tzOffset = _date.getTimezoneOffset();
+
+  if (tzOffset !== 0) {
+    const absoluteOffset = Math.abs(tzOffset);
+    const hourOffset = addLeadingZeros(Math.trunc(absoluteOffset / 60), 2);
+    const minuteOffset = addLeadingZeros(absoluteOffset % 60, 2);
+    // If less than 0, the sign is +, because it is ahead of time.
+    const sign = tzOffset < 0 ? "+" : "-";
+
+    offset = `${sign}${hourOffset}:${minuteOffset}`;
+  } else {
+    offset = "Z"; 
+  }
+  return `${options?.includeDay ? dayName + ", " : ""}${dayOfMonth} ${monthName} ${year} ${hour}:${minute}:${second} ${offset}`;
+}

--- a/src/formatRFC822/test.ts
+++ b/src/formatRFC822/test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import sinon from "sinon";
+import { formatRFC822 } from "./index.js";
+import { generateOffset } from "../_lib/test/index.js";
+
+describe("formatRFC822", () => {
+  it("formats RFC-822 date string", () => {
+    const date = new Date(2019, 2 /* Mar */, 3, 19, 0, 52, 123);
+    expect(formatRFC822(date)).toBe(`04 Mar 19 00:00:52 ${generateOffset(date)}`);
+
+    const getTimezoneOffsetStub = sinon.stub(
+      Date.prototype,
+      "getTimezoneOffset",
+    );
+
+    getTimezoneOffsetStub.returns(0);
+    expect(formatRFC822(date)).toBe("04 Mar 19 00:00:52 Z");
+
+    getTimezoneOffsetStub.returns(480);
+    expect(formatRFC822(date)).toBe("04 Mar 19 00:00:52 -08:00");
+
+    getTimezoneOffsetStub.restore();
+  });
+
+  it("accepts a timestamp", () => {
+    const date = new Date(2019, 2 /* Mar */, 3, 19, 0, 52, 123);
+    const time = date.getTime();
+    expect(formatRFC822(time)).toBe(`04 Mar 19 00:00:52 ${generateOffset(date)}`);
+  });
+
+  it("allows to include day", () => {
+    const date = new Date(2019, 2 /* Mar */, 3, 19, 0, 52, 123);
+    expect(formatRFC822(date, { includeDay: true })).toBe(`Mon, 04 Mar 19 00:00:52 ${generateOffset(date)}`);
+  });
+
+  it("throws RangeError if the time value is invalid", () => {
+    expect(formatRFC822.bind(null, new Date(NaN))).toThrow(RangeError);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,7 @@ export * from "./formatDuration/index.js";
 export * from "./formatISO/index.js";
 export * from "./formatISO9075/index.js";
 export * from "./formatISODuration/index.js";
+export * from "./formatRFC822/index.js";
 export * from "./formatRFC3339/index.js";
 export * from "./formatRFC7231/index.js";
 export * from "./formatRelative/index.js";


### PR DESCRIPTION
## Describe your changes
Introduction new functionality formatRFC822

"This standard specifies a syntax for text messages that  are
     sent  among  computer  users, within the framework of "electronic
     mail". 

[RFC822](https://datatracker.ietf.org/doc/html/rfc822)

## Issue ticket number and link

[#ISSUE 3797](https://github.com/date-fns/date-fns/issues/3797)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Unit tests

