### PR TITLE
fix(eachHourOfInterval): handle DST fall back correctly

### DIFF
--- a/src/eachHourOfInterval/index.ts
+++ b/src/eachHourOfInterval/index.ts
@@ -76,11 +76,14 @@ export function eachHourOfInterval<
     reversed = !reversed;
   }
 
+  const current = date.getTime();
+  const stepMs = step*60*60*1000;
   const dates: EachHourOfIntervalResult<IntervalType, Options> = [];
 
-  while (+date <= endTime) {
-    dates.push(constructFrom(start, date));
-    date.setHours(date.getHours() + step);
+  let time = current;
+  while (time <= endTime) {
+    dates.push(constructFrom(start, time));
+    time += stepMs;
   }
 
   return reversed ? dates.reverse() : dates;

--- a/src/eachHourOfInterval/test.ts
+++ b/src/eachHourOfInterval/test.ts
@@ -97,6 +97,16 @@ describe("eachHourOfInterval", () => {
     expect(result).toEqual([]);
   });
 
+  it("handles DST Fall Back (25 hour day)", () => {
+      const interval =  {
+        start: new TZDate(2026, 10, 1, 0, 0, 0, "America/New_York"),
+        end: new TZDate(2026, 10, 1, 23, 59, 59, "America/New_York"),
+      };
+
+      const result = eachHourOfInterval(interval);
+      expect(result.length).toBe(25); 
+  });
+
   describe("options.step", () => {
     const interval = {
       start: new Date(2014, 9 /* Oct */, 6, 12),
@@ -153,6 +163,16 @@ describe("eachHourOfInterval", () => {
       const result = eachHourOfInterval(interval, { step: NaN });
       expect(result).toEqual([]);
     });
+
+    it("handles DST Fall Back with options.step", () => {
+      const interval =  {
+        start: new TZDate(2026, 10, 1, 0, 0, 0, "America/New_York"),
+        end: new TZDate(2026, 10, 1, 23, 59, 59, "America/New_York"),
+      };
+      const result = eachHourOfInterval(interval, {step: 2});
+
+      expect(result.length).toBe(13);
+    })
   });
 
   it("resolves the date type by default", () => {


### PR DESCRIPTION
### Summary
Fixes `eachHourOfInterval` to correctly return 25 entries on DST fall back dates instead of 24.

### Issue
Fixes #4123 

### Details
- Handles repeated hour during DST fall back
- Prevents missing hour in affected time zones
