### PR TITLE
docs: clarify behavior of strict mode functions (#4011)

### DIFF
--- a/src/formatDistanceStrict/index.ts
+++ b/src/formatDistanceStrict/index.ts
@@ -48,8 +48,9 @@ export type FormatDistanceStrictUnit =
  *
  * @description
  * Return the distance between the given dates in words, using strict units.
- * This is like `formatDistance`, but does not use helpers like 'almost', 'over',
- * 'less than' and the like.
+ * This function uses exact time calculations and rounds durations based on a configurable
+ * `roundingMethod` (defaults to 'round') and does not use helpers
+ * like "almost", "over", or "less than".
  *
  * | Distance between dates | Result              |
  * |------------------------|---------------------|

--- a/src/formatDistanceToNowStrict/index.ts
+++ b/src/formatDistanceToNowStrict/index.ts
@@ -18,8 +18,9 @@ export interface FormatDistanceToNowStrictOptions
  *
  * @description
  * Return the distance between the given dates in words, using strict units.
- * This is like `formatDistance`, but does not use helpers like 'almost', 'over',
- * 'less than' and the like.
+ * This function uses exact time calculations and rounds durations based on a configurable
+ * `roundingMethod` (defaults to 'round') and does not use helpers
+ * like "almost", "over", or "less than".
  *
  * | Distance between dates | Result              |
  * |------------------------|---------------------|


### PR DESCRIPTION
Update JSDoc for `formatDistanceStrict` and `formatDistanceToNowStrict` to clarify that strict mode uses exact time calculations and a configurable roundingMethod, rather than just omitting helper words like "almost" or "over". This resolves the misleading description in the first paragraph of both methods' documentation.