### PR TITLE
Fix slovene short format to obey linguistic rules

### DIFF
--- a/src/locale/sl/_lib/formatLong/index.ts
+++ b/src/locale/sl/_lib/formatLong/index.ts
@@ -5,7 +5,7 @@ const dateFormats = {
   full: "EEEE, dd. MMMM y",
   long: "dd. MMMM y",
   medium: "d. MMM y",
-  short: "d. MM. yy",
+  short: "d. M. y",
 };
 
 const timeFormats = {


### PR DESCRIPTION
Slovene linguistic rules demand that dates be written without leading zeroes and with spaces after the dot. They also don't cater for a two-digit year.

I hope. I was just put off by current solution which was inconsistent between day and month: one was WITH leading zeroes, one without. THAT is DEFINITELY wrong!

Native Slovene here.

also, two sources I could find on the subject:
https://www.leemeta.si/blog/slovenski-pravopis/kako-pravilno-zapisemo-datum-v-slovenscini
https://www.rtvslo.si/kultura/jezikovni-spletovalec/5-preprostih-pravil-zapisovanje-datuma-in-ure/551842