### PR TITLE
Feat/next business day

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "date-fns",
       "version": "4.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@umalqura/core": "^0.0.7"
+      },
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.16.2",
         "@babel/cli": "^7.22.10",
@@ -22,6 +25,7 @@
         "@size-limit/file": "^11.0.1",
         "@types/bun": "^1.1.9",
         "@types/lodash": "^4.14.202",
+        "@types/mocha": "^10.0.10",
         "@types/node": "^20.14.2",
         "@types/sinon": "^9.0.6",
         "@typescript-eslint/eslint-plugin": "^8.5.0",
@@ -3700,6 +3704,13 @@
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true
     },
+    "node_modules/@types/mocha": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.14.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
@@ -4000,6 +4011,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@umalqura/core": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@umalqura/core/-/core-0.0.7.tgz",
+      "integrity": "sha512-o8G1J2KRzM/Hal5Taln1QHzhfJsE4+8hQH087Pl6C0ZjPhmw7tjjuejjbgj++Lc2BP4kRDswTJ3J5TuGGybA2Q==",
+      "license": "MIT"
     },
     "node_modules/@vitest/browser": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -7442,6 +7442,7 @@
     "@size-limit/file": "^11.0.1",
     "@types/bun": "^1.1.9",
     "@types/lodash": "^4.14.202",
+    "@types/mocha": "^10.0.10",
     "@types/node": "^20.14.2",
     "@types/sinon": "^9.0.6",
     "@typescript-eslint/eslint-plugin": "^8.5.0",
@@ -7468,5 +7469,8 @@
     "typedoc-plugin-missing-exports": "^3.0.0",
     "typescript": "^5.4.5",
     "vitest": "^1.3.1"
