### PR TITLE
fix: add optional chaining to prevent crash when locale.localize.preprocessor is undefined

### DIFF
--- a/src/format/index.ts
+++ b/src/format/index.ts
@@ -409,7 +409,7 @@ export function format(
     });
 
   // invoke localize preprocessor (only for french locales at the moment)
-  if (locale.localize.preprocessor) {
+  if (locale.localize?.preprocessor) {
     parts = locale.localize.preprocessor(originalDate, parts);
   }
 


### PR DESCRIPTION
Summary

This PR fixes a runtime crash that happens when date-fns tries to call
locale.localize.preprocessor in locales where the function does not exist
(for example, the German de locale).

The current implementation assumes that the preprocessor is always available, which leads to:

TypeError: Cannot read properties of undefined (reading 'preprocessor')

Cause

Only a few locales (like French) define a localize.preprocessor function.
Most other locales do not include it. Because the code calls this function
without checking its existence, apps crash when formatting dates in those locales.

Fix

This PR adds a simple optional chaining check to ensure the preprocessor
is only called when available:

if (locale.localize?.preprocessor) {
  parts = locale.localize.preprocessor(originalDate, parts);
}