### PR TITLE
Optionally omit timezone offset from `formatISO`

### DIFF
--- a/src/formatISO/index.ts
+++ b/src/formatISO/index.ts
@@ -7,7 +7,13 @@ import type { ContextOptions, DateArg, ISOFormatOptions } from "../types.js";
  */
 export interface FormatISOOptions
   extends ISOFormatOptions,
-    ContextOptions<Date> {}
+    ContextOptions<Date> {
+      /**
+       * Whether to include the time zone offset in the formatted string.
+       * @default true
+       */
+      includeOffset?: boolean
+    }
 
 /**
  * @name formatISO
@@ -43,6 +49,11 @@ export interface FormatISOOptions
  * // Represent 18 September 2019 in ISO 8601 format, time only (local time zone is UTC):
  * const result = formatISO(new Date(2019, 8, 18, 19, 0, 52), { representation: 'time' })
  * //=> '19:00:52Z'
+ *
+ * @example
+ * // Represent 18 September 2019 in ISO 8601 format, timezone omitted (local time zone is UTC):
+ * const result = formatISO(new Date(2019, 8, 18, 19, 0, 52), { includeOffset: false })
+ * //=> '2019-09-18T19:00:52'
  */
 export function formatISO(
   date: DateArg<Date> & {},
@@ -56,6 +67,7 @@ export function formatISO(
 
   const format = options?.format ?? "extended";
   const representation = options?.representation ?? "complete";
+  const includeOffset = options?.includeOffset ?? true;
 
   let result = "";
   let tzOffset = "";
@@ -78,16 +90,18 @@ export function formatISO(
     // Add the timezone.
     const offset = date_.getTimezoneOffset();
 
-    if (offset !== 0) {
-      const absoluteOffset = Math.abs(offset);
-      const hourOffset = addLeadingZeros(Math.trunc(absoluteOffset / 60), 2);
-      const minuteOffset = addLeadingZeros(absoluteOffset % 60, 2);
-      // If less than 0, the sign is +, because it is ahead of time.
-      const sign = offset < 0 ? "+" : "-";
-
-      tzOffset = `${sign}${hourOffset}:${minuteOffset}`;
-    } else {
-      tzOffset = "Z";
+    if (includeOffset === true) {
+      if (offset !== 0) {
+        const absoluteOffset = Math.abs(offset);
+        const hourOffset = addLeadingZeros(Math.trunc(absoluteOffset / 60), 2);
+        const minuteOffset = addLeadingZeros(absoluteOffset % 60, 2);
+        // If less than 0, the sign is +, because it is ahead of time.
+        const sign = offset < 0 ? "+" : "-";
+  
+        tzOffset = `${sign}${hourOffset}:${minuteOffset}`;
+      } else {
+        tzOffset = "Z";
+      }
     }
 
     const hour = addLeadingZeros(date_.getHours(), 2);

--- a/src/formatISO/test.ts
+++ b/src/formatISO/test.ts
@@ -65,6 +65,20 @@ describe("formatISO", () => {
     );
   });
 
+  it("optionally omits timezone offset", () => {
+    const date = new Date(2019, 2 /* Mar */, 3, 19, 0, 52, 123);
+    const tzOffset = generateOffset(date);
+
+    expect(
+      formatISO(date, { representation: "time", format: "extended", includeOffset: false }),
+    ).not.toContain(tzOffset);
+    expect(formatISO(date, { representation: "time", format: "basic", includeOffset: false })).not.toContain(tzOffset);
+    expect(
+      formatISO(date, { representation: "complete", format: "extended", includeOffset: false }),
+    ).not.toContain(tzOffset);
+    expect(formatISO(date, { representation: "complete", format: "basic", includeOffset: false })).not.toContain(tzOffset);
+  });
+
   it("throws RangeError if the time value is invalid", () => {
     expect(formatISO.bind(null, new Date(NaN))).toThrow(RangeError);
   });


### PR DESCRIPTION
Adds an option to `formatISO`, `includeOffset`, which can be set to
`false` to omit the timezone offset from the formatted string. This
option defaults to `true`, maintaining the existing behavior unless it
is explicitly set to `false` by a consumer.

The option is implemented in `FormatISOOptions` instead of the shared
`ISOFormatOptions` interface because the latter is shared by
`formatISO99075`, which does not support timezone offsets.
