### PR TITLE
feat: add `maxUnits` option to `formatDuration` function

### DIFF
--- a/src/formatDuration/index.ts
+++ b/src/formatDuration/index.ts
@@ -14,6 +14,8 @@ export interface FormatDurationOptions
   zero?: boolean;
   /** The delimiter string to use */
   delimiter?: string;
+  /** The maximum amount of units to show */
+  maxUnits?: number;
 }
 
 const defaultFormat: DurationUnit[] = [
@@ -83,6 +85,24 @@ const defaultFormat: DurationUnit[] = [
  * // Customize the delimiter
  * formatDuration({ years: 2, months: 9, weeks: 3 }, { delimiter: ', ' })
  * //=> '2 years, 9 months, 3 weeks'
+ *
+ * @example
+ * // Restrict the maximum amount of units to show
+ * formatDuration(
+ *   {
+ *     years: 2,
+ *     months: 9,
+ *     weeks: 1,
+ *     days: 7,
+ *     hours: 5,
+ *     minutes: 9,
+ *     seconds: 30
+ *   },
+ *   { maxUnits: 2 }
+ * )
+ * //=> '2 years 9 months'
+ * formatDuration({ months: 9 }, { maxUnits: 2 })
+ * //=> '9 months'
  */
 export function formatDuration(
   duration: Duration,
@@ -93,6 +113,7 @@ export function formatDuration(
   const format = options?.format ?? defaultFormat;
   const zero = options?.zero ?? false;
   const delimiter = options?.delimiter ?? " ";
+  const maxUnits = options?.maxUnits ?? format.length;
 
   if (!locale.formatDistance) {
     return "";
@@ -100,6 +121,7 @@ export function formatDuration(
 
   const result = format
     .reduce((acc, unit) => {
+      if (acc.length >= maxUnits) return acc;
       const token = `x${unit.replace(/(^.)/, (m) =>
         m.toUpperCase(),
       )}` as FormatDistanceToken;

--- a/src/formatDuration/test.ts
+++ b/src/formatDuration/test.ts
@@ -63,4 +63,63 @@ describe("formatDuration", () => {
   it("allows to customize the delimiter", () => {
     expect(formatDuration({ months: 9, days: 2 }, { delimiter: ", " })).toBe("9 months, 2 days");
   });
+
+  it("formats full duration with a maximum of 2 units", () => {
+    expect(formatDuration(
+      {
+        years: 2,
+        months: 9,
+        weeks: 1,
+        days: 7,
+        hours: 5,
+        minutes: 9,
+        seconds: 30,
+      },
+      { maxUnits: 2 },
+    )).toBe("2 years 9 months");
+  });
+
+  it("formats a duration with gaps and a maximum of 2 units", () => {
+    expect(formatDuration(
+      {
+        months: 9,
+        hours: 5,
+      },
+      { maxUnits: 2 },
+    )).toBe("9 months 5 hours");
+  });
+
+  it("formats partial duration with a maximum of 3 units", () => {
+    expect(formatDuration({ months: 9, days: 2 },  { maxUnits: 3 })).toBe("9 months 2 days");
+  });
+
+  it("formats custom format duration with a maximum of 2 units", () => {
+    expect(formatDuration(
+      {
+        years: 2,
+        months: 9,
+        weeks: 3,
+        days: 7,
+        hours: 5,
+        minutes: 9,
+        seconds: 30,
+      },
+      { maxUnits: 2, format: ["months", "weeks", "hours"] },
+    )).toBe("9 months 3 weeks");
+  });
+
+  it("allows to include zeros with a maximum of 2 units", () => {
+    expect(formatDuration(
+      {
+        years: 0,
+        months: 1,
+        weeks: 0,
+        days: 0,
+        hours: 0,
+        minutes: 0,
+        seconds: 0,
+      },
+      { maxUnits: 2, zero: true },
+    )).toBe("0 years 1 month");
+  });
 });


### PR DESCRIPTION
## The issue

We want to humanise a duration for dates of various ranges that we don't know ahead of time (they could be minutes apart to months apart). For the longer durations we don't need to know the exact duration between the dates, but we want it to be more specific than just "1 month" (e.g. "1 month 3 days" but not "1 month 3 days 2 hours 34 minutes" etc.).

We could parse the duration before passing it to formatDuration and then only pass through the required units in the `format` option, but that would require a lot of extra logic vs just having formatDuration handle it with a simple check.

## The PR

This PR adds an option to specify the maximum amount of units to show. It simply stops appending units as soon as the limit is hit (after taking the other options into account).