### PR TITLE
feat: add getHoursBetween function to calculate full hours between tw…

### DIFF
--- a/src/getHoursBetween/index.ts
+++ b/src/getHoursBetween/index.ts
@@ -1,0 +1,64 @@
+import { normalizeDates } from "../_lib/normalizeDates/index.ts";
+import { millisecondsInHour } from "../constants/index.ts";
+import type { ContextOptions, DateArg } from "../types.ts";
+
+/**
+ * The {@link getHoursBetween} function options.
+ */
+export interface GetHoursBetweenOptions extends ContextOptions<Date> {}
+
+/**
+ * @name getHoursBetween
+ * @category Hour Helpers
+ * @summary Get the number of full hours between the given dates.
+ *
+ * @description
+ * Get the number of full hour periods between two dates. Fractional hours are
+ * truncated towards zero.
+ *
+ * One "full hour" is a complete 60-minute period. For example, the difference
+ * between 10:30 and 11:30 is 1 full hour, but the difference between 10:30
+ * and 11:29 is 0 full hours.
+ *
+ * @param laterDate - The later date
+ * @param earlierDate - The earlier date
+ * @param options - An object with options
+ *
+ * @returns The number of full hours
+ *
+ * @example
+ * // How many full hours are between
+ * // 2 July 2014 06:50:00 and 2 July 2014 19:00:00?
+ * const result = getHoursBetween(
+ *   new Date(2014, 6, 2, 19, 0),
+ *   new Date(2014, 6, 2, 6, 50)
+ * )
+ * //=> 12
+ *
+ * @example
+ * // How many full hours are between
+ * // 2 July 2014 06:50:00 and 2 July 2014 18:49:00?
+ * const result = getHoursBetween(
+ *   new Date(2014, 6, 2, 18, 49),
+ *   new Date(2014, 6, 2, 6, 50)
+ * )
+ * //=> 11
+ */
+export function getHoursBetween(
+  laterDate: DateArg<Date> & {},
+  earlierDate: DateArg<Date> & {},
+  options?: GetHoursBetweenOptions | undefined,
+): number {
+  const [laterDate_, earlierDate_] = normalizeDates(
+    options?.in,
+    laterDate,
+    earlierDate,
+  );
+
+  const diff = (+laterDate_ - +earlierDate_) / millisecondsInHour;
+  const result = Math.trunc(diff);
+  
+  // Prevent negative zero
+  return result === 0 ? 0 : result;
+}
+

