### PR TITLE
feat: add isLeapDecade util with tests

### DIFF
--- a/src/isLeapDecade/index.ts
+++ b/src/isLeapDecade/index.ts
@@ -1,0 +1,46 @@
+import { isLeapYear } from '../isLeapYear/index.js'
+import { toDate } from '../toDate/index.js'
+import type { ContextOptions, DateArg } from '../types.js'
+
+export interface IsLeapDecadeOptions extends ContextOptions<Date> {}
+
+/**
+ * @name isLeapDecade
+ * @category Decade Helpers
+ * @summary Check if a decade contains at least 3 leap years.
+ *
+ * @description
+ * Given a year, this function checks if the decade that year belongs to
+ * has at least 3 leap years.
+ *
+ * Leap years are calculated using the existing isLeapYear utility.
+ *
+ * @param date - the given date
+ * @param options - The options object
+ * @returns true if the decade has 3 or more leap years, false otherwise
+ *
+ * @example
+ * // Is the 1990s a leap decade?
+ * const result = isLeapDecade(new Date(1995, 0, 1))
+ * //=> false
+ */
+export default function isLeapDecade(
+  date: DateArg<Date>,
+  options?: IsLeapDecadeOptions,
+): boolean {
+  const targetDate = toDate(date, options?.in)
+  if (isNaN(targetDate.getTime())) return false
+
+  const year = targetDate.getFullYear()
+  const decadeStart = Math.floor(year / 10) * 10
+  const decadeEnd = decadeStart + 9
+
+  let leapCount = 0
+  for (let y = decadeStart; y <= decadeEnd; y++) {
+    if (isLeapYear(new Date(y, 0, 1))) {
+      leapCount++
+    }
+  }
+
+  return leapCount >= 3
+}

--- a/src/isLeapDecade/test.ts
+++ b/src/isLeapDecade/test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { tz } from '@date-fns/tz'
+import isLeapDecade from './index.js'
+
+describe('isLeapDecade', () => {
+  it('returns false for a decade with less than 3 leap years (1990s)', () => {
+    expect(isLeapDecade(new Date(1995, 0, 1))).toBe(false)
+  })
+
+  it('returns false for a decade with less than 3 leap years (2010s)', () => {
+    expect(isLeapDecade(new Date(2017, 0, 1))).toBe(false)
+  })
+
+  it('works with a timestamp', () => {
+    const timestamp = new Date(2004, 0, 1).getTime()
+    expect(isLeapDecade(timestamp)).toBe(true)
+  })
+
+  it('returns true for the 2000s', () => {
+    expect(isLeapDecade(new Date(2004, 0, 1))).toBe(true)
+  })
+
+  it('returns false for the 1900s', () => {
+    expect(isLeapDecade(new Date(1900, 0, 1))).toBe(false)
+  })
+
+  it('returns false if the input is an Invalid Date', () => {
+    expect(isLeapDecade(new Date(NaN))).toBe(false)
+  })
+
+  describe('context', () => {
+    it('handles time zone context correctly', () => {
+      expect(
+        isLeapDecade('2000-01-01T00:00:00Z', {
+          in: tz('Asia/Singapore'),
+        }),
+      ).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
### Summary

This PR adds the `isLeapDecade` utility function to determine whether a given decade includes at least 3 leap years.

### Changes

- New function: `isLeapDecade(date)`
- Full test suite for various decades and contexts
- Integration with `context` option

### Notes

Tests are passing ✅ except for some unrelated context tests in `addMinutes` / `subMinutes`.

### Checklist

- [x] Function implemented
- [x] Unit tests added
- [x] Tests pass
