### PR TITLE
Update getDay return type

### DIFF
--- a/pkgs/core/src/getDay/index.ts
+++ b/pkgs/core/src/getDay/index.ts
@@ -1,5 +1,5 @@
 import { toDate } from "../toDate/index.ts";
-import type { ContextOptions, DateArg } from "../types.ts";
+import type { ContextOptions, DateArg, Day } from "../types.ts";
 
 /**
  * The {@link getDay} function options.
@@ -27,6 +27,6 @@ export interface GetDayOptions extends ContextOptions<Date> {}
 export function getDay(
   date: DateArg<Date> & {},
   options?: GetDayOptions | undefined,
-): number {
-  return toDate(date, options?.in).getDay();
+): Day {
+  return toDate(date, options?.in).getDay() as Day;
 }


### PR DESCRIPTION
The problem of types:
```ts
import { getDay, type WeekOptions } from 'date-fns';

const options: WeekOptions = {
  weekStartsOn: getDay(new Date())
  // ↑ Type 'number' is not assignable to type 'Day | undefined'. (ts 2322)
};
```

- `typescript`: v5.8.3
- `date-fns`: v4.4.0

Refs:
- #1663
- https://date-fns.org/v4.4.0/docs/getDay