### PR TITLE
fix: Add formatters to sideEffects to prevent Parcel tree-shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,16 @@
     "type": "github",
     "url": "https://github.com/sponsors/kossnocorp"
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "./_lib/format/formatters.js",
+    "./_lib/format/formatters/index.js",
+    "./_lib/format/longFormatters.js",
+    "./_lib/format/longFormatters/index.js",
+    "./format/_lib/format/formatters.js",
+    "./format/_lib/format/formatters/index.js",
+    "./format/_lib/format/longFormatters.js",
+    "./format/_lib/format/longFormatters/index.js"
+  ],
   "browser": "./index",
   "type": "module",
   "main": "index.cjs",


### PR DESCRIPTION
Fixes #4088

- Added _lib/format/formatters.js and _lib/format/longFormatters.js to sideEffects array
- Prevents Parcel from tree-shaking formatters when importing only format()
- Resolves runtime error: Cannot read properties of undefined (reading 'M')
- Implements Option A from issue #4088