### PR TITLE
test: add DST and roundingMethod edge-case tests for differenceInWeeks

### DIFF
--- a/test/differenceInWeeks/test.ts
+++ b/test/differenceInWeeks/test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { differenceInWeeks } from '../../src/differenceInWeeks/index.ts'
+
+describe('differenceInWeeks – DST and rounding edge cases', () => {
+  it('handles DST spring-forward correctly (23-hour day)', () => {
+    const earlier = new Date(2024, 2, 10, 0, 0)
+    const later = new Date(2024, 2, 17, 0, 0)
+    expect(differenceInWeeks(later, earlier)).toBe(1)
+  })
+
+  it('handles DST fall-back correctly (25-hour day)', () => {
+    const earlier = new Date(2024, 10, 3, 0, 0)
+    const later = new Date(2024, 10, 10, 0, 0)
+    expect(differenceInWeeks(later, earlier)).toBe(1)
+  })
+
+  it('supports roundingMethod: "ceil"', () => {
+    expect(
+      differenceInWeeks(
+        new Date(2020, 0, 10),
+        new Date(2020, 0, 5),
+        { roundingMethod: 'ceil' }
+      )
+    ).toBe(1)
+  })
+
+  it('supports roundingMethod: "floor"', () => {
+    expect(
+      differenceInWeeks(
+        new Date(2020, 0, 10),
+        new Date(2020, 0, 6),
+        { roundingMethod: 'floor' }
+      )
+    ).toBe(0)
+  })
+
+  it('supports roundingMethod: "round"', () => {
+    expect(
+      differenceInWeeks(
+        new Date(2020, 0, 10),
+        new Date(2020, 0, 5, 12),
+        { roundingMethod: 'round' }
+      )
+    ).toBe(1)
+  })
+
+  it('supports roundingMethod: "trunc"', () => {
+    expect(
+      differenceInWeeks(
+        new Date(2020, 0, 10),
+        new Date(2020, 0, 6),
+        { roundingMethod: 'trunc' }
+      )
+    ).toBe(0)
+  })
+})


### PR DESCRIPTION
Closes [#4101](https://github.com/date-fns/date-fns/issues/4101)

This PR adds missing test coverage for `differenceInWeeks`, specifically:

• DST spring-forward and fall-back transitions  
• roundingMethod options: "ceil", "floor", "round", "trunc"  
• Behavior matches documented expectations but previously had no tests  

These scenarios ensure stability around timezone offset changes and rounding behavior.  
All new tests pass successfully under the existing test suite.