--- a/src/getHoursBetween/test.ts
+++ b/src/getHoursBetween/test.ts
@@ -1,0 +1,165 @@
+import { TZDate, tz } from "@date-fns/tz";
+import { describe, expect, it } from "vitest";
+import type { ContextOptions, DateArg } from "../types.ts";
+import { getHoursBetween } from "./index.ts";
+
+describe("getHoursBetween", () => {
+  it("returns the number of full hours between the given dates", () => {
+    const result = getHoursBetween(
+      new Date(2014, 6 /* Jul */, 2, 20, 0),
+      new Date(2014, 6 /* Jul */, 2, 6, 0),
+    );
+    expect(result).toBe(14);
+  });
+
+  it("truncates fractional hours towards zero", () => {
+    const result = getHoursBetween(
+      new Date(2014, 6 /* Jul */, 2, 19, 0),
+      new Date(2014, 6 /* Jul */, 2, 6, 50),
+    );
+    expect(result).toBe(12);
+  });
+
+  it("returns 0 when difference is less than one full hour", () => {
+    const result = getHoursBetween(
+      new Date(2014, 6 /* Jul */, 2, 18, 49),
+      new Date(2014, 6 /* Jul */, 2, 6, 50),
+    );
+    expect(result).toBe(11);
+  });
+
+  it("returns a negative number if the time value of the first date is smaller", () => {
+    const result = getHoursBetween(
+      new Date(2014, 6 /* Jul */, 2, 6, 0),
+      new Date(2014, 6 /* Jul */, 2, 20, 0),
+    );
+    expect(result).toBe(-14);
+  });
+
+  it("returns a 0, not a negative 0 - issue #2555 ", () => {
+    const result = getHoursBetween(
+      new Date(2021, 6 /* Jul */, 22, 6, 1, 28.973),
+      new Date(2021, 6 /* Jul */, 22, 6, 1, 28.976),
+    );
+    expect(result).toBe(0);
+  });
+
+  it("accepts timestamps", () => {
+    const result = getHoursBetween(
+      new Date(2014, 8 /* Sep */, 5, 18, 0).getTime(),
+      new Date(2014, 8 /* Sep */, 5, 6, 0).getTime(),
+    );
+    expect(result).toBe(12);
+  });
+
+  describe("edge cases", () => {
+    it("the difference is less than an hour, but the given dates are in different calendar hours", () => {
+      const result = getHoursBetween(
+        new Date(2014, 8 /* Sep */, 5, 12),
+        new Date(2014, 8 /* Sep */, 5, 11, 59),
+      );
+      expect(result).toBe(0);
+    });
+
+    it("the same for the swapped dates", () => {
+      const result = getHoursBetween(
+        new Date(2014, 8 /* Sep */, 5, 11, 59),
+        new Date(2014, 8 /* Sep */, 5, 12),
+      );
+      expect(result).toBe(0);
+    });
+
+    it("the difference is an integral number of hours", () => {
+      const result = getHoursBetween(
+        new Date(2014, 8 /* Sep */, 5, 13, 0),
+        new Date(2014, 8 /* Sep */, 5, 12, 0),
+      );
+      expect(result).toBe(1);
+    });
+
+    it("the given dates are the same", () => {
+      const result = getHoursBetween(
+        new Date(2014, 8 /* Sep */, 5, 0, 0),
+        new Date(2014, 8 /* Sep */, 5, 0, 0),
+      );
+      expect(result).toBe(0);
+    });
+
+    it("does not return -0 when the given dates are the same", () => {
+      function isNegativeZero(x: number): boolean {
+        return x === 0 && 1 / x < 0;
+      }
+
+      const result = getHoursBetween(
+        new Date(2014, 8 /* Sep */, 5, 0, 0),
+        new Date(2014, 8 /* Sep */, 5, 0, 0),
+      );
+
+      const resultIsNegative = isNegativeZero(result);
+      expect(resultIsNegative).toBe(false);
+    });
+  });
+
+  it("returns NaN if the first date is `Invalid Date`", () => {
+    const result = getHoursBetween(
+      new Date(NaN),
+      new Date(2017, 0 /* Jan */, 1),
+    );
+    expect(isNaN(result)).toBe(true);
+  });
+
+  it("returns NaN if the second date is `Invalid Date`", () => {
+    const result = getHoursBetween(
+      new Date(2017, 0 /* Jan */, 1),
+      new Date(NaN),
+    );
+    expect(isNaN(result)).toBe(true);
+  });
+
+  it("returns NaN if the both dates are `Invalid Date`", () => {
+    const result = getHoursBetween(new Date(NaN), new Date(NaN));
+    expect(isNaN(result)).toBe(true);
+  });
+
+  it("allows dates to be of different types", () => {
+    function _test<DateType1 extends Date, DateType2 extends Date>(
+      arg1: DateType1 | number | string,
+      arg2: DateType2 | number | string,
+    ) {
+      getHoursBetween(arg1, arg2);
+    }
+  });
+
+  it("normalizes the dates", () => {
+    const dateLeft = new TZDate(2024, 5, 7, 8, "Asia/Singapore");
+    const dateRight = new TZDate(2024, 5, 6, 4, "America/New_York");
+    expect(getHoursBetween(dateLeft, dateRight)).toBe(16);
+    expect(getHoursBetween(dateRight, dateLeft)).toBe(-16);
+  });
+
+  describe("context", () => {
+    it("allows to specify the context", () => {
+      expect(
+        getHoursBetween("2024-08-18T03:00:00Z", "2024-08-01T00:00:00Z", {
+          in: tz("America/New_York"),
+        }),
+      ).toBe(411);
+      expect(
+        getHoursBetween("2024-08-18T03:00:00Z", "2024-08-01T00:00:00Z", {
+          in: tz("Asia/Singapore"),
+        }),
+      ).toBe(411);
+    });
+
+    it("doesn't enforce argument and context to be of the same type", () => {
+      function _test<DateType extends Date, ResultDate extends Date = DateType>(
+        arg1: DateArg<DateType>,
+        arg2: DateArg<DateType>,
+        options?: ContextOptions<ResultDate>,
+      ) {
+        getHoursBetween(arg1, arg2, { in: options?.in });
+      }
+    });
+  });
+});
+


### PR DESCRIPTION
## Description

This PR adds a new `getHoursBetween` function that calculates the number of **full hours** between two dates. The function truncates fractional hours towards zero, making it useful when you need to count complete hour periods.

## Motivation

While `differenceInHours` exists in date-fns, it uses rounding methods that can return fractional hours. There are use cases where you specifically need to count only complete/full hours (e.g., billing systems, hourly rate calculations, or when you need to know how many whole hours have elapsed).

## What's Changed

- Added `getHoursBetween` function in `src/getHoursBetween/index.ts`
- Added comprehensive test suite in `src/getHoursBetween/test.ts`
- Function follows date-fns patterns and conventions
- Supports all date types (Date, timestamps, strings) and context options

## Behavior

- Returns the number of full hour periods between two dates
- Truncates fractional hours towards zero (e.g., 1.9 hours → 1, 11.1 hours → 11)
- Returns negative numbers if the first date is earlier than the second
- Returns 0 (not -0) when dates are the same or difference is less than 1 hour
- Handles edge cases like invalid dates, different date types, and timezone contexts

## Examples

```typescript
// How many full hours between 6:50 AM and 7:00 PM?
getHoursBetween(
  new Date(2014, 6, 2, 19, 0),  // 7:00 PM
  new Date(2014, 6, 2, 6, 50)   // 6:50 AM
)
//=> 12

// Less than one full hour
getHoursBetween(
  new Date(2014, 6, 2, 18, 49),  // 6:49 PM
  new Date(2014, 6, 2, 6, 50)    // 6:50 AM
)
//=> 11

// Same hour, different minutes
getHoursBetween(
  new Date(2014, 6, 2, 12, 0),   // 12:00 PM
  new Date(2014, 6, 2, 11, 59)   // 11:59 AM
)
//=> 0
```

## Testing

- ✅ Comprehensive test suite covering edge cases
- ✅ Tests for positive and negative differences
- ✅ Tests for invalid dates
- ✅ Tests for different date types (Date, timestamps, strings)
- ✅ Tests for timezone contexts
- ✅ Tests to ensure no negative zero is returned

## Type Safety

- Full TypeScript support
- Follows date-fns type patterns
- Supports generic date types and context options

## Related

This function complements the existing `differenceInHours` function by providing a way to get only full/complete hours without rounding.