### PR TITLE
Fixed sample code in webpack doc

### DIFF
--- a/docs/webpack.md
+++ b/docs/webpack.md
@@ -42,7 +42,7 @@ export default config = {
   plugins: [
     new webpack.ContextReplacementPlugin(
       /date-fns[/\\]locale/,
-      new RegExp(`(${locales.join("|")})\.js$`),
+      new RegExp(`(${supportedLocales.join("|")})\.js$`),
     ),
   ],
 };


### PR DESCRIPTION
Imported `supportedLocales` config variable was not being referenced properly in the body of the sample code.