+  },
+  "dependencies": {
+    "@umalqura/core": "^0.0.7"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,4 +245,5 @@ export * from "./weeksToDays/index.js";
 export * from "./yearsToDays/index.js";
 export * from "./yearsToMonths/index.js";
 export * from "./yearsToQuarters/index.js";
-export type * from "./types.js";
+export * from "./types.js";
+

--- a/src/nextBusinessDay/index.ts
+++ b/src/nextBusinessDay/index.ts
@@ -3,38 +3,47 @@ import { isWeekend } from '../isWeekend/index.js';
 import { isEqual } from '../isEqual/index.js';
 import { toDate } from '../toDate/index.js';
 
+/**
+ * Options for nextBusinessDay function
+ */
 export interface NextBusinessDayOptions {
   holidays?: Date[];
 }
 
 /**
- * @name nextBusinessDay
- * @category Business Day Helpers
- * @summary Get the next business day (excluding weekends and optional holidays).
- *
- * @description
- * Returns the next business day after the given date. Skips weekends and custom holidays.
- *
- * @param date - The starting date
- * @param options - Optional holidays to skip
- * @returns The next business day
+ * Returns the next business day, skipping weekends and optional holidays
+ * @param {Date|number} [date] - The starting date (defaults to now)
+ * @param {NextBusinessDayOptions} [options] - Configuration options
+ * @returns {Date} The next business day
  *
  * @example
- * // Next business day after Friday:
- * nextBusinessDay(new Date(2025, 6, 18)) // => Mon Jul 21 2025
+ * // Basic usage (skips weekends)
+ * nextBusinessDay(new Date(2025, 6, 18)) // Fri Jul 18 → Mon Jul 21
  *
- * // Skip custom holidays:
- * nextBusinessDay(new Date(2025, 6, 2), { holidays: [new Date(2025, 6, 3)] })
+ * // With custom holidays
+ * nextBusinessDay(new Date(2025, 6, 2), {
+ *   holidays: [new Date(2025, 6, 3)] // Skip July 3
+ * })
  */
-export function nextBusinessDay(date: Date | number, options?: NextBusinessDayOptions): Date {
-  let result = toDate(date);
-  const holidays: Date[] = options?.holidays?.map((d) => toDate(d)) || [];
+export function nextBusinessDay(
+  date?: Date | number,
+  options?: NextBusinessDayOptions
+): Date {
+  // 1. Convert input to Date object (or use current date if undefined)
+  let currentDate = date ? toDate(date) : toDate(Date.now());
+
+  // 2. Prepare holidays array (empty if not provided)
+  const holidays = (options?.holidays || []).map((holiday) => toDate(holiday));
 
   do {
-    result = addDays(result, 1);
+    // 3. Move to next day
+    currentDate = addDays(currentDate, 1);
   } while (
-    isWeekend(result) || holidays.some((holiday) => isEqual(holiday, result))
+    // 4. Continue searching if:
+    isWeekend(currentDate) || // - It's a weekend
+    holidays.some((holiday) => isEqual(holiday, currentDate)) // - It's a holiday
   );
 
-  return result;
+  // 5. Return the found business day
+  return currentDate;
 }

--- a/src/nextBusinessDay/index.ts
+++ b/src/nextBusinessDay/index.ts
@@ -1,0 +1,40 @@
+import { addDays } from '../addDays/index.js';
+import { isWeekend } from '../isWeekend/index.js';
+import { isEqual } from '../isEqual/index.js';
+import { toDate } from '../toDate/index.js';
+
+export interface NextBusinessDayOptions {
+  holidays?: Date[];
+}
+
+/**
+ * @name nextBusinessDay
+ * @category Business Day Helpers
+ * @summary Get the next business day (excluding weekends and optional holidays).
+ *
+ * @description
+ * Returns the next business day after the given date. Skips weekends and custom holidays.
+ *
+ * @param date - The starting date
+ * @param options - Optional holidays to skip
+ * @returns The next business day
+ *
+ * @example
+ * // Next business day after Friday:
+ * nextBusinessDay(new Date(2025, 6, 18)) // => Mon Jul 21 2025
+ *
+ * // Skip custom holidays:
+ * nextBusinessDay(new Date(2025, 6, 2), { holidays: [new Date(2025, 6, 3)] })
+ */
+export function nextBusinessDay(date: Date | number, options?: NextBusinessDayOptions): Date {
+  let result = toDate(date);
+  const holidays: Date[] = options?.holidays?.map((d) => toDate(d)) || [];
+
+  do {
+    result = addDays(result, 1);
+  } while (
+    isWeekend(result) || holidays.some((holiday) => isEqual(holiday, result))
+  );
+
+  return result;
+}

--- a/src/nextBusinessDay/test.ts
+++ b/src/nextBusinessDay/test.ts
@@ -1,0 +1,21 @@
+import assert from 'assert';
+import { nextBusinessDay } from '../../src/nextBusinessDay/index.js';
+
+describe('nextBusinessDay', () => {
+  it('returns next Monday after Friday', () => {
+    const result = nextBusinessDay(new Date(2025, 6, 18)); // Fri
+    assert.deepStrictEqual(result, new Date(2025, 6, 21)); // Mon
+  });
+
+  it('skips custom holidays', () => {
+    const result = nextBusinessDay(new Date(2025, 6, 2), {
+      holidays: [new Date(2025, 6, 3)], // 3rd is holiday
+    });
+    assert.deepStrictEqual(result, new Date(2025, 6, 4));
+  });
+
+  it('works when current date is weekend', () => {
+    const result = nextBusinessDay(new Date(2025, 6, 19)); // Saturday
+    assert.deepStrictEqual(result, new Date(2025, 6, 21)); // Monday
+  });
+});

--- a/src/nextBusinessDay/test.ts
+++ b/src/nextBusinessDay/test.ts
@@ -1,21 +1,50 @@
-import assert from 'assert';
-import { nextBusinessDay } from '../../src/nextBusinessDay/index.js';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest'
+import { nextBusinessDay } from './index.js'
 
 describe('nextBusinessDay', () => {
+  // Freeze time for consistent tests when no date is provided
+  beforeAll(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2025, 6, 20)) // Sunday, July 20, 2025
+  })
+
+  afterAll(() => {
+    vi.useRealTimers()
+  })
+
   it('returns next Monday after Friday', () => {
-    const result = nextBusinessDay(new Date(2025, 6, 18)); // Fri
-    assert.deepStrictEqual(result, new Date(2025, 6, 21)); // Mon
-  });
+    const friday = new Date(2025, 6, 18)
+    const result = nextBusinessDay(friday)
+    expect(result).toEqual(new Date(2025, 6, 21))
+  })
+
+  it('returns next day if not weekend (Thursday -> Friday)', () => {
+    const thursday = new Date(2025, 6, 17)
+    const result = nextBusinessDay(thursday)
+    expect(result).toEqual(new Date(2025, 6, 18))
+  })
+
+  it('skips weekend when starting on Saturday', () => {
+    const saturday = new Date(2025, 6, 19)
+    const result = nextBusinessDay(saturday)
+    expect(result).toEqual(new Date(2025, 6, 21))
+  })
+
+  it('skips weekend when starting on Sunday', () => {
+    const sunday = new Date(2025, 6, 20)
+    const result = nextBusinessDay(sunday)
+    expect(result).toEqual(new Date(2025, 6, 21))
+  })
+
+  it('defaults to next business day from today (Sunday -> Monday)', () => {
+    const result = nextBusinessDay()
+    expect(result).toEqual(new Date(2025, 6, 21))
+  })
 
   it('skips custom holidays', () => {
-    const result = nextBusinessDay(new Date(2025, 6, 2), {
-      holidays: [new Date(2025, 6, 3)], // 3rd is holiday
-    });
-    assert.deepStrictEqual(result, new Date(2025, 6, 4));
-  });
-
-  it('works when current date is weekend', () => {
-    const result = nextBusinessDay(new Date(2025, 6, 19)); // Saturday
-    assert.deepStrictEqual(result, new Date(2025, 6, 21)); // Monday
-  });
-});
+    const wednesday = new Date(2025, 6, 2)
+    const holiday = new Date(2025, 6, 3)
+    const result = nextBusinessDay(wednesday, { holidays: [holiday] })
+    expect(result).toEqual(new Date(2025, 6, 4))
+  })
+})

