### PR TITLE
Fix incorrect time in set() JSDoc example

### DIFF
--- a/src/set/index.ts
+++ b/src/set/index.ts
@@ -39,7 +39,7 @@ export interface SetOptions<DateType extends Date = Date>
  * //=> Tue Oct 20 2015 00:00:00
  *
  * @example
- * // Set 12 PM to 1 September 2014 01:23:45 to 1 September 2014 12:00:00:
+ * // Set 12 PM to 1 September 2014 01:23:45 to 1 September 2014 12:23:45:
  * const result = set(new Date(2014, 8, 1, 1, 23, 45), { hours: 12 })
  * //=> Mon Sep 01 2014 12:23:45
  */


### PR DESCRIPTION
Fixes #4129

The JSDoc comment for the `set()` function had an incorrect description of the expected result. The comment stated that setting only the hours to 12 would result in "12:00:00", but the actual result (correctly shown in the code example) is "12:23:45" since the `set()` function only modifies the specified fields and leaves other time components unchanged.

## Changes
- Updated the JSDoc comment to correctly reflect that the result is "12:23:45" not "12:00:00"

## Testing
Verified the existing code example shows the correct output:
```typescript
const result = set(new Date(2014, 8, 1, 1, 23, 45), { hours: 12 })
//=> Mon Sep 01 2014 12:23:45
```

The minutes (23) and seconds (45) are preserved as expected.