### PR TITLE
fix: strict ISO-8601 w/o Z parsing for x token

### DIFF
--- a/src/parse/_lib/constants.ts
+++ b/src/parse/_lib/constants.ts
@@ -28,4 +28,9 @@ export const timezonePatterns = {
   basicOptionalSeconds: /^([+-])(\d{2})(\d{2})((\d{2}))?|Z/,
   extended: /^([+-])(\d{2}):(\d{2})|Z/,
   extendedOptionalSeconds: /^([+-])(\d{2}):(\d{2})(:(\d{2}))?|Z/,
+  basicOptionalMinutesWithoutZ: /^([+-])(\d{2})(\d{2})?/,
+  basicWithoutZ: /^([+-])(\d{2})(\d{2})/,
+  basicOptionalSecondsWithoutZ: /^([+-])(\d{2})(\d{2})((\d{2}))?/,
+  extendedWithoutZ: /^([+-])(\d{2}):(\d{2})/,
+  extendedOptionalSecondsWithoutZ: /^([+-])(\d{2}):(\d{2})(:(\d{2}))?/,
 };

--- a/src/parse/_lib/parsers/ISOTimezoneParser.ts
+++ b/src/parse/_lib/parsers/ISOTimezoneParser.ts
@@ -13,24 +13,24 @@ export class ISOTimezoneParser extends Parser<number> {
     switch (token) {
       case "x":
         return parseTimezonePattern(
-          timezonePatterns.basicOptionalMinutes,
+          timezonePatterns.basicOptionalMinutesWithoutZ,
           dateString,
         );
       case "xx":
-        return parseTimezonePattern(timezonePatterns.basic, dateString);
+        return parseTimezonePattern(timezonePatterns.basicWithoutZ, dateString);
       case "xxxx":
         return parseTimezonePattern(
-          timezonePatterns.basicOptionalSeconds,
+          timezonePatterns.basicOptionalSecondsWithoutZ,
           dateString,
         );
       case "xxxxx":
         return parseTimezonePattern(
-          timezonePatterns.extendedOptionalSeconds,
+          timezonePatterns.extendedOptionalSecondsWithoutZ,
           dateString,
         );
       case "xxx":
       default:
-        return parseTimezonePattern(timezonePatterns.extended, dateString);
+        return parseTimezonePattern(timezonePatterns.extendedWithoutZ, dateString);
     }
   }
 


### PR DESCRIPTION
This PR fixes an issue where the x timezone tokens (x, xx, xxx, xxxx, xxxxx) were incorrectly accepting Z (Zulu time) during parsing. According to the documentation, these tokens should follow the ISO-8601 “timezone without Z” rules, but the previous implementation shared logic with tokens that do support Z.

What was wrong

The shared timezone parser allowed Z, so inputs like:

parse("2016-11-25T16:38:38.123Z", "yyyy-MM-dd'T'HH:mm:ss.SSSx", new Date())


were being parsed successfully instead of producing an invalid date. This contradicts the spec and the library docs.

What I changed

Added new regex patterns in src/parse/_lib/constants.ts that explicitly exclude Z.

Updated ISOTimezoneParser to use the new patterns only for x-tokens.

Ensured other timezone tokens continue using the original logic.

#4114 
