### PR TITLE
[Docs] Place subSeconds/subMilliseconds back in correct categories

### DIFF
--- a/src/subMilliseconds/index.ts
+++ b/src/subMilliseconds/index.ts
@@ -8,6 +8,11 @@ export interface SubMillisecondsOptions<DateType extends Date = Date>
   extends ContextOptions<DateType> {}
 
 /**
+ * @name subMilliseconds
+ * @category Millisecond Helpers
+ * @summary Subtract the specified number of milliseconds from the given date.
+ *
+ * @description
  * Subtract the specified number of milliseconds from the given date.
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).

--- a/src/subSeconds/index.ts
+++ b/src/subSeconds/index.ts
@@ -8,6 +8,11 @@ export interface SubSecondsOptions<DateType extends Date = Date>
   extends ContextOptions<DateType> {}
 
 /**
+ * @name subSeconds
+ * @category Second Helpers
+ * @summary Subtract the specified number of seconds from the given date.
+ *
+ * @description
  * Subtract the specified number of seconds from the given date.
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).


### PR DESCRIPTION
Fixes #3918 