### PR TITLE
Add startOfSemester and endOfSemester #3812

### DIFF
--- a/src/endOfSemester/index.ts
+++ b/src/endOfSemester/index.ts
@@ -1,0 +1,45 @@
+import { toDate } from "../toDate/index.js";
+import type { ContextOptions, DateArg } from "../types.js";
+
+/**
+ * The {@link endOfSemester} function options.
+ */
+export interface EndOfSemesterOptions<DateType extends Date = Date>
+  extends ContextOptions<DateType> {}
+
+/**
+ * @name endOfSemester
+ * @category Semester Helpers
+ * @summary Return the end of a year semester for the given date.
+ *
+ * @description
+ * Return the end of a year semester for the given date.
+ * The result will be in the local timezone.
+ *
+ * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
+ * @typeParam ResultDate - The result `Date` type, it is the type returned from the context function if it is passed, or inferred from the arguments.
+ *
+ * @param date - The original date
+ * @param options - An object with options
+ *
+ * @returns The end of a semester
+ *
+ * @example
+ * // The end of a semester for 2 September 2014 11:55:00:
+ * const result = endOfSemester(new Date(2014, 8, 2, 11, 55, 0))
+ * //=> Wed Dec 30 2014 23:59:59.999
+ */
+export function endOfSemester<
+  DateType extends Date,
+  ResultDate extends Date = DateType,
+>(
+  date: DateArg<DateType>,
+  options?: EndOfSemesterOptions<ResultDate> | undefined,
+): ResultDate {
+  const _date = toDate(date, options?.in);
+  const currentMonth = _date.getMonth();
+  const month = currentMonth - (currentMonth % 6) + 6;
+  _date.setMonth(month, 0);
+  _date.setHours(23, 59, 59, 999);
+  return _date;
+}

--- a/src/endOfSemester/test.ts
+++ b/src/endOfSemester/test.ts
@@ -1,0 +1,92 @@
+import { TZDate, tz } from "@date-fns/tz";
+import { UTCDate } from "@date-fns/utc";
+import { describe, expect, it } from "vitest";
+import { assertType } from "../_lib/test/index.js";
+import { endOfSemester } from "./index.js";
+
+describe("endOfSemester", () => {
+  const semester1End = new Date(2014, 5, 30, 23, 59, 59, 999);
+  const semester2End = new Date(2014, 11, 31, 23, 59, 59, 999);
+  it("returns the date with the time set to 23:59:59.999 and the date set to the last day of a semester", () => {
+    const date = new Date(2014, 8 /* Sep */, 2, 11, 55, 0);
+    const result = endOfSemester(date);
+    expect(result).toEqual(semester2End);
+  });
+
+  it("30 of June should be in the first semester", () => {
+    const date = new Date(2014, 5 /* Jun */, 30, 23, 59, 59, 999);
+    const result = endOfSemester(date);
+    expect(result).toEqual(semester1End);
+  });
+
+  it("1 of July should be in the second semester", () => {
+    const date = new Date(2014, 6 /* Jul */, 1);
+    const result = endOfSemester(date);
+    expect(result).toEqual(semester2End);
+  });
+
+  it("1 of January should be in the first semester", () => {
+    const date = new Date(2014, 0, 1);
+    const result = endOfSemester(date);
+    expect(result).toEqual(semester1End);
+  });
+
+  it("31 of Decembers should be in the second semester", () => {
+    const date = new Date(2014, 11, 31);
+    const result = endOfSemester(date);
+    expect(result).toEqual(semester2End)
+  });
+
+  it("accepts a timestamp", () => {
+    const date = new Date(2014, 8 /* Sep */, 2, 11, 55, 0).getTime();
+    const result = endOfSemester(date);
+    expect(result).toEqual(semester2End);
+  });
+
+  it("does not mutate the original date", () => {
+    const date = new Date(2014, 8 /* Sep */, 2, 11, 55, 0);
+    endOfSemester(date);
+    expect(date).toEqual(date);
+  });
+
+  it("returns `Invalid Date` if the given date is invalid", () => {
+    const result = endOfSemester(new Date(NaN));
+    expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
+  });
+
+  it("resolves the date type by default", () => {
+    const result = endOfSemester(Date.now());
+    expect(result).toBeInstanceOf(Date);
+    assertType<assertType.Equal<Date, typeof result>>(true);
+  });
+
+  it("resolves the argument type if a date extension is passed", () => {
+    const result = endOfSemester(new UTCDate());
+    expect(result).toBeInstanceOf(UTCDate);
+    assertType<assertType.Equal<UTCDate, typeof result>>(true);
+  });
+
+  describe("context", () => {
+    it("allows to specify the context", () => {
+      expect(
+        endOfSemester("2024-04-10T07:00:00Z", {
+          in: tz("Asia/Singapore"),
+        }).toISOString(),
+      ).toBe("2024-06-30T23:59:59.999+08:00");
+      expect(
+        endOfSemester("2024-04-10T07:00:00Z", {
+          in: tz("America/Los_Angeles"),
+        }).toISOString(),
+      ).toBe("2024-06-30T23:59:59.999-07:00");
+    });
+
+    it("resolves the context date type", () => {
+      const date = new Date("2014-09-01T00:00:00Z");
+      const result = endOfSemester(date, {
+        in: tz("Asia/Tokyo"),
+      });
+      expect(result).toBeInstanceOf(TZDate);
+      assertType<assertType.Equal<TZDate, typeof result>>(true);
+    });
+  });
+});

