### PR TITLE
Fix incorrect formatISO timezone offsets precision

### DIFF
--- a/src/_lib/format/formatters/index.ts
+++ b/src/_lib/format/formatters/index.ts
@@ -768,7 +768,8 @@ export const formatters: { [token: string]: Formatter } = {
 
 function formatTimezoneShort(offset: number, delimiter: string = ""): string {
   const sign = offset > 0 ? "-" : "+";
-  const absOffset = Math.abs(offset);
+  // Round to nearest minute to handle fractional minute offsets (e.g., historical timezones)
+  const absOffset = Math.abs(Math.round(offset));
   const hours = Math.trunc(absOffset / 60);
   const minutes = absOffset % 60;
   if (minutes === 0) {
@@ -781,16 +782,19 @@ function formatTimezoneWithOptionalMinutes(
   offset: number,
   delimiter?: string,
 ): string {
-  if (offset % 60 === 0) {
-    const sign = offset > 0 ? "-" : "+";
-    return sign + addLeadingZeros(Math.abs(offset) / 60, 2);
+  // Round to nearest minute to handle fractional minute offsets (e.g., historical timezones)
+  const roundedOffset = Math.round(offset);
+  if (roundedOffset % 60 === 0) {
+    const sign = roundedOffset > 0 ? "-" : "+";
+    return sign + addLeadingZeros(Math.abs(roundedOffset) / 60, 2);
   }
-  return formatTimezone(offset, delimiter);
+  return formatTimezone(roundedOffset, delimiter);
 }
 
 function formatTimezone(offset: number, delimiter: string = ""): string {
   const sign = offset > 0 ? "-" : "+";
-  const absOffset = Math.abs(offset);
+  // Round to nearest minute to handle fractional minute offsets (e.g., historical timezones)
+  const absOffset = Math.abs(Math.round(offset));
   const hours = addLeadingZeros(Math.trunc(absOffset / 60), 2);
   const minutes = addLeadingZeros(absOffset % 60, 2);
   return sign + hours + delimiter + minutes;

--- a/src/_lib/test/index.ts
+++ b/src/_lib/test/index.ts
@@ -25,7 +25,8 @@ export function generateOffset(originalDate: Date) {
   const tzOffset = originalDate.getTimezoneOffset();
 
   if (tzOffset !== 0) {
-    const absoluteOffset = Math.abs(tzOffset);
+    // Round to nearest minute to handle fractional minute offsets (e.g., historical timezones)
+    const absoluteOffset = Math.abs(Math.round(tzOffset));
     const hourOffset = addLeadingZeros(Math.trunc(absoluteOffset / 60), 2);
     const minuteOffset = addLeadingZeros(absoluteOffset % 60, 2);
     // If less than 0, the sign is +, because it is ahead of time.

--- a/src/formatISO/index.ts
+++ b/src/formatISO/index.ts
@@ -79,7 +79,8 @@ export function formatISO(
     const offset = date_.getTimezoneOffset();
 
     if (offset !== 0) {
-      const absoluteOffset = Math.abs(offset);
+      // Round to nearest minute to handle fractional minute offsets (e.g., historical timezones)
+      const absoluteOffset = Math.abs(Math.round(offset));
       const hourOffset = addLeadingZeros(Math.trunc(absoluteOffset / 60), 2);
       const minuteOffset = addLeadingZeros(absoluteOffset % 60, 2);
       // If less than 0, the sign is +, because it is ahead of time.

--- a/src/formatISO/test.ts
+++ b/src/formatISO/test.ts
@@ -69,6 +69,24 @@ describe("formatISO", () => {
     expect(formatISO.bind(null, new Date(NaN))).toThrow(RangeError);
   });
 
+  it("handles sub-minute timezone offsets by rounding to nearest minute", () => {
+    const date = new Date(2019, 2 /* Mar */, 3, 19, 0, 52, 123);
+    const getTimezoneOffsetStub = sinon.stub(
+      Date.prototype,
+      "getTimezoneOffset",
+    );
+
+    // Simulate fractional minute offset (e.g., historical London timezone UTC-0:01:15 = -1.25 minutes)
+    getTimezoneOffsetStub.returns(-1.25);
+    expect(formatISO(date)).toBe("2019-03-03T19:00:52+00:01");
+
+    // Simulate positive fractional minute offset
+    getTimezoneOffsetStub.returns(1.25);
+    expect(formatISO(date)).toBe("2019-03-03T19:00:52-00:01");
+
+    getTimezoneOffsetStub.restore();
+  });
+
   describe("context", () => {
     it("allows to specify the context", () => {
       const date = "2024-09-17T10:00:00Z";

--- a/src/formatRFC3339/index.ts
+++ b/src/formatRFC3339/index.ts
@@ -71,7 +71,8 @@ export function formatRFC3339(
   const tzOffset = date_.getTimezoneOffset();
 
   if (tzOffset !== 0) {
-    const absoluteOffset = Math.abs(tzOffset);
+    // Round to nearest minute to handle fractional minute offsets (e.g., historical timezones)
+    const absoluteOffset = Math.abs(Math.round(tzOffset));
     const hourOffset = addLeadingZeros(Math.trunc(absoluteOffset / 60), 2);
     const minuteOffset = addLeadingZeros(absoluteOffset % 60, 2);
     // If less than 0, the sign is +, because it is ahead of time.

--- a/src/formatRFC3339/test.ts
+++ b/src/formatRFC3339/test.ts
@@ -51,6 +51,24 @@ describe("formatRFC3339", () => {
     expect(formatRFC3339.bind(null, new Date(NaN))).toThrow(RangeError);
   });
 
+  it("handles sub-minute timezone offsets by rounding to nearest minute", () => {
+    const date = new Date(2019, 2 /* Mar */, 3, 19, 0, 52, 123);
+    const getTimezoneOffsetStub = sinon.stub(
+      Date.prototype,
+      "getTimezoneOffset",
+    );
+
+    // Simulate fractional minute offset (e.g., historical London timezone UTC-0:01:15 = -1.25 minutes)
+    getTimezoneOffsetStub.returns(-1.25);
+    expect(formatRFC3339(date)).toBe("2019-03-03T19:00:52+00:01");
+
+    // Simulate positive fractional minute offset
+    getTimezoneOffsetStub.returns(1.25);
+    expect(formatRFC3339(date)).toBe("2019-03-03T19:00:52-00:01");
+
+    getTimezoneOffsetStub.restore();
+  });
+
   describe("context", () => {
     it("allows to specify the context", () => {
       const date = "2024-09-17T10:00:00Z";


### PR DESCRIPTION
##  Summary

  I've successfully addressed GitHub issue #3835 which reported that formatISO incorrectly handles timezone offsets with precision down to seconds. The problem occurred in Firefox when
  displaying historical dates (like London before 1848 with UTC-0:01:15 offset), where getTimezoneOffset() returns fractional minutes (e.g., -1.25).

 ## Changes Made

  I fixed the issue by adding Math.round() to handle fractional minute timezone offsets in the following files:

  1. src/formatISO/index.ts:83 - Added rounding to formatISO function
  2. src/formatRFC3339/index.ts:75 - Added rounding to formatRFC3339 function
  3. src/_lib/format/formatters/index.ts:772 - Added rounding to formatTimezoneShort helper
  4. src/_lib/format/formatters/index.ts:786 - Added rounding to formatTimezoneWithOptionalMinutes helper
  5. src/_lib/format/formatters/index.ts:797 - Added rounding to formatTimezone helper
  6. src/_lib/test/index.ts:29 - Added rounding to generateOffset test helper

  ## Test Cases Added

  I added comprehensive test cases to verify the fix:

  - src/formatISO/test.ts:72-88 - Tests for formatISO with fractional minute offsets
  - src/formatRFC3339/test.ts:54-70 - Tests for formatRFC3339 with fractional minute offsets

  The fix ensures that when Firefox (or any browser) returns sub-minute timezone offsets, they are rounded to the nearest minute, producing valid ISO 8601 representations. For example,
  -1.25 minutes rounds to -1 minute, resulting in -00:01 instead of the invalid -00:1.25.