### PR TITLE
Fix typo in narrow day values for Galician locale

### DIFF
--- a/src/locale/gl/_lib/localize/index.ts
+++ b/src/locale/gl/_lib/localize/index.ts
@@ -51,7 +51,7 @@ const monthValues = {
 };
 
 const dayValues = {
-  narrow: ["d", "l", "m", "m", "j", "v", "s"] as const,
+  narrow: ["d", "l", "m", "m", "x", "v", "s"] as const,
   short: ["do", "lu", "ma", "me", "xo", "ve", "sa"] as const,
   abbreviated: ["dom", "lun", "mar", "mer", "xov", "ven", "sab"] as const,
   wide: [


### PR DESCRIPTION
Fix the galician (gl) narrow format to Thursday (Xoves in galician) from "J" to "X"