### PR TITLE
docs(intervalToDuration): fix example to show zero values are omitted

### DIFF
--- a/src/intervalToDuration/index.ts
+++ b/src/intervalToDuration/index.ts
@@ -32,7 +32,23 @@ export interface IntervalToDurationOptions extends ContextOptions<Date> {}
  *   start: new Date(1929, 0, 15, 12, 0, 0),
  *   end: new Date(1968, 3, 4, 19, 5, 0)
  * });
- * //=> { years: 39, months: 2, days: 20, hours: 7, minutes: 5, seconds: 0 }
+ * //=> { years: 39, months: 2, days: 20, hours: 7, minutes: 5 }
+ *
+ * @example
+ * // Get the duration between January 1, 2023, 12:00:00 and January 1, 2023, 12:00:01
+ * intervalToDuration({
+ *   start: new Date(2023, 0, 1, 12, 0, 0),
+ *   end: new Date(2023, 0, 1, 12, 0, 1)
+ * });
+ * //=> { seconds: 1 }
+ *
+ * @example
+ * // Duration object will only include non-zero values
+ * intervalToDuration({
+ *   start: new Date(2023, 0, 1, 12, 0, 0),
+ *   end: new Date(2023, 0, 1, 12, 0, 0)
+ * });
+ * //=> {}
  */
 export function intervalToDuration(
   interval: Interval,


### PR DESCRIPTION
## Fix intervalToDuration documentation to reflect zero value omission

Fixes #4131

### Problem
The documentation example for `intervalToDuration` showed `seconds: 0` in the return value, but the function actually omits zero values from the duration object as of v4.1.0.

**Previous documentation:**
```typescript
//=> { years: 39, months: 2, days: 20, hours: 7, minutes: 5, seconds: 0 }
```

**Actual behavior:**
```typescript
//=> { years: 39, months: 2, days: 20, hours: 7, minutes: 5 }
```

### Changes
Updated the documentation in `src/intervalToDuration/index.ts` to:

1. **Corrected the main example** - Removed `seconds: 0` from the output to match actual behavior
2. **Added clarifying examples**:
   - Example showing seconds included when value is non-zero
   - Example showing empty object when dates are equal, explicitly documenting that zero values are omitted

### Validation
The changes are validated against the existing test suite:

- ✅ Test "returns correct duration for arbitrary dates" (lines 7-20 in test.ts) confirms the main example returns no `seconds` property
- ✅ Test "returns correct duration (1 of everything)" (lines 21-36) confirms non-zero seconds ARE included
- ✅ Test "returns duration of 0 when the dates are the same" (lines 36-44) confirms empty object behavior

### Implementation
The actual implementation (lines 66-68) confirms this is intentional behavior:
```typescript
const seconds = differenceInSeconds(end, remainingSeconds);
if (seconds) duration.seconds = seconds;  // Only adds if truthy (non-zero)
```

All duration properties (years, months, days, hours, minutes, seconds) follow the same pattern.
