### PR TITLE
docs: clarify month indexing in closestIndexTo example

### DIFF
--- a/src/closestIndexTo/index.ts
+++ b/src/closestIndexTo/index.ts
@@ -16,7 +16,7 @@ import type { DateArg } from "../types.ts";
  *
  * @example
  * // Which date is closer to 6 September 2015?
- * const dateToCompare = new Date(2015, 8, 6)
+ * const dateToCompare = new Date(2015, 8, 6) // Note: months are 0-indexed, so 8 = September
  * const datesArray = [
  *   new Date(2015, 0, 1),
  *   new Date(2016, 0, 1),


### PR DESCRIPTION
This PR fixes issue #4149 by adding a clarifying comment to the closestIndexTo documentation example.

The example shows `new Date(2015, 8, 6)` for September 6, 2015, which is correct since JavaScript's Date constructor uses 0-indexed months (0 = January, 8 = September). However, this has caused confusion for developers who expect September to be month 9.

I've added an inline comment to make this clearer: `// Note: months are 0-indexed, so 8 = September`

This small clarification should help prevent future confusion about the example.

Fixes #4149