### PR TITLE
fix: isWithinInterval example

### DIFF
--- a/src/isWithinInterval/index.ts
+++ b/src/isWithinInterval/index.ts
@@ -38,12 +38,12 @@ export interface IsWithinIntervalOptions extends ContextOptions<Date> {}
  *
  * @example
  * // For date equal to the interval start:
- * isWithinInterval(date, { start, end: date })
+ * isWithinInterval(date, { start: date, end })
  * // => true
  *
  * @example
  * // For date equal to the interval end:
- * isWithinInterval(date, { start: date, end })
+ * isWithinInterval(date, { start, end: date })
  * // => true
  */
 export function isWithinInterval(


### PR DESCRIPTION
The documentation examples for isWithinInterval contained misleading descriptions. This fix updates the examples to ensure they are accurate and easier to understand.

Since this is a documentation-only update, it does not affect the functionality of the code.