### PR TITLE
Add isSameInterval function to check for exact interval match

### DIFF
--- a/src/isSameInterval/index.ts
+++ b/src/isSameInterval/index.ts
@@ -1,0 +1,45 @@
+import { toDate } from "../toDate/index.js";
+import type { Interval } from "../types.js";
+
+/**
+ * @name isSameInterval
+ * @category Interval Helpers
+ * @summary Are the given intervals equal?
+ *
+ * @description
+ * Are the given intervals equal?
+ *
+ * @param intervalLeft - The first interval to compare
+ * @param intervalRight - The second interval to compare
+ *
+ * @returns The intervals are equal
+ *
+ * @example
+ * isSameInterval(
+ *   { start: new Date(2024, 0, 10), end: new Date(2024, 0, 20) },
+ *   { start: new Date(2024, 0, 10), end: new Date(2024, 0, 20) }
+ * )
+ * //=> true
+ *
+ * @example
+ * isSameInterval(
+ *   { start: new Date(2024, 0, 10), end: new Date(2024, 0, 20) },
+ *   { start: new Date(2024, 0, 11), end: new Date(2024, 0, 20) }
+ * )
+ * //=> false
+ *
+ * @example
+ *   { start: new Date(2024, 0, 11), end: new Date(2024, 0, 20) },
+ *   { start: new Date(2024, 0, 10), end: new Date(2024, 0, 20) }
+ * )
+ * //=> false
+ */
+export function isSameInterval(
+  intervalLeft: Interval,
+  intervalRight: Interval,
+): boolean {
+  return (
+    +toDate(intervalLeft.start) === +toDate(intervalRight.start) &&
+    +toDate(intervalLeft.end) === +toDate(intervalRight.end)
+  );
+}

--- a/src/isSameInterval/test.ts
+++ b/src/isSameInterval/test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { isSameInterval } from "./index.js";
+
+describe("isSameInterval", () => {
+  it("returns true if the given intervals are equal", () => {
+    const result = isSameInterval(
+      {
+        start: new Date(2024, 1 /* Feb */, 10),
+        end: new Date(2024, 1 /* Feb */, 20),
+      },
+      {
+        start: new Date(2024, 1 /* Feb */, 10),
+        end: new Date(2024, 1 /* Feb */, 20),
+      },
+    );
+    expect(result).toBe(true);
+  });
+
+  it("returns false if the given intervals are not equal", () => {
+    const result = isSameInterval(
+      {
+        start: new Date(2024, 1 /* Feb */, 10),
+        end: new Date(2024, 1 /* Feb */, 20),
+      },
+      {
+        start: new Date(2024, 1 /* Feb */, 11),
+        end: new Date(2024, 1 /* Feb */, 20),
+      },
+    );
+    expect(result).toBe(false);
+  });
+
+  it("accepts a timestamp", () => {
+    const result = isSameInterval(
+      {
+        start: new Date(2024, 1 /* Feb */, 10).getTime(),
+        end: new Date(2024, 1 /* Feb */, 20).getTime(),
+      },
+      {
+        start: new Date(2024, 1 /* Feb */, 10).getTime(),
+        end: new Date(2024, 1 /* Feb */, 20).getTime(),
+      },
+    );
+    expect(result).toBe(true);
+  });
+
+  it("returns false if the first interval start is `Invalid Date`", () => {
+    const result = isSameInterval(
+      {
+        start: new Date(NaN),
+        end: new Date(2024, 1 /* Feb */, 20),
+      },
+      {
+        start: new Date(2024, 1 /* Feb */, 10),
+        end: new Date(2024, 1 /* Feb */, 20),
+      },
+    );
+    expect(result).toBe(false);
+  });
+  it("returns false if the first interval end is `Invalid Date`", () => {
+    const result = isSameInterval(
+      {
+        start: new Date(2024, 1 /* Feb */, 10),
+        end: new Date(NaN),
+      },
+      {
+        start: new Date(2024, 1 /* Feb */, 10),
+        end: new Date(2024, 1 /* Feb */, 20),
+      },
+    );
+    expect(result).toBe(false);
+  });
+
+  it("returns false if the second interval start is `Invalid Date`", () => {
+    const result = isSameInterval(
+      {
+        start: new Date(2024, 1 /* Feb */, 10),
+        end: new Date(2024, 1 /* Feb */, 20),
+      },
+      {
+        start: new Date(NaN),
+        end: new Date(2024, 1 /* Feb */, 20),
+      },
+    );
+    expect(result).toBe(false);
+  });
+  it("returns false if the second interval end is `Invalid Date`", () => {
+    const result = isSameInterval(
+      {
+        start: new Date(2024, 1 /* Feb */, 10),
+        end: new Date(2024, 1 /* Feb */, 20),
+      },
+      {
+        start: new Date(2024, 1 /* Feb */, 10),
+        end: new Date(NaN),
+      },
+    );
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
This merge request introduces the isSameInterval function, which compares two intervals to determine if they are exactly the same. The function checks both the start and end points of each interval and returns true if they match.