--- a/src/startOfToday/index.ts
+++ b/src/startOfToday/index.ts
@@ -26,6 +26,12 @@ export interface StartOfTodayOptions<DateType extends Date = Date>
  * // If today is 6 October 2014:
  * const result = startOfToday()
  * //=> Mon Oct 6 2014 00:00:00
+ *
+ * @example
+ * // If today is 18 August 2024 in Asia/Tokyo:
+ * import { tz } from '@date-fns/tz'
+ * const result = startOfToday({ in: tz('Asia/Tokyo') })
+ * //=> Sun Aug 18 2024 00:00:00 GMT+0900 (Japan Standard Time)
  */
 export function startOfToday<ContextDate extends Date>(
   options?: StartOfTodayOptions<ContextDate> | undefined,

--- a/src/startOfToday/test.ts
+++ b/src/startOfToday/test.ts
@@ -25,14 +25,17 @@ describe("startOfToday", () => {
       expect(startOfToday({ in: tz("Asia/Singapore") }).toISOString()).toBe(
         "2024-08-18T00:00:00.000+08:00",
       );
+
       fakeNow(new Date("2024-08-18T16:00:00Z"));
       expect(startOfToday({ in: tz("Asia/Singapore") }).toISOString()).toBe(
         "2024-08-19T00:00:00.000+08:00",
       );
+
       fakeNow(new Date("2024-08-18T03:00:00Z"));
       expect(startOfToday({ in: tz("America/New_York") }).toISOString()).toBe(
         "2024-08-17T00:00:00.000-04:00",
       );
+
       fakeNow(new Date("2024-08-18T04:00:00Z"));
       expect(startOfToday({ in: tz("America/New_York") }).toISOString()).toBe(
         "2024-08-18T00:00:00.000-04:00",


### PR DESCRIPTION

### feat: add nextBusinessDay helper with optional holiday support

### Description:
This PR adds a new utility function nextBusinessDay(date, options) which returns the next business day after the given date.

It:

Skips weekends (Saturday and Sunday)

Supports skipping optional custom holidays via the holidays option

Includes full test coverage using vitest and handles edge cases like starting on weekends or holidays.

