### PR TITLE
use constants in `add()` and `sub()`

### DIFF
--- a/src/add/index.ts
+++ b/src/add/index.ts
@@ -1,5 +1,6 @@
 import { addDays } from "../addDays/index.js";
 import { addMonths } from "../addMonths/index.js";
+import { daysInWeek, millisecondsInSecond, minutesInHour, monthsInYear } from "../constants/index.js";
 import { constructFrom } from "../constructFrom/index.js";
 import { toDate } from "../toDate/index.js";
 import type { ContextOptions, DateArg, Duration } from "../types.js";
@@ -58,16 +59,16 @@ export function add<DateType extends Date, ResultDate extends Date = DateType>(
   // Add years and months
   const _date = toDate(date, options?.in);
   const dateWithMonths =
-    months || years ? addMonths(_date, months + years * 12) : _date;
+    months || years ? addMonths(_date, months + years * monthsInYear) : _date;
 
   // Add weeks and days
   const dateWithDays =
-    days || weeks ? addDays(dateWithMonths, days + weeks * 7) : dateWithMonths;
+    days || weeks ? addDays(dateWithMonths, days + weeks * daysInWeek) : dateWithMonths;
 
   // Add days, hours, minutes, and seconds
-  const minutesToAdd = minutes + hours * 60;
-  const secondsToAdd = seconds + minutesToAdd * 60;
-  const msToAdd = secondsToAdd * 1000;
+  const minutesToAdd = minutes + hours * minutesInHour;
+  const secondsToAdd = seconds + minutesToAdd * minutesInHour;
+  const msToAdd = secondsToAdd * millisecondsInSecond;
 
   return constructFrom(options?.in || date, +dateWithDays + msToAdd);
 }

--- a/src/sub/index.ts
+++ b/src/sub/index.ts
@@ -1,3 +1,4 @@
+import { daysInWeek, millisecondsInSecond, minutesInHour, monthsInYear } from "../constants/index.js";
 import { constructFrom } from "../constructFrom/index.js";
 import { subDays } from "../subDays/index.js";
 import { subMonths } from "../subMonths/index.js";
@@ -66,12 +67,12 @@ export function sub<DateType extends Date, ResultDate extends Date = DateType>(
     seconds = 0,
   } = duration;
 
-  const withoutMonths = subMonths(date, months + years * 12, options);
-  const withoutDays = subDays(withoutMonths, days + weeks * 7, options);
+  const withoutMonths = subMonths(date, months + years * monthsInYear, options);
+  const withoutDays = subDays(withoutMonths, days + weeks * daysInWeek, options);
 
-  const minutesToSub = minutes + hours * 60;
-  const secondsToSub = seconds + minutesToSub * 60;
-  const msToSub = secondsToSub * 1000;
+  const minutesToSub = minutes + hours * minutesInHour;
+  const secondsToSub = seconds + minutesToSub * minutesInHour;
+  const msToSub = secondsToSub * millisecondsInSecond;
 
   return constructFrom(options?.in || date, +withoutDays - msToSub);
 }


### PR DESCRIPTION
Switches to use the already defined constants in the `add()` and `sub()` methods.