--- a/src/startOfSemester/index.ts
+++ b/src/startOfSemester/index.ts
@@ -1,0 +1,45 @@
+import { toDate } from "../toDate/index.js";
+import type { ContextOptions, DateArg } from "../types.js";
+
+/**
+ * The {@link startOfSemester} function options.
+ */
+export interface StartOfSemesterOptions<DateType extends Date = Date>
+  extends ContextOptions<DateType> {}
+
+/**
+ * @name startOfSemester
+ * @category Semester Helpers
+ * @summary Return the start of a year semester for the given date.
+ *
+ * @description
+ * Return the start of a year semester for the given date.
+ * The result will be in the local timezone.
+ *
+ * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
+ * @typeParam ResultDate - The result `Date` type, it is the type returned from the context function if it is passed, or inferred from the arguments.
+ *
+ * @param date - The original date
+ * @param options - The options
+ *
+ * @returns The start of a semester
+ *
+ * @example
+ * // The start of a semester for 2 September 2014 11:55:00:
+ * const result = startOfSemester(new Date(2014, 8, 2, 11, 55, 0))
+ * //=> Tue Jul 01 2014 00:00:00
+ */
+export function startOfSemester<
+  DateType extends Date,
+  ResultDate extends Date = DateType,
+>(
+  date: DateArg<DateType>,
+  options?: StartOfSemesterOptions<ResultDate> | undefined,
+): ResultDate {
+  const _date = toDate(date, options?.in);
+  const currentMonth = _date.getMonth();
+  const month = currentMonth - (currentMonth % 6);
+  _date.setMonth(month, 1);
+  _date.setHours(0, 0, 0, 0);
+  return _date;
+}

--- a/src/startOfSemester/test.ts
+++ b/src/startOfSemester/test.ts
@@ -1,0 +1,86 @@
+import { TZDate, tz } from "@date-fns/tz";
+import { UTCDate } from "@date-fns/utc";
+import { describe, expect, it } from "vitest";
+import { assertType } from "../_lib/test/index.js";
+import { startOfSemester} from "./index.js";
+
+describe("startOfQuarter", () => {
+  const semester1Start = new Date(2014, 0, 1);
+  const semester2Start = new Date(2014, 6, 1);
+  it("returns the date with the time set to 00:00:00 and the date set to the first day of a semester",
+  () => {
+    const date = new Date(2014, 8 /* Sep */, 2, 11, 55, 0);
+    const result = startOfSemester(date);
+    expect(result).toEqual(new Date(2014, 6 /* Jul */, 1));
+  });
+
+  it("30 of June should be in the first semester", () => {
+    const date = new Date(2014, 5 /* Jun */, 30, 23, 59, 59, 999);
+    const result = startOfSemester(date);
+    expect(result).toEqual(semester1Start);
+  });
+
+  it("1 of July should be in the second semester", () => {
+    const date = new Date(2014, 6 /* Jul */, 1);
+    const result = startOfSemester(date);
+    expect(result).toEqual(semester2Start);
+  });
+
+  it("1 of January should be in the first semester", () => {
+    const date = new Date(2014, 0, 1);
+    const result = startOfSemester(date);
+    expect(result).toEqual(semester1Start);
+  });
+
+  it("31 of Decembers should be in the second semester", () => {
+    const date = new Date(2014, 11, 31);
+    const result = startOfSemester(date);
+    expect(result).toEqual(semester2Start);
+  });
+
+  it("accepts a timestamp", () => {
+    const date = new Date(2014, 8 /* Sep */, 2, 11, 55, 0).getTime();
+    const result = startOfSemester(date);
+    expect(result).toEqual(new Date(2014, 6 /* Jul */, 1));
+  });
+
+  it("does not mutate the original date", () => {
+    const date = new Date(2014, 8 /* Sep */, 2, 11, 55, 0);
+    startOfSemester(date);
+    expect(date).toEqual(new Date(2014, 8 /* Sep */, 2, 11, 55, 0));
+  });
+
+  it("returns `Invalid Date` if the given date is invalid", () => {
+    const result = startOfSemester(new Date(NaN));
+    expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
+  });
+
+  it("resolves the date type by default", () => {
+    const result = startOfSemester(Date.now());
+    expect(result).toBeInstanceOf(Date);
+    assertType<assertType.Equal<Date, typeof result>>(true);
+  });
+
+  it("resolves the argument type if a date extension is passed", () => {
+    const result = startOfSemester(new UTCDate());
+    expect(result).toBeInstanceOf(UTCDate);
+    assertType<assertType.Equal<UTCDate, typeof result>>(true);
+  });
+
+  describe("context", () => {
+    it("allows to specify the context", () => {
+      const date = new Date(2022, 1 /* Feb */, 19);
+      const context = { in: tz("America/New_York") };
+      const result = startOfSemester(date, context);
+      expect(result.toISOString()).toEqual("2022-01-01T00:00:00.000-05:00");
+    });
+
+    it("resolves the context date type", () => {
+      const date = new Date(2022, 1 /* Feb */, 19);
+      const context = { in: tz("America/New_York") };
+      const result = startOfSemester(date, context);
+      expect(result).toBeInstanceOf(TZDate);
+      assertType<assertType.Equal<TZDate, typeof result>>(true);
+    });
+  });
+});


### PR DESCRIPTION
I’m creating this pull request to add the startOfSemester and endOfSemester functions, as described in issue #3812.

The implementation is based on the existing startOfQuarter and endOfQuarter functions.

This is my first pull request to an open source repository, so please let me know if there are any issues.

Thank you!

