### PR TITLE
Fix bug #4141: Format Distance does not include number of hours/mins/seconds when the hour/min/sec is 1 (Polish, Finnish and Slovak)

### DIFF
--- a/src/locale/fi/_lib/formatDistance/index.ts
+++ b/src/locale/fi/_lib/formatDistance/index.ts
@@ -36,13 +36,13 @@ function futureYears(text: string): string {
 
 const formatDistanceLocale: FormatDistanceLocale<FormatDistanceTokenValue> = {
   lessThanXSeconds: {
-    one: "alle sekunti",
+    one: "alle 1 sekunti",
     other: "alle {{count}} sekuntia",
     futureTense: futureSeconds,
   },
 
   xSeconds: {
-    one: "sekunti",
+    one: "1 sekunti",
     other: "{{count}} sekuntia",
     futureTense: futureSeconds,
   },
@@ -54,79 +54,79 @@ const formatDistanceLocale: FormatDistanceLocale<FormatDistanceTokenValue> = {
   },
 
   lessThanXMinutes: {
-    one: "alle minuutti",
+    one: "alle 1 minuutti",
     other: "alle {{count}} minuuttia",
     futureTense: futureMinutes,
   },
 
   xMinutes: {
-    one: "minuutti",
+    one: "1 minuutti",
     other: "{{count}} minuuttia",
     futureTense: futureMinutes,
   },
 
   aboutXHours: {
-    one: "noin tunti",
+    one: "noin 1 tunti",
     other: "noin {{count}} tuntia",
     futureTense: futureHours,
   },
 
   xHours: {
-    one: "tunti",
+    one: "1 tunti",
     other: "{{count}} tuntia",
     futureTense: futureHours,
   },
 
   xDays: {
-    one: "päivä",
+    one: "1 päivä",
     other: "{{count}} päivää",
     futureTense: futureDays,
   },
 
   aboutXWeeks: {
-    one: "noin viikko",
+    one: "noin 1 viikko",
     other: "noin {{count}} viikkoa",
     futureTense: futureWeeks,
   },
 
   xWeeks: {
-    one: "viikko",
+    one: "1 viikko",
     other: "{{count}} viikkoa",
     futureTense: futureWeeks,
   },
 
   aboutXMonths: {
-    one: "noin kuukausi",
+    one: "noin 1 kuukausi",
     other: "noin {{count}} kuukautta",
     futureTense: futureMonths,
   },
 
   xMonths: {
-    one: "kuukausi",
+    one: "1 kuukausi",
     other: "{{count}} kuukautta",
     futureTense: futureMonths,
   },
 
   aboutXYears: {
-    one: "noin vuosi",
+    one: "noin 1 vuosi",
     other: "noin {{count}} vuotta",
     futureTense: futureYears,
   },
 
   xYears: {
-    one: "vuosi",
+    one: "1 vuosi",
     other: "{{count}} vuotta",
     futureTense: futureYears,
   },
 
   overXYears: {
-    one: "yli vuosi",
+    one: "yli 1 vuosi",
     other: "yli {{count}} vuotta",
     futureTense: futureYears,
   },
 
   almostXYears: {
-    one: "lähes vuosi",
+    one: "lähes 1 vuosi",
     other: "lähes {{count}} vuotta",
     futureTense: futureYears,
   },

--- a/src/locale/pl/_lib/formatDistance/index.ts
+++ b/src/locale/pl/_lib/formatDistance/index.ts
@@ -15,9 +15,9 @@ type FormatDistanceTokenValue = {
 const formatDistanceLocale: FormatDistanceLocale<FormatDistanceTokenValue> = {
   lessThanXSeconds: {
     one: {
-      regular: "mniej niż sekunda",
-      past: "mniej niż sekundę",
-      future: "mniej niż sekundę",
+      regular: "mniej niż 1 sekunda",
+      past: "mniej niż 1 sekundę",
+      future: "mniej niż 1 sekundę",
     },
     twoFour: "mniej niż {{count}} sekundy",
     other: "mniej niż {{count}} sekund",
@@ -25,9 +25,9 @@ const formatDistanceLocale: FormatDistanceLocale<FormatDistanceTokenValue> = {
 
   xSeconds: {
     one: {
-      regular: "sekunda",
-      past: "sekundę",
-      future: "sekundę",
+      regular: "1 sekunda",
+      past: "1 sekundę",
+      future: "1 sekundę",
     },
     twoFour: "{{count}} sekundy",
     other: "{{count}} sekund",
@@ -41,9 +41,9 @@ const formatDistanceLocale: FormatDistanceLocale<FormatDistanceTokenValue> = {
 
   lessThanXMinutes: {
     one: {
-      regular: "mniej niż minuta",
-      past: "mniej niż minutę",
-      future: "mniej niż minutę",
+      regular: "mniej niż 1 minuta",
+      past: "mniej niż 1 minutę",
+      future: "mniej niż 1 minutę",
     },
     twoFour: "mniej niż {{count}} minuty",
     other: "mniej niż {{count}} minut",
@@ -51,9 +51,9 @@ const formatDistanceLocale: FormatDistanceLocale<FormatDistanceTokenValue> = {
 
   xMinutes: {
     one: {
-      regular: "minuta",
-      past: "minutę",
-      future: "minutę",
+      regular: "1 minuta",
+      past: "1 minutę",
+      future: "1 minutę",
     },
     twoFour: "{{count}} minuty",
     other: "{{count}} minut",
@@ -61,9 +61,9 @@ const formatDistanceLocale: FormatDistanceLocale<FormatDistanceTokenValue> = {
 
   aboutXHours: {
     one: {
-      regular: "około godziny",
-      past: "około godziny",
-      future: "około godzinę",
+      regular: "około 1 godziny",
+      past: "około 1 godziny",
+      future: "około 1 godzinę",
     },
     twoFour: "około {{count}} godziny",
     other: "około {{count}} godzin",
@@ -71,9 +71,9 @@ const formatDistanceLocale: FormatDistanceLocale<FormatDistanceTokenValue> = {
 
   xHours: {
     one: {
-      regular: "godzina",
-      past: "godzinę",
-      future: "godzinę",
+      regular: "1 godzina",
+      past: "1 godzinę",
+      future: "1 godzinę",
     },
     twoFour: "{{count}} godziny",
     other: "{{count}} godzin",
@@ -81,8 +81,8 @@ const formatDistanceLocale: FormatDistanceLocale<FormatDistanceTokenValue> = {
 
   xDays: {
     one: {
-      regular: "dzień",
-      past: "dzień",
+      regular: "1 dzień",
+      past: "1 dzień",
       future: "1 dzień",
     },
     twoFour: "{{count}} dni",
@@ -90,49 +90,49 @@ const formatDistanceLocale: FormatDistanceLocale<FormatDistanceTokenValue> = {
   },
 
   aboutXWeeks: {
-    one: "około tygodnia",
+    one: "około 1 tygodnia",
     twoFour: "około {{count}} tygodni",
     other: "około {{count}} tygodni",
   },
 
   xWeeks: {
-    one: "tydzień",
+    one: "1tydzień",
     twoFour: "{{count}} tygodnie",
     other: "{{count}} tygodni",
   },
 
   aboutXMonths: {
-    one: "około miesiąc",
+    one: "około 1 miesiąc",
     twoFour: "około {{count}} miesiące",
     other: "około {{count}} miesięcy",
   },
 
   xMonths: {
-    one: "miesiąc",
+    one: "1 miesiąc",
     twoFour: "{{count}} miesiące",
     other: "{{count}} miesięcy",
   },
 
   aboutXYears: {
-    one: "około rok",
+    one: "około 1 rok",
     twoFour: "około {{count}} lata",
     other: "około {{count}} lat",
   },
 
   xYears: {
-    one: "rok",
+    one: "1 rok",
     twoFour: "{{count}} lata",
     other: "{{count}} lat",
   },
 
   overXYears: {
-    one: "ponad rok",
+    one: "ponad 1 rok",
     twoFour: "ponad {{count}} lata",
     other: "ponad {{count}} lat",
   },
 
   almostXYears: {
-    one: "prawie rok",
+    one: "prawie 1 rok",
     twoFour: "prawie {{count}} lata",
     other: "prawie {{count}} lat",
   },

--- a/src/locale/sk/_lib/formatDistance/index.ts
+++ b/src/locale/sk/_lib/formatDistance/index.ts
@@ -80,9 +80,9 @@ function lowercaseFirstLetter(string: string) {
 const formatDistanceLocale = {
   xSeconds: {
     one: {
-      present: "sekunda",
-      past: "sekundou",
-      future: "sekundu",
+      present: "1 sekunda",
+      past: "1 sekundou",
+      future: "1 sekundu",
     },
     twoFour: {
       present: "{{count}} sekundy",
@@ -106,9 +106,9 @@ const formatDistanceLocale = {
 
   xMinutes: {
     one: {
-      present: "minúta",
-      past: "minútou",
-      future: "minútu",
+      present: "1 minúta",
+      past: "1 minútou",
+      future: "1 minútu",
     },
     twoFour: {
       present: "{{count}} minúty",
@@ -124,9 +124,9 @@ const formatDistanceLocale = {
 
   xHours: {
     one: {
-      present: "hodina",
-      past: "hodinou",
-      future: "hodinu",
+      present: "1 hodina",
+      past: "1 hodinou",
+      future: "1 hodinu",
     },
     twoFour: {
       present: "{{count}} hodiny",
@@ -142,9 +142,9 @@ const formatDistanceLocale = {
 
   xDays: {
     one: {
-      present: "deň",
-      past: "dňom",
-      future: "deň",
+      present: "1 deň",
+      past: "1 dňom",
+      future: "1 deň",
     },
     twoFour: {
       present: "{{count}} dni",
@@ -160,9 +160,9 @@ const formatDistanceLocale = {
 
   xWeeks: {
     one: {
-      present: "týždeň",
-      past: "týždňom",
-      future: "týždeň",
+      present: "1 týždeň",
+      past: "1 týždňom",
+      future: "1 týždeň",
     },
     twoFour: {
       present: "{{count}} týždne",
@@ -178,9 +178,9 @@ const formatDistanceLocale = {
 
   xMonths: {
     one: {
-      present: "mesiac",
-      past: "mesiacom",
-      future: "mesiac",
+      present: "1 mesiac",
+      past: "1 mesiacom",
+      future: "1 mesiac",
     },
     twoFour: {
       present: "{{count}} mesiace",
@@ -196,9 +196,9 @@ const formatDistanceLocale = {
 
   xYears: {
     one: {
-      present: "rok",
-      past: "rokom",
-      future: "rok",
+      present: "1 rok",
+      past: "1 rokom",
+      future: "1 rok",
     },
     twoFour: {
       present: "{{count}} roky",


### PR DESCRIPTION
Summary:
Format Distance does not include nummber of hours/mins/seconds when the hour/min/sec is 1
When switching between languages, if I have a string as 1hour 1min, it changes to hour min (issue exists in Polish, Finnish and Slovak).

Issue
Fixes https://github.com/date-fns/date-fns/issues/4141