### PR TITLE
fix: re-export Duration type in intervalToDuration to fix TypeDoc documentation (#4059)

### DIFF
--- a/src/intervalToDuration/index.ts
+++ b/src/intervalToDuration/index.ts
@@ -66,3 +66,6 @@ export function intervalToDuration(
 
   return duration;
 }
+
+// Re-export Duration type to ensure TypeDoc picks up its documentation
+export type { Duration } from "../types.ts";


### PR DESCRIPTION
### Description

Fixes #4059 

This PR addresses the issue where the `Duration` interface documentation was not appearing in the TypeDoc-generated documentation when accessed through the `intervalToDuration` function page.

### Problem

When navigating to the Duration type from the `intervalToDuration` function documentation (https://date-fns.org/v4.1.0/docs/intervalToDuration#types/Duration/2523), the documentation page showed "No documentation available" despite the interface having proper JSDoc comments in `src/types.ts`.

### Solution

Added an explicit re-export of the `Duration` type in `src/intervalToDuration/index.ts`:

```typescript
// Re-export Duration type to ensure TypeDoc picks up its documentation
export type { Duration } from "../types.ts";