### PR TITLE
Add explicit NaN validation to addMilliseconds for consistency

### DIFF
--- a/src/addMilliseconds/index.ts
+++ b/src/addMilliseconds/index.ts
@@ -5,7 +5,7 @@ import type { ContextOptions, DateArg } from "../types.ts";
  * The {@link addMilliseconds} function options.
  */
 export interface AddMillisecondsOptions<DateType extends Date = Date>
-  extends ContextOptions<DateType> {}
+  extends ContextOptions<DateType> { }
 
 /**
  * @name addMilliseconds
@@ -37,5 +37,6 @@ export function addMilliseconds<
   amount: number,
   options?: AddMillisecondsOptions<ResultDate> | undefined,
 ): ResultDate {
+  if (isNaN(amount)) return constructFrom(options?.in || date, NaN);
   return constructFrom(options?.in || date, +toDate(date) + amount);
 }


### PR DESCRIPTION
This commit adds explicit NaN parameter validation to the addMilliseconds function to ensure consistency across all add* functions in the library.

Previously, there was an inconsistency in how add* functions handled NaN:
- addDays, addMonths, addBusinessDays: Explicit isNaN() check
- addHours, addMinutes, addSeconds, addMilliseconds: Implicit NaN handling

While both approaches produced the same correct result (Invalid Date), the inconsistency made the codebase harder to maintain and understand.

This change:
- Adds explicit isNaN() check to addMilliseconds (line 40)
- Ensures all add* functions follow the same validation pattern
- Improves code clarity and maintainability
- Fixes addHours, addMinutes, and addSeconds (which delegate to addMilliseconds)

The fix maintains backward compatibility - all functions still return Invalid Date when passed NaN, just with consistent implementation.