### PR TITLE
Fix intervalToDuration JSDOC example output

### DIFF
--- a/src/intervalToDuration/index.ts
+++ b/src/intervalToDuration/index.ts
@@ -32,7 +32,7 @@ export interface IntervalToDurationOptions extends ContextOptions<Date> {}
  *   start: new Date(1929, 0, 15, 12, 0, 0),
  *   end: new Date(1968, 3, 4, 19, 5, 0)
  * });
- * //=> { years: 39, months: 2, days: 20, hours: 7, minutes: 5, seconds: 0 }
+ * //=> { years: 39, months: 2, days: 20, hours: 7, minutes: 5 }
  */
 export function intervalToDuration(
   interval: Interval,


### PR DESCRIPTION
Fixes JSDoc example output for `intervalToDuration`, it still shows `seconds:
0`, which according to changelog is no longer produced.

- [CHANGELOG.md#L255](https://github.com/date-fns/date-fns/blob/6c70ac6d073ebe869e42795f5e71dfecf5abbea0/CHANGELOG.md?plain=1#L255)

> BREAKING: intervalToDuration now skips 0 values in the resulting duration,
> resulting in more compact objects with only relevant properties.

Tripped up some calculations I did, thought my data was mangled somehow, until
I read the changelog. Example should reflect this breaking change.

Thanks for a great library!
