### PR TITLE
fix: handle context option in roundToNearestMinutes when returning Invalid Date

### DIFF
--- a/src/roundToNearestMinutes/index.ts
+++ b/src/roundToNearestMinutes/index.ts
@@ -63,7 +63,8 @@ export function roundToNearestMinutes<
 ): ResultDate {
   const nearestTo = options?.nearestTo ?? 1;
 
-  if (nearestTo < 1 || nearestTo > 30) return constructFrom(date, NaN);
+  if (nearestTo < 1 || nearestTo > 30)
+    return constructFrom(options?.in || date, NaN);
 
   const date_ = toDate(date, options?.in);
   const fractionalSeconds = date_.getSeconds() / 60;

--- a/src/roundToNearestMinutes/test.ts
+++ b/src/roundToNearestMinutes/test.ts
@@ -261,6 +261,20 @@ describe("roundToNearestMinutes", () => {
     expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
   });
 
+  it("returns `Invalid Date` if nearestTo is less than 1", () => {
+    const result = roundToNearestMinutes(new Date(2014, 6, 10, 12, 30), {
+      nearestTo: 0,
+    });
+    expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
+  });
+
+  it("returns `Invalid Date` if nearestTo is greater than 30", () => {
+    const result = roundToNearestMinutes(new Date(2014, 6, 10, 12, 30), {
+      nearestTo: 31,
+    });
+    expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
+  });
+
   it("resolves the date type by default", () => {
     const result = roundToNearestMinutes(Date.now());
     expect(result).toBeInstanceOf(Date);
@@ -292,6 +306,16 @@ describe("roundToNearestMinutes", () => {
         in: tz("Asia/Tokyo"),
       });
       expect(result).toBeInstanceOf(TZDate);
+      assertType<assertType.Equal<TZDate, typeof result>>(true);
+    });
+
+    it("returns Invalid Date with correct context type when nearestTo is invalid", () => {
+      const result = roundToNearestMinutes("2014-09-01T00:00:00Z", {
+        in: tz("Asia/Tokyo"),
+        nearestTo: 0,
+      });
+      expect(result).toBeInstanceOf(TZDate);
+      expect(isNaN(result.getTime())).toBe(true);
       assertType<assertType.Equal<TZDate, typeof result>>(true);
     });
   });


### PR DESCRIPTION
# Fix: Handle context option in roundToNearestMinutes when returning Invalid Date

## Summary

Fixed an inconsistency in `roundToNearestMinutes` where the context option (`options?.in`) was not properly handled when returning Invalid Date for invalid `nearestTo` values. This makes the function consistent with `roundToNearestHours` which correctly handles this case.

## Reason for Change

When `roundToNearestMinutes` receives an invalid `nearestTo` value (< 1 or > 30), it returns Invalid Date. However, unlike `roundToNearestHours`, it was not using the context option (`options?.in`) when constructing the Invalid Date, which could cause type inconsistencies when using timezone contexts.

**Before:**
```typescript
if (nearestTo < 1 || nearestTo > 30) return constructFrom(date, NaN);
```

**After:**
```typescript
if (nearestTo < 1 || nearestTo > 30)
  return constructFrom(options?.in || date, NaN);
```

This ensures that when a timezone context is provided and `nearestTo` is invalid, the returned Invalid Date uses the correct date type from the context (e.g., `TZDate` instead of `Date`).

## Tests Added

- Test for `nearestTo < 1` returning Invalid Date
- Test for `nearestTo > 30` returning Invalid Date  
- Test for invalid `nearestTo` with context option ensuring correct date type (`TZDate`)

## Impact Analysis

- **Breaking Changes**: None. This is a bug fix that improves consistency.
- **Backward Compatibility**: Fully backward compatible. The behavior for valid inputs remains unchanged.
- **Type Safety**: Improves type safety when using timezone contexts with invalid `nearestTo` values.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Tests added/updated and passing
- [x] Documentation updated (JSDoc comments are already correct)
- [x] No breaking changes
- [x] Commit message follows date-fns conventions (`fix:` prefix)
- [x] Code is minimal and focused on the fix
- [x] Follows existing patterns (matches `roundToNearestHours` implementation)

