### PR TITLE
fix: getUnixTime handling when passing dates before the epoch time in ms

### DIFF
--- a/src/getUnixTime/index.ts
+++ b/src/getUnixTime/index.ts
@@ -9,7 +9,7 @@ import type { DateArg } from "../types.js";
  * @description
  * Get the seconds timestamp of the given date.
  *
- * @param date - The given date
+ * @param date - The given date. If the date is in milliseconds, it will be rounded to the nearest second.
  *
  * @returns The timestamp
  *
@@ -19,5 +19,5 @@ import type { DateArg } from "../types.js";
  * //=> 1330512305
  */
 export function getUnixTime(date: DateArg<Date> & {}): number {
-  return Math.trunc(+toDate(date) / 1000);
+  return Math.round(+toDate(date) / 1000);
 }

--- a/src/getUnixTime/test.ts
+++ b/src/getUnixTime/test.ts
@@ -23,4 +23,11 @@ describe("getUnixTime", () => {
     expect(getUnixTime(new Date(1001))).toBe(1);
     expect(getUnixTime(new Date(-1001))).toBe(-1);
   });
+
+  it("should return the same value if the inputs are the same in terms of seconds", () => {
+    const date1 = getUnixTime(new Date("1960-01-01T00:00:00.2Z"))
+    const date2 = getUnixTime(new Date("1960-01-01T00:00:00Z"))
+
+    expect(date1).toBe(date2)
+  });
 });


### PR DESCRIPTION
This PR should resolve this issue #3923 
## Description
This PR updates the getUnixTime function to improve the handling of dates with millisecond precision when converting them to Unix timestamps.

## From:
The function previously used Math.trunc() to truncate the milliseconds, which caused dates with non-zero milliseconds (even close to the next second) to round down to the earlier second. This approach could result in different timestamps for dates that should, in practical terms, be considered the same.

## To:
The function now uses Math.round() instead of Math.trunc(), ensuring that milliseconds are properly rounded to the nearest second. This adjustment leads to more consistent and accurate Unix timestamps, especially for dates that differ by milliseconds but fall within the same second.

## Test Case Added:
A new test case has been introduced to verify that dates differing only by small fractions of a second return the same Unix timestamp. Specifically, it checks that dates like "1960-01-01T00:00:00.2Z" and "1960-01-01T00:00:00Z" are treated as equivalent in terms of their Unix time, ensuring consistent behavior after rounding.