### PR TITLE
doc: update roundToNearestHours docs

### DIFF
--- a/src/roundToNearestHours/index.ts
+++ b/src/roundToNearestHours/index.ts
@@ -40,22 +40,22 @@ export interface RoundToNearestHoursOptions<DateType extends Date = Date>
  * //=> Thu Jul 10 2014 13:00:00
  *
  * @example
- * // Round 10 July 2014 12:34:56 to nearest half hour:
+ * // Round 10 July 2014 12:34:56 to nearest multiple of 6 hours:
  * const result = roundToNearestHours(new Date(2014, 6, 10, 12, 34, 56), { nearestTo: 6 })
  * //=> Thu Jul 10 2014 12:00:00
  *
  * @example
- * // Round 10 July 2014 12:34:56 to nearest half hour:
+ * // Round 10 July 2014 12:34:56 to nearest multiple of 8 hours:
  * const result = roundToNearestHours(new Date(2014, 6, 10, 12, 34, 56), { nearestTo: 8 })
  * //=> Thu Jul 10 2014 16:00:00
  *
  * @example
- * // Floor (rounds down) 10 July 2014 12:34:56 to nearest hour:
+ * // Ceil (rounds up) 10 July 2014 1:23:45 to nearest hour:
  * const result = roundToNearestHours(new Date(2014, 6, 10, 1, 23, 45), { roundingMethod: 'ceil' })
  * //=> Thu Jul 10 2014 02:00:00
  *
  * @example
- * // Ceil (rounds up) 10 July 2014 12:34:56 to nearest quarter hour:
+ * // Floor (rounds down) 10 July 2014 12:34:56 to nearest multiple of 8 hours:
  * const result = roundToNearestHours(new Date(2014, 6, 10, 12, 34, 56), { roundingMethod: 'floor', nearestTo: 8 })
  * //=> Thu Jul 10 2014 08:00:00
  */


### PR DESCRIPTION
I'm not too happy with how I've described how nearestTo works. Still feels unclear to me. I'm open to better wording of it

- Fix description of examples of nearestTo because you can't round to fractions of hours. You can only round to multiples of hours
- Fix description of ceil and floor examples as they were describing the wrong examples.
- Fix Time in description of ceil example

fixes #3976