### PR TITLE
Fix: parseISO should reject invalid timezone offsets Add strict parseISO timezone validation tests and test runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,5 @@
-# Use official Node LTS
 FROM node:20-bullseye
-
-# Set working directory
 WORKDIR /app
-
-# Copy package files first (better caching)
-COPY package.json package-lock.json* pnpm-lock.yaml* ./
-
-# Install pnpm (date-fns prefers pnpm)
-RUN npm install -g pnpm
-
-# Install dependencies
-RUN pnpm install
-
-# Copy the rest of the repo
 COPY . .
-
-# Make test.sh executable
-RUN chmod +x test.sh
-
-# Default command: run both base and new tests
-CMD ["bash", "-c", "./test.sh base && ./test.sh new"]
+RUN npm ci
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Use official Node LTS
+FROM node:20-bullseye
+
+# Set working directory
+WORKDIR /app
+
+# Copy package files first (better caching)
+COPY package.json package-lock.json* pnpm-lock.yaml* ./
+
+# Install pnpm (date-fns prefers pnpm)
+RUN npm install -g pnpm
+
+# Install dependencies
+RUN pnpm install
+
+# Copy the rest of the repo
+COPY . .
+
+# Make test.sh executable
+RUN chmod +x test.sh
+
+# Default command: run both base and new tests
+CMD ["bash", "-c", "./test.sh base && ./test.sh new"]

--- a/PROBLEM.md
+++ b/PROBLEM.md
@@ -1,0 +1,22 @@
+# VENUS Problem: parseISO should reject invalid timezone offsets
+
+## Summary
+The `parseISO` function should return `Invalid Date` when the input contains an invalid ISO-8601 timezone offset. Currently, some malformed timezone suffixes or out-of-range timezone values can be accepted and produce a valid `Date`, which may silently normalize incorrect user input and cause downstream data integrity issues.
+
+## Expected behavior
+For invalid timezone offsets, `parseISO` must return `Invalid Date` (i.e., `getTime()` is `NaN`). The behavior must be deterministic and verifiable via return values.
+
+Timezone offsets should be considered invalid when:
+- The timezone suffix does not match a valid ISO-8601 offset format (e.g., incomplete offsets).
+- The hour component is outside the allowed range.
+- The minute component is outside `0..59`.
+
+Valid ISO strings must continue to parse correctly without regressions.
+
+## Test plan
+New deterministic tests are added to cover:
+- Out-of-range timezone hour values (e.g., `+25:00`, `+99:00`).
+- Invalid minute values (e.g., `+24:01`).
+- Malformed timezone offsets (e.g., `+2`, `+2360`).
+
+Base tests must continue to pass, and the new tests must fail on the unpatched version and pass after the fix.

--- a/src/parseISO/index.ts
+++ b/src/parseISO/index.ts
@@ -243,7 +243,9 @@ function parseTimezone(timezoneString: string): number {
   if (timezoneString === "Z") return 0;
 
   const captures = timezoneString.match(timezoneRegex);
-  if (!captures) return 0;
+
+  // ✅ FIX 1: malformed timezone should be invalid, not treated as UTC
+  if (!captures) return NaN;
 
   const sign = captures[1] === "+" ? -1 : 1;
   const hours = parseInt(captures[2]);
@@ -255,6 +257,7 @@ function parseTimezone(timezoneString: string): number {
 
   return sign * (hours * millisecondsInHour + minutes * millisecondsInMinute);
 }
+
 
 function dayOfISOWeekYear(
   isoWeekYear: number,
@@ -314,6 +317,8 @@ function validateTime(
   );
 }
 
-function validateTimezone(_hours: number, minutes: number): boolean {
-  return minutes >= 0 && minutes <= 59;
+function validateTimezone(hours: number, minutes: number): boolean {
+  // ✅ FIX 2: validate hour range as well as minutes
+  return hours >= 0 && hours <= 23 && minutes >= 0 && minutes <= 59;
 }
+

--- a/src/parseISO/venus/test.ts
+++ b/src/parseISO/venus/test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { parseISO } from "../index.js";
+
+describe("VENUS_NEW – strict timezone validation for parseISO", () => {
+  it("returns Invalid Date for timezone with invalid hour (+25:00)", () => {
+    const result = parseISO("2020-01-01T00:00:00+25:00");
+    expect(isNaN(result.getTime())).toBe(true);
+  });
+
+  it("returns Invalid Date for timezone with invalid hour (+99:00)", () => {
+    const result = parseISO("2020-01-01T00:00:00+99:00");
+    expect(isNaN(result.getTime())).toBe(true);
+  });
+
+  it("returns Invalid Date for timezone with invalid minutes (+24:01)", () => {
+    const result = parseISO("2020-01-01T00:00:00+24:01");
+    expect(isNaN(result.getTime())).toBe(true);
+  });
+
+  it("returns Invalid Date for malformed timezone (+2)", () => {
+    const result = parseISO("2020-01-01T00:00:00+2");
+    expect(isNaN(result.getTime())).toBe(true);
+  });
+
+  it("returns Invalid Date for malformed timezone (+2360)", () => {
+    const result = parseISO("2020-01-01T00:00:00+2360");
+    expect(isNaN(result.getTime())).toBe(true);
+  });
+});

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+run_vitest () {
+  if command -v pnpm >/dev/null 2>&1; then
+    pnpm -s vitest run "$@"
+  else
+    npx vitest run "$@"
+  fi
+}
+
+BASE_TESTS=()
+for f in \
+  "src/parseISO/test.ts" \
+  "src/parseISO/test.js" \
+  "src/parseISO/test.mts" \
+  "src/parseISO/test.cts"
+do
+  if [ -f "$f" ]; then
+    BASE_TESTS+=("$f")
+  fi
+done
+
+case "${1:-}" in
+  base)
+    if [ ${#BASE_TESTS[@]} -eq 0 ]; then
+      echo "Could not find base parseISO tests"
+      exit 1
+    fi
+    run_vitest "${BASE_TESTS[@]}"
+    ;;
+  new)
+   run_vitest "src/parseISO/venus/test.ts"
+    ;;
+  *)
+    echo "Usage: ./test.sh {base|new}"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
### Problem

`parseISO` currently accepts invalid ISO 8601 timezone offsets due to two issues in the timezone parsing logic:

1. If the timezone part does not match the `±HH(:)MM` regex, `parseTimezone()` returns `0` instead of `Invalid`.
   - Example: `2020-01-01T00:00:00+2` is incorrectly treated as UTC instead of being rejected.

2. `validateTimezone()` only validates the minutes range (0–59) and does not validate the hour range.
   - As a result, offsets like `+25:00` or `+99:00` are accepted even though they are not valid ISO 8601 offsets.

This leads to incorrect parsing of invalid ISO strings instead of returning an invalid date.

---

### Expected Behavior

If an ISO string contains an invalid timezone offset, `parseISO()` should return an `Invalid Date`.

This can be verified by:
