### PR TITLE
#3710 fix isValid/toDate to consistently accept string arg

### DIFF
--- a/src/isValid/index.ts
+++ b/src/isValid/index.ts
@@ -23,15 +23,20 @@ import { toDate } from "../toDate/index.js";
  * //=> true
  *
  * @example
- * // For the value, convertible into a date:
+ * // For the numeric value, convertible into a date:
  * const result = isValid(1393804800000)
  * //=> true
  *
+ * @example
+ * // For the string value, convertible into a date:
+ * const result = isValid('2014-02-11T11:30:30.000Z')
+ * //=> true
+ * 
  * @example
  * // For the invalid date:
  * const result = isValid(new Date(''))
  * //=> false
  */
 export function isValid(date: unknown): boolean {
-  return !((!isDate(date) && typeof date !== "number") || isNaN(+toDate(date)));
+  return !((!isDate(date) && typeof date !== "number" && typeof date !== "string") || isNaN(+toDate(date)));
 }

--- a/src/isValid/test.ts
+++ b/src/isValid/test.ts
@@ -17,6 +17,16 @@ describe("isValid", () => {
     expect(isValid(NaN)).toBe(false);
   });
 
+  it("accepts a valid number", () => {
+    expect(isValid(1393804800000)).toBe(true);
+    expect(isValid(2**53+1)).toBe(false);
+  });
+
+  it("accepts a valid string", () => {
+    expect(isValid('2014-02-11T11:30:30.000Z')).toBe(true);
+    expect(isValid('asd')).toBe(false);
+  });
+
   it("treats null as an invalid date", () => {
     const result = isValid(null);
     expect(result).toBe(false);

--- a/src/toDate/index.ts
+++ b/src/toDate/index.ts
@@ -12,6 +12,8 @@ import type { ConstructableDate, ContextFn, DateArg } from "../types.js";
  * If the argument is an instance of Date, the function returns its clone.
  *
  * If the argument is a number, it is treated as a timestamp.
+ * 
+ * If the argument is a string, it is parsed by new Date("string").
  *
  * If the argument is none of the above, the function returns Invalid Date.
  *
@@ -37,6 +39,11 @@ import type { ConstructableDate, ContextFn, DateArg } from "../types.js";
  * @example
  * // Convert the timestamp to date:
  * const result = toDate(1392098430000)
+ * //=> Tue Feb 11 2014 11:30:30
+ * 
+ * @example
+ * // Convert the string to date:
+ * const result = toDate('2014-02-11T11:30:30.000Z')
  * //=> Tue Feb 11 2014 11:30:30
  */
 export function toDate<

--- a/src/toDate/test.ts
+++ b/src/toDate/test.ts
@@ -22,6 +22,17 @@ describe("toDate", () => {
     });
   });
 
+  describe("string argument", () => {
+    it("creates a date from a valid string", () => {
+      const result = toDate("2016-01-01T23:30:45.123Z");
+      expect(result).toEqual(new Date("2016-01-01T23:30:45.123Z"));
+    });
+    it("returns invalid Date if string is invalid date", () => {
+      const result = toDate("asd");
+      expect(isNaN(result.getTime())).toBe(true);
+    });
+  });
+
   describe("invalid argument", () => {
     it("returns Invalid Date if argument is NaN", () => {
       const result = toDate(NaN);


### PR DESCRIPTION
Issue #3710 has a good description for this PR.

## Current situation:

- `toDate` is being used in all functions to parse function argument from `Date`, `number`, `string`
- `isValid` is not currently accepting `string` as a valid date
- this situation is not consistent
- documentation is not clear about this

## Proposed Solution

- Make `isValid` accept string and return `true` or `false` depending on `toDate` parsing returning valid or invalid Date. This dependency from `isValid` to `toDate` makes them consistent
- Make documentation clear about strings in these two functions
- Update tests to check on strings valid or invalid