### PR TITLE
Fix ordinal numbers for ko

### DIFF
--- a/src/locale/ko/_lib/localize/index.ts
+++ b/src/locale/ko/_lib/localize/index.ts
@@ -144,13 +144,24 @@ const ordinalNumber: LocalizeFn<number> = (dirtyNumber, options) => {
   const unit = String(options?.unit);
 
   switch (unit) {
-    case "minute":
-    case "second":
-      return String(number);
+    case "year":
+      return `${number}년`;
+    case "quater":
+      return `${number}분기`;
+    case "month":
+      return `${number}월`;
+    case "week":
+      return `${number}주`;
     case "date":
-      return number + "일";
+      return `${number}일`;
+    case "hour":
+      return `${number}시`;
+    case "minute":
+      return `${number}분`;
+    case "second":
+      return `${number}초`;
     default:
-      return number + "번째";
+      return `${number}`;
   }
 };
 

--- a/src/locale/ko/_lib/match/index.ts
+++ b/src/locale/ko/_lib/match/index.ts
@@ -3,7 +3,7 @@ import type { Match } from "../../../types.js";
 import { buildMatchFn } from "../../../_lib/buildMatchFn/index.js";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.js";
 
-const matchOrdinalNumberPattern = /^(\d+)(일|번째)?/i;
+const matchOrdinalNumberPattern = /^(\d+)(년|분기|월|주|일|시|분|초|번째)?/i;
 const parseOrdinalNumberPattern = /\d+/i;
 
 const matchEraPatterns = {

--- a/src/locale/ko/index.ts
+++ b/src/locale/ko/index.ts
@@ -13,6 +13,7 @@ import { match } from "./_lib/match/index.js";
  * @author Hong Chulju [@angdev](https://github.com/angdev)
  * @author Lee Seoyoen [@iamssen](https://github.com/iamssen)
  * @author Taiki IKeda [@so99ynoodles](https://github.com/so99ynoodles)
+ * @author Seungduk Seo [@seosd97](https://github.com/seosd97)
  */
 export const ko: Locale = {
   code: "ko",


### PR DESCRIPTION
I found issue for ordinal numbers for ko.

Currently, '번째' is used as a unit for ordinal numbers, but it looks odd because '번째' is a direct translation of English ordinal numbers. In Korean, it can be used for simply counting ordinal numbers, but it cannot represent a date without an additional suffix, such as '1번째 달'.
Only '일' is used for the day when formatting dates like '1st January'. I think this is correct, but other date units also need the appropriate unit.

I've referenced languages that ja which use almost the same grammar for date.
年 -> 년
四半期 -> 분기
月 -> 월
週 -> 주
日 -> 일
