### PR TITLE
feat: same business week check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1270,6 +1270,16 @@
         "default": "./isPast.js"
       }
     },
+     "./isSameBusinessWeek": {
+      "require": {
+        "types": "./isSameBusinessWeek.d.ts",
+        "default": "./isSameBusinessWeek.js"
+      },
+      "import": {
+        "types": "./isSameBusinessWeek.d.mts",
+        "default": "./isSameBusinessWeek.mjs"
+      }
+    },
     "./isSameDay": {
       "require": {
         "types": "./isSameDay.d.cts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,6 +121,7 @@ export * from "./isLeapYear/index.ts";
 export * from "./isMatch/index.ts";
 export * from "./isMonday/index.ts";
 export * from "./isPast/index.ts";
+export * from "./isSameBusinessWeek/index.js";
 export * from "./isSameDay/index.ts";
 export * from "./isSameHour/index.ts";
 export * from "./isSameISOWeek/index.ts";

--- a/src/isSameBusinessWeek/index.ts
+++ b/src/isSameBusinessWeek/index.ts
@@ -1,0 +1,76 @@
+import { startOfWeek } from "../startOfWeek/index.js";
+import { endOfWeek } from "../endOfWeek/index.js";
+import { isWeekend } from "../isWeekend/index.js";
+import { toDate } from "../toDate/index.js";
+import { Locale } from "../types.js";
+
+/**
+ * @name isSameBusinessWeek
+ * @category Week Helpers
+ * @summary Are the given dates in the same business week?
+ *
+ * @description
+ * Checks if the given dates are in the same business week.
+ * A business week is considered Monday to Friday by default.
+ * Week boundaries can be configured using `weekStartsOn`.
+ *
+ * Weekend days (Saturday and Sunday) are normalized to the nearest
+ * business day within the same week before comparison.
+ *
+ * @typeParam DateType - The `Date` type, the function operates on.
+ *
+ * @param dateLeft - The first date to check
+ * @param dateRight - The second date to check
+ * @param options - An object with options
+ *
+ * @returns `true` if the dates are in the same business week
+ *
+ * @example
+ * // Are Friday and Monday in the same business week?
+ * isSameBusinessWeek(
+ *   new Date(2025, 4, 9),
+ *   new Date(2025, 4, 12),
+ *   { weekStartsOn: 1 }
+ * )
+ * //=> true
+ */
+export function isSameBusinessWeek<DateType extends Date>(
+  dateLeft: DateType | number | string,
+  dateRight: DateType | number | string,
+  options?: {
+    weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+    locale?: Locale;
+  },
+): boolean {
+  const leftDate = toDate(dateLeft);
+  const rightDate = toDate(dateRight);
+
+  if (isNaN(leftDate.getTime()) || isNaN(rightDate.getTime())) {
+    return false;
+  }
+
+  const normalizeToBusinessDay = (date: Date): Date => {
+    const normalized = new Date(date.getTime());
+
+    if (isWeekend(normalized)) {
+      const day = normalized.getDay();
+      // Saturday → Friday
+      if (day === 6) normalized.setDate(normalized.getDate() - 1);
+      // Sunday → Monday
+      if (day === 0) normalized.setDate(normalized.getDate() + 1);
+    }
+
+    return normalized;
+  };
+
+  const normalizedLeft = normalizeToBusinessDay(leftDate);
+  const normalizedRight = normalizeToBusinessDay(rightDate);
+
+  const startLeft = startOfWeek(normalizedLeft, options);
+  const endLeft = endOfWeek(normalizedLeft, options);
+
+  return (
+    normalizedRight.getTime() >= startLeft.getTime() &&
+    normalizedRight.getTime() <= endLeft.getTime()
+  );
+}

--- a/src/isSameBusinessWeek/test.ts
+++ b/src/isSameBusinessWeek/test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { isSameBusinessWeek } from "./index.js";
+
+describe("isSameBusinessWeek", () => {
+  it("returns true for dates in the same business week", () => {
+    const result = isSameBusinessWeek(
+      new Date(2025, 4 /* May */, 6), // Tuesday
+      new Date(2025, 4 /* May */, 9), // Friday
+      { weekStartsOn: 1 },
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false for dates in different business weeks", () => {
+    const result = isSameBusinessWeek(
+      new Date(2025, 4 /* May */, 9), // Friday
+      new Date(2025, 4 /* May */, 16), // Next Friday
+      { weekStartsOn: 1 },
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("treats Saturday as part of the previous business week", () => {
+    const result = isSameBusinessWeek(
+      new Date(2025, 4 /* May */, 9), // Friday
+      new Date(2025, 4 /* May */, 10), // Saturday
+      { weekStartsOn: 1 },
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it("treats Sunday as part of the next business week", () => {
+    const result = isSameBusinessWeek(
+      new Date(2025, 4 /* May */, 12), // Monday
+      new Date(2025, 4 /* May */, 11), // Sunday
+      { weekStartsOn: 1 },
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it("respects custom weekStartsOn option", () => {
+    const result = isSameBusinessWeek(
+      new Date(2025, 4 /* May */, 4), // Sunday
+      new Date(2025, 4 /* May */, 8), // Thursday
+      { weekStartsOn: 0 },
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false if either date is invalid", () => {
+    const result = isSameBusinessWeek(new Date(NaN), new Date(2025, 4, 6));
+    expect(result).toBe(false);
+  });
+
+  it("accepts timestamps", () => {
+    const result = isSameBusinessWeek(
+      new Date(2025, 4, 6).getTime(),
+      new Date(2025, 4, 7).getTime(),
+      { weekStartsOn: 1 },
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it("does not mutate the original dates", () => {
+    const date = new Date(2025, 4, 9);
+    isSameBusinessWeek(date, new Date(2025, 4, 10), { weekStartsOn: 1 });
+    expect(date).toEqual(new Date(2025, 4, 9));
+  });
+});


### PR DESCRIPTION
Description:
This PR introduces a new utility function, isSameBusinessWeek, for the date-fns library. The function determines whether two dates fall within the same business week (Monday through Friday), ignoring weekends.

Motivation:
While date-fns provides several functions for comparing weeks (isSameWeek, isSameISOWeek), there is currently no native support for comparing business weeks, which is commonly required in business and financial applications. This contribution fills that gap.

Implementation Details:

isSameBusinessWeek(dateLeft, dateRight, options?) returns true if both dates are in the same Monday-to-Friday week; otherwise, false.

Takes an optional options object to allow locale-specific weekStartsOn overrides.
Weekend days are skipped in the comparison, consistent with typical business week logic.