### PR TITLE
fix(parseISO): return Invalid Date for null/undefined arguments

### DIFF
--- a/src/parseISO/index.ts
+++ b/src/parseISO/index.ts
@@ -54,6 +54,11 @@ export function parseISO<
 >(argument: string, options?: ParseISOOptions<ResultDate>): ResultDate {
   const invalidDate = () => constructFrom(options?.in, NaN);
 
+  // Return Invalid Date for non-string arguments (including null/undefined)
+  if (typeof argument !== "string") {
+    return invalidDate();
+  }
+
   const additionalDigits = options?.additionalDigits ?? 2;
   const dateStrings = splitDateString(argument);
 

--- a/src/parseISO/test.ts
+++ b/src/parseISO/test.ts
@@ -362,6 +362,34 @@ describe("parseISO", () => {
       expect(result instanceof Date).toBe(true);
       expect(isNaN(result.getTime())).toBe(true);
     });
+
+    it("returns Invalid Date if argument is null", () => {
+      // @ts-expect-error - testing runtime behavior with invalid input
+      const result = parseISO(null);
+      expect(result instanceof Date).toBe(true);
+      expect(isNaN(result.getTime())).toBe(true);
+    });
+
+    it("returns Invalid Date if argument is undefined", () => {
+      // @ts-expect-error - testing runtime behavior with invalid input
+      const result = parseISO(undefined);
+      expect(result instanceof Date).toBe(true);
+      expect(isNaN(result.getTime())).toBe(true);
+    });
+
+    it("returns Invalid Date if argument is a number", () => {
+      // @ts-expect-error - testing runtime behavior with invalid input
+      const result = parseISO(1234567890);
+      expect(result instanceof Date).toBe(true);
+      expect(isNaN(result.getTime())).toBe(true);
+    });
+
+    it("returns Invalid Date if argument is a Date object", () => {
+      // @ts-expect-error - testing runtime behavior with invalid input
+      const result = parseISO(new Date());
+      expect(result instanceof Date).toBe(true);
+      expect(isNaN(result.getTime())).toBe(true);
+    });
   });
 
   it("resolves the date type by default", () => {


### PR DESCRIPTION
## Summary

Fixes #4127

Previously, passing `null` or `undefined` to `parseISO` would throw a `TypeError`:

```
TypeError: Cannot read properties of null (reading 'split')
    at splitDateString (parseISO.js:105:28)
    at parseISO (parseISO.js:49:23)
```

According to the documentation, `parseISO` should return `Invalid Date` "if the argument isn't a string" - this fix implements that behavior by adding a type check at the start of the function.

## Changes

- Add `typeof argument !== "string"` check to return `Invalid Date` for non-string inputs
- Add tests for `null`, `undefined`, number, and Date object inputs

## Test Plan

- [x] All 62 existing tests pass
- [x] 4 new tests added for invalid argument types (null, undefined, number, Date object)
- [x] Verified fix matches documented behavior