### PR TITLE
Expose locale build helpers

### DIFF
--- a/docs/i18nContributionGuide.md
+++ b/docs/i18nContributionGuide.md
@@ -214,7 +214,7 @@ From the CLDR chart, use ['Date & Time'/'Gregorian'/'Eras'](https://www.unicode.
 
 ```js
 // In `en-US` locale:
-import buildLocalizeFn from "../../../_lib/buildLocalizeFn/index.js";
+import buildLocalizeFn from "../../../buildLocalizeFn/index.js";
 
 var eraValues = {
   narrow: ["B", "A"],
@@ -356,7 +356,7 @@ From the CLDR chart, use ['Date & Time'/'Gregorian'/'Quarters'](https://www.unic
 
 ```js
 // In `en-US` locale:
-import buildLocalizeFn from "../../../_lib/buildLocalizeFn/index.js";
+import buildLocalizeFn from "../../../buildLocalizeFn/index.js";
 
 var quarterValues = {
   narrow: ["1", "2", "3", "4"],
@@ -390,7 +390,7 @@ From the CLDR chart, use ['Date & Time'/'Gregorian'/'Months'](https://www.unicod
 
 ```js
 // In `en-US` locale:
-import buildLocalizeFn from "../../../_lib/buildLocalizeFn/index.js";
+import buildLocalizeFn from "../../../buildLocalizeFn/index.js";
 
 var monthValues = {
   narrow: ["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"],
@@ -486,7 +486,7 @@ From the CLDR chart, use ['Date & Time'/'Gregorian'/'Days'](https://www.unicode.
 
 ```js
 // In `en-US` locale:
-import buildLocalizeFn from "../../../_lib/buildLocalizeFn/index.js";
+import buildLocalizeFn from "../../../buildLocalizeFn/index.js";
 
 var dayValues = {
   narrow: ["S", "M", "T", "W", "T", "F", "S"],
@@ -526,7 +526,7 @@ From the CLDR chart, use ['Date & Time'/'Gregorian'/'Day periods'](https://www.u
 
 ```js
 // In `en-US` locale:
-import buildLocalizeFn from "../../../_lib/buildLocalizeFn/index.js";
+import buildLocalizeFn from "../../../buildLocalizeFn/index.js";
 
 var dayPeriodValues = {
   narrow: {
@@ -783,7 +783,7 @@ Contains the functions used by `parse` to parse a localized value:
 ```js
 // In `en-US` locale:
 import buildMatchPatternFn from "../../../_lib/buildMatchPatternFn/index.js";
-import buildMatchFn from "../../../_lib/buildMatchFn/index.js";
+import buildMatchFn from "../../../buildMatchFn/index.js";
 
 var matchOrdinalNumberPattern = /^(\d+)(th|st|nd|rd)?/i;
 var parseOrdinalNumberPattern = /\d+/i;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
       },
       "import": {
         "types": "./index.d.ts",
-        "default": "./index.js"
+        "default": "./index.ts"
       }
     },
     "./constants": {
@@ -58,6 +58,26 @@
       "import": {
         "types": "./fp.d.ts",
         "default": "./fp.js"
+      }
+    },
+    "./locale/buildLocalizeFn": {
+      "require": {
+        "types": "./locale/buildLocalizeFn.d.cts",
+        "default": "./locale/buildLocalizeFn.cjs"
+      },
+      "import": {
+        "types": "./locale/buildLocalizeFn.d.ts",
+        "default": "./locale/buildLocalizeFn.js"
+      }
+    },
+    "./locale/buildMatchFn": {
+      "require": {
+        "types": "./locale/buildMatchFn.d.cts",
+        "default": "./locale/buildMatchFn.cjs"
+      },
+      "import": {
+        "types": "./locale/buildMatchFn.d.ts",
+        "default": "./locale/buildMatchFn.js"
       }
     },
     "./add": {

--- a/scripts/_lib/listLocales.ts
+++ b/scripts/_lib/listLocales.ts
@@ -2,6 +2,7 @@ import { readdir } from "fs/promises";
 import path from "path";
 
 const ignorePattern = /^_|\./; // can't start with `_` or have a `.` in it
+const ignoredLocales = new Set(["buildLocalizeFn", "buildMatchFn"]);
 
 export interface LocaleFile {
   name: string;
@@ -15,7 +16,9 @@ export async function listLocales(): Promise<LocaleFile[]> {
   const locales: string[] = await readdir(localesPath);
 
   return locales
-    .filter((file: string) => !ignorePattern.test(file))
+    .filter(
+      (file: string) => !ignorePattern.test(file) && !ignoredLocales.has(file),
+    )
     .map((locale: string) => ({
       name: locale
         .split("-")

--- a/scripts/build/indices.ts
+++ b/scripts/build/indices.ts
@@ -22,7 +22,6 @@ interface File {
   const locales = await listLocales();
   const fns = await listFns();
   const fpFns = await listFPFns();
-
   await Promise.all([
     generatePackageJSON({ fns, fpFns, locales }).then((json) =>
       writeFile("package.json", json),
@@ -49,6 +48,7 @@ async function generatePackageJSON({
   fpFns,
   locales,
 }: GeneratePackageJSONProps) {
+  const localeHelpers = ["./locale/buildLocalizeFn", "./locale/buildMatchFn"];
   const packageJSON = JSON.parse(await readFile("package.json", "utf-8"));
   packageJSON.exports = Object.fromEntries(
     [
@@ -68,6 +68,7 @@ async function generatePackageJSON({
       ],
     ]
       .concat(mapExports(["./constants", "./locale", "./fp"], "."))
+      .concat(mapExports(localeHelpers))
       .concat(mapExports(mapFiles(fns)))
       .concat(mapExports(mapFiles(fpFns), "./fp"))
       .concat(mapExports(mapFiles(locales), "./locale")),

--- a/src/locale/af/_lib/localize/index.ts
+++ b/src/locale/af/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["vC", "nC"] as const,

--- a/src/locale/af/_lib/match/index.ts
+++ b/src/locale/af/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(ste|de)?/i;

--- a/src/locale/ar-DZ/_lib/localize/index.ts
+++ b/src/locale/ar-DZ/_lib/localize/index.ts
@@ -1,4 +1,4 @@
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 import type { Localize, LocalizeFn } from "../../../types.ts";
 import type { Quarter } from "../../../../types.ts";
 

--- a/src/locale/ar-DZ/_lib/match/index.ts
+++ b/src/locale/ar-DZ/_lib/match/index.ts
@@ -1,5 +1,5 @@
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
 

--- a/src/locale/ar-EG/_lib/localize/index.ts
+++ b/src/locale/ar-EG/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["ق", "ب"] as const,

--- a/src/locale/ar-EG/_lib/match/index.ts
+++ b/src/locale/ar-EG/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)/;

--- a/src/locale/ar-MA/_lib/localize/index.ts
+++ b/src/locale/ar-MA/_lib/localize/index.ts
@@ -1,4 +1,4 @@
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 import type { Localize, LocalizeFn } from "../../../types.ts";
 import type { Quarter } from "../../../../types.ts";
 

--- a/src/locale/ar-MA/_lib/match/index.ts
+++ b/src/locale/ar-MA/_lib/match/index.ts
@@ -1,5 +1,5 @@
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
 

--- a/src/locale/ar-SA/_lib/localize/index.ts
+++ b/src/locale/ar-SA/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["ق", "ب"] as const,

--- a/src/locale/ar-SA/_lib/match/index.ts
+++ b/src/locale/ar-SA/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(th|st|nd|rd)?/i;

--- a/src/locale/ar-TN/_lib/localize/index.ts
+++ b/src/locale/ar-TN/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["ق", "ب"] as const,

--- a/src/locale/ar-TN/_lib/match/index.ts
+++ b/src/locale/ar-TN/_lib/match/index.ts
@@ -1,5 +1,5 @@
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import type { Match } from "../../../types.ts";
 import type { Quarter } from "../../../../types.ts";
 

--- a/src/locale/ar/_lib/localize/index.ts
+++ b/src/locale/ar/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["ق", "ب"] as const,

--- a/src/locale/ar/_lib/match/index.ts
+++ b/src/locale/ar/_lib/match/index.ts
@@ -1,5 +1,5 @@
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import type { Match } from "../../../types.ts";
 import type { Quarter } from "../../../../types.ts";
 

--- a/src/locale/az/_lib/localize/index.ts
+++ b/src/locale/az/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["e.ə", "b.e"] as const,

--- a/src/locale/az/_lib/match/index.ts
+++ b/src/locale/az/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(-?(ci|inci|nci|uncu|üncü|ncı))?/i;

--- a/src/locale/be-tarask/_lib/localize/index.ts
+++ b/src/locale/be-tarask/_lib/localize/index.ts
@@ -1,6 +1,6 @@
 import type { Localize } from "../../../types.ts";
 import type { LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["да н.э.", "н.э."] as const,

--- a/src/locale/be-tarask/_lib/match/index.ts
+++ b/src/locale/be-tarask/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern =

--- a/src/locale/be/_lib/localize/index.ts
+++ b/src/locale/be/_lib/localize/index.ts
@@ -1,6 +1,6 @@
 import type { Localize } from "../../../types.ts";
 import type { LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["да н.э.", "н.э."] as const,

--- a/src/locale/be/_lib/match/index.ts
+++ b/src/locale/be/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern =

--- a/src/locale/bg/_lib/localize/index.ts
+++ b/src/locale/bg/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { LocaleUnit, Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["пр.н.е.", "н.е."] as const,

--- a/src/locale/bg/_lib/match/index.ts
+++ b/src/locale/bg/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern =

--- a/src/locale/bn/_lib/localize/index.ts
+++ b/src/locale/bn/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const numberValues = {
   locale: {

--- a/src/locale/bn/_lib/match/index.ts
+++ b/src/locale/bn/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(ম|য়|র্থ|ষ্ঠ|শে|ই|তম)?/i;

--- a/src/locale/bs/_lib/localize/index.ts
+++ b/src/locale/bs/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["pr.n.e.", "AD"] as const,

--- a/src/locale/bs/_lib/match/index.ts
+++ b/src/locale/bs/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)\./i;

--- a/src/locale/buildLocalizeFn/index.ts
+++ b/src/locale/buildLocalizeFn/index.ts
@@ -1,10 +1,10 @@
-import type { Day, Era, Month, Quarter } from "../../../types.ts";
+import type { Day, Era, Month, Quarter } from "../../types.ts";
 import type {
   LocaleDayPeriod,
   LocaleUnitValue,
   LocaleWidth,
   LocalizeFn,
-} from "../../types.ts";
+} from "../types.ts";
 
 export type BuildLocalizeFnArgs<
   Value extends LocaleUnitValue,

--- a/src/locale/buildMatchFn/index.ts
+++ b/src/locale/buildMatchFn/index.ts
@@ -1,11 +1,11 @@
-import type { Quarter, Era, Day, Month } from "../../../types.ts";
+import type { Quarter, Era, Day, Month } from "../../types.ts";
 import type {
   LocaleUnitValue,
   LocaleWidth,
   LocaleDayPeriod,
   MatchFn,
   MatchValueCallback,
-} from "../../types.ts";
+} from "../types.ts";
 
 export interface BuildMatchFnArgs<
   Result extends LocaleUnitValue,

--- a/src/locale/ca/_lib/localize/index.ts
+++ b/src/locale/ca/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 /**
  * General information

--- a/src/locale/ca/_lib/match/index.ts
+++ b/src/locale/ca/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(è|r|n|r|t)?/i;

--- a/src/locale/ckb/_lib/localize/index.ts
+++ b/src/locale/ckb/_lib/localize/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["پ", "د"] as const,

--- a/src/locale/ckb/_lib/match/index.ts
+++ b/src/locale/ckb/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(th|st|nd|rd)?/i;

--- a/src/locale/cs/_lib/localize/index.ts
+++ b/src/locale/cs/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["př. n. l.", "n. l."] as const,

--- a/src/locale/cs/_lib/match/index.ts
+++ b/src/locale/cs/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)\.?/i;

--- a/src/locale/cy/_lib/localize/index.ts
+++ b/src/locale/cy/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["C", "O"] as const,

--- a/src/locale/cy/_lib/match/index.ts
+++ b/src/locale/cy/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(af|ail|ydd|ed|fed|eg|ain)?/i;

--- a/src/locale/da/_lib/localize/index.ts
+++ b/src/locale/da/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["fvt", "vt"] as const,

--- a/src/locale/da/_lib/match/index.ts
+++ b/src/locale/da/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(\.)?/i;

--- a/src/locale/de-AT/_lib/localize/index.ts
+++ b/src/locale/de-AT/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["v.Chr.", "n.Chr."] as const,

--- a/src/locale/de/_lib/localize/index.ts
+++ b/src/locale/de/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["v.Chr.", "n.Chr."] as const,

--- a/src/locale/de/_lib/match/index.ts
+++ b/src/locale/de/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(\.)?/i;

--- a/src/locale/el/_lib/localize/index.ts
+++ b/src/locale/el/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["πΧ", "μΧ"] as const,

--- a/src/locale/el/_lib/match/index.ts
+++ b/src/locale/el/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(ος|η|ο)?/i;

--- a/src/locale/en-US/_lib/localize/index.ts
+++ b/src/locale/en-US/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["B", "A"] as const,

--- a/src/locale/en-US/_lib/match/index.ts
+++ b/src/locale/en-US/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(th|st|nd|rd)?/i;

--- a/src/locale/eo/_lib/localize/index.ts
+++ b/src/locale/eo/_lib/localize/index.ts
@@ -1,6 +1,6 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
 import type { Quarter } from "../../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["aK", "pK"] as const,

--- a/src/locale/eo/_lib/match/index.ts
+++ b/src/locale/eo/_lib/match/index.ts
@@ -1,5 +1,5 @@
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import type { Match } from "../../../types.ts";
 import type { Quarter } from "../../../../types.ts";
 

--- a/src/locale/es/_lib/localize/index.ts
+++ b/src/locale/es/_lib/localize/index.ts
@@ -1,4 +1,4 @@
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 import type { Quarter } from "../../../../types.ts";
 import type { Localize, LocalizeFn } from "../../../types.ts";
 

--- a/src/locale/es/_lib/match/index.ts
+++ b/src/locale/es/_lib/match/index.ts
@@ -1,5 +1,5 @@
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
 

--- a/src/locale/et/_lib/localize/index.ts
+++ b/src/locale/et/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["e.m.a", "m.a.j"] as const,

--- a/src/locale/et/_lib/match/index.ts
+++ b/src/locale/et/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^\d+\./i;

--- a/src/locale/eu/_lib/localize/index.ts
+++ b/src/locale/eu/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["k.a.", "k.o."] as const,

--- a/src/locale/eu/_lib/match/index.ts
+++ b/src/locale/eu/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(.)?/i;

--- a/src/locale/fa-IR/_lib/localize/index.ts
+++ b/src/locale/fa-IR/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["ق", "ب"] as const,

--- a/src/locale/fa-IR/_lib/match/index.ts
+++ b/src/locale/fa-IR/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(th|st|nd|rd)?/i;

--- a/src/locale/fi/_lib/localize/index.ts
+++ b/src/locale/fi/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["eaa.", "jaa."] as const,

--- a/src/locale/fi/_lib/match/index.ts
+++ b/src/locale/fi/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(\.)/i;

--- a/src/locale/fr/_lib/localize/index.ts
+++ b/src/locale/fr/_lib/localize/index.ts
@@ -1,4 +1,4 @@
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 import type { Localize, LocalizeFn } from "../../../types.ts";
 
 const eraValues = {

--- a/src/locale/fr/_lib/match/index.ts
+++ b/src/locale/fr/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(ième|ère|ème|er|e)?/i;

--- a/src/locale/fy/_lib/localize/index.ts
+++ b/src/locale/fy/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["f.K.", "n.K."] as const,

--- a/src/locale/fy/_lib/match/index.ts
+++ b/src/locale/fy/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)e?/i;

--- a/src/locale/gd/_lib/localize/index.ts
+++ b/src/locale/gd/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["R", "A"] as const,

--- a/src/locale/gd/_lib/match/index.ts
+++ b/src/locale/gd/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(d|na|tr|mh)?/i;

--- a/src/locale/gl/_lib/localize/index.ts
+++ b/src/locale/gl/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["AC", "DC"] as const,

--- a/src/locale/gl/_lib/match/index.ts
+++ b/src/locale/gl/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(º)?/i;

--- a/src/locale/gu/_lib/localize/index.ts
+++ b/src/locale/gu/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 // https://www.unicode.org/cldr/charts/32/summary/gu.html
 // #1621 - #1630

--- a/src/locale/gu/_lib/match/index.ts
+++ b/src/locale/gu/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(લ|જ|થ|ઠ્ઠ|મ)?/i;

--- a/src/locale/he/_lib/localize/index.ts
+++ b/src/locale/he/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["לפנה״ס", "לספירה"] as const,

--- a/src/locale/he/_lib/match/index.ts
+++ b/src/locale/he/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern =

--- a/src/locale/hi/_lib/localize/index.ts
+++ b/src/locale/hi/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 type hiLocaleNumberType =
   | "\u0967"

--- a/src/locale/hi/_lib/match/index.ts
+++ b/src/locale/hi/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 import { localeToNumber } from "../localize/index.ts";
 

--- a/src/locale/hr/_lib/localize/index.ts
+++ b/src/locale/hr/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["pr.n.e.", "AD"] as const,

--- a/src/locale/hr/_lib/match/index.ts
+++ b/src/locale/hr/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)\./i;

--- a/src/locale/ht/_lib/localize/index.ts
+++ b/src/locale/ht/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["av. J.-K", "ap. J.-K"] as const,

--- a/src/locale/ht/_lib/match/index.ts
+++ b/src/locale/ht/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(ye|yèm)?/i;

--- a/src/locale/hu/_lib/localize/index.ts
+++ b/src/locale/hu/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["ie.", "isz."] as const,

--- a/src/locale/hu/_lib/match/index.ts
+++ b/src/locale/hu/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)\.?/i;

--- a/src/locale/hy/_lib/localize/index.ts
+++ b/src/locale/hy/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["Ք", "Մ"] as const,

--- a/src/locale/hy/_lib/match/index.ts
+++ b/src/locale/hy/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)((-|֊)?(ին|րդ))?/i;

--- a/src/locale/id/_lib/localize/index.ts
+++ b/src/locale/id/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 // All data for localization are taken from this page
 // https://www.unicode.org/cldr/charts/32/summary/id.html

--- a/src/locale/id/_lib/match/index.ts
+++ b/src/locale/id/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^ke-(\d+)?/i;

--- a/src/locale/is/_lib/localize/index.ts
+++ b/src/locale/is/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["f.Kr.", "e.Kr."] as const,

--- a/src/locale/is/_lib/match/index.ts
+++ b/src/locale/is/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(\.)?/i;

--- a/src/locale/it/_lib/localize/index.ts
+++ b/src/locale/it/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["aC", "dC"] as const,

--- a/src/locale/it/_lib/match/index.ts
+++ b/src/locale/it/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(º)?/i;

--- a/src/locale/ja-Hira/_lib/localize/index.ts
+++ b/src/locale/ja-Hira/_lib/localize/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["BC", "AC"] as const,

--- a/src/locale/ja-Hira/_lib/match/index.ts
+++ b/src/locale/ja-Hira/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern =

--- a/src/locale/ja/_lib/localize/index.ts
+++ b/src/locale/ja/_lib/localize/index.ts
@@ -1,4 +1,4 @@
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 import type { Quarter } from "../../../../types.ts";
 import type { Localize, LocalizeFn } from "../../../types.ts";
 

--- a/src/locale/ja/_lib/match/index.ts
+++ b/src/locale/ja/_lib/match/index.ts
@@ -1,5 +1,5 @@
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import type { Match } from "../../../types.ts";
 import type { Quarter } from "../../../../types.ts";
 

--- a/src/locale/ka/_lib/localize/index.ts
+++ b/src/locale/ka/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["ჩ.წ-მდე", "ჩ.წ"] as const,

--- a/src/locale/ka/_lib/match/index.ts
+++ b/src/locale/ka/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(-ლი|-ე)?/i;

--- a/src/locale/kk/_lib/localize/index.ts
+++ b/src/locale/kk/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["б.з.д.", "б.з."] as const,

--- a/src/locale/kk/_lib/match/index.ts
+++ b/src/locale/kk/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(-?(ші|шы))?/i;

--- a/src/locale/km/_lib/localize/index.ts
+++ b/src/locale/km/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["ម.គស", "គស"] as const,

--- a/src/locale/km/_lib/match/index.ts
+++ b/src/locale/km/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(th|st|nd|rd)?/i;

--- a/src/locale/kn/_lib/localize/index.ts
+++ b/src/locale/kn/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 // Reference: https://www.unicode.org/cldr/charts/32/summary/kn.html
 

--- a/src/locale/kn/_lib/match/index.ts
+++ b/src/locale/kn/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(ನೇ|ನೆ)?/i;

--- a/src/locale/ko/_lib/localize/index.ts
+++ b/src/locale/ko/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["BC", "AD"] as const,

--- a/src/locale/ko/_lib/match/index.ts
+++ b/src/locale/ko/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(일|번째)?/i;

--- a/src/locale/lb/_lib/localize/index.ts
+++ b/src/locale/lb/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["v.Chr.", "n.Chr."] as const,

--- a/src/locale/lb/_lib/match/index.ts
+++ b/src/locale/lb/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(\.)?/i;

--- a/src/locale/lt/_lib/localize/index.ts
+++ b/src/locale/lt/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["pr. Kr.", "po Kr."] as const,

--- a/src/locale/lt/_lib/match/index.ts
+++ b/src/locale/lt/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(-oji)?/i;

--- a/src/locale/lv/_lib/localize/index.ts
+++ b/src/locale/lv/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["p.m.ē", "m.ē"] as const,

--- a/src/locale/lv/_lib/match/index.ts
+++ b/src/locale/lv/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)\./i;

--- a/src/locale/mk/_lib/localize/index.ts
+++ b/src/locale/mk/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["пр.н.е.", "н.е."] as const,

--- a/src/locale/mk/_lib/match/index.ts
+++ b/src/locale/mk/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(-?[врмт][и])?/i;

--- a/src/locale/mn/_lib/localize/index.ts
+++ b/src/locale/mn/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["НТӨ", "НТ"] as const,

--- a/src/locale/mn/_lib/match/index.ts
+++ b/src/locale/mn/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /\d+/i;

--- a/src/locale/ms/_lib/localize/index.ts
+++ b/src/locale/ms/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 // Most data for localization are taken from this page
 // https://www.unicode.org/cldr/charts/32/summary/ms.html

--- a/src/locale/ms/_lib/match/index.ts
+++ b/src/locale/ms/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^ke-(\d+)?/i;

--- a/src/locale/mt/_lib/localize/index.ts
+++ b/src/locale/mt/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["Q", "W"] as const,

--- a/src/locale/mt/_lib/match/index.ts
+++ b/src/locale/mt/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(º)?/i;

--- a/src/locale/nb/_lib/localize/index.ts
+++ b/src/locale/nb/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["f.Kr.", "e.Kr."] as const,

--- a/src/locale/nb/_lib/match/index.ts
+++ b/src/locale/nb/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)\.?/i;

--- a/src/locale/nl-BE/_lib/localize/index.ts
+++ b/src/locale/nl-BE/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["v.C.", "n.C."] as const,

--- a/src/locale/nl-BE/_lib/match/index.ts
+++ b/src/locale/nl-BE/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)e?/i;

--- a/src/locale/nl/_lib/localize/index.ts
+++ b/src/locale/nl/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["v.C.", "n.C."] as const,

--- a/src/locale/nl/_lib/match/index.ts
+++ b/src/locale/nl/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)e?/i;

--- a/src/locale/nn/_lib/localize/index.ts
+++ b/src/locale/nn/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["f.Kr.", "e.Kr."] as const,

--- a/src/locale/nn/_lib/match/index.ts
+++ b/src/locale/nn/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)\.?/i;

--- a/src/locale/oc/_lib/localize/index.ts
+++ b/src/locale/oc/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["ab. J.C.", "apr. J.C."] as const,

--- a/src/locale/oc/_lib/match/index.ts
+++ b/src/locale/oc/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(èr|nd|en)?[a]?/i;

--- a/src/locale/pl/_lib/localize/index.ts
+++ b/src/locale/pl/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["p.n.e.", "n.e."] as const,

--- a/src/locale/pl/_lib/match/index.ts
+++ b/src/locale/pl/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)?/i;

--- a/src/locale/pt-BR/_lib/localize/index.ts
+++ b/src/locale/pt-BR/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["AC", "DC"] as const,

--- a/src/locale/pt-BR/_lib/match/index.ts
+++ b/src/locale/pt-BR/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)[ºªo]?/i;

--- a/src/locale/pt/_lib/localize/index.ts
+++ b/src/locale/pt/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["aC", "dC"] as const,

--- a/src/locale/pt/_lib/match/index.ts
+++ b/src/locale/pt/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(º|ª)?/i;

--- a/src/locale/ro/_lib/localize/index.ts
+++ b/src/locale/ro/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["Î", "D"] as const,

--- a/src/locale/ro/_lib/match/index.ts
+++ b/src/locale/ro/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)?/i;

--- a/src/locale/ru/_lib/localize/index.ts
+++ b/src/locale/ru/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["до н.э.", "н.э."] as const,

--- a/src/locale/ru/_lib/match/index.ts
+++ b/src/locale/ru/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(-?(е|я|й|ое|ье|ая|ья|ый|ой|ий|ый))?/i;

--- a/src/locale/se/_lib/localize/index.ts
+++ b/src/locale/se/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["o.Kr.", "m.Kr."] as const,

--- a/src/locale/se/_lib/match/index.ts
+++ b/src/locale/se/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)\.?/i;

--- a/src/locale/sk/_lib/localize/index.ts
+++ b/src/locale/sk/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 // https://www.unicode.org/cldr/charts/32/summary/sk.html#1772
 const eraValues = {

--- a/src/locale/sk/_lib/match/index.ts
+++ b/src/locale/sk/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)\.?/i;

--- a/src/locale/sl/_lib/localize/index.ts
+++ b/src/locale/sl/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["pr. n. št.", "po n. št."] as const,

--- a/src/locale/sl/_lib/match/index.ts
+++ b/src/locale/sl/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)\./i;

--- a/src/locale/sq/_lib/localize/index.ts
+++ b/src/locale/sq/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["P", "M"] as const,

--- a/src/locale/sq/_lib/match/index.ts
+++ b/src/locale/sq/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(-rë|-të|t|)?/i;

--- a/src/locale/sr-Latn/_lib/localize/index.ts
+++ b/src/locale/sr-Latn/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["pr.n.e.", "AD"] as const,

--- a/src/locale/sr-Latn/_lib/match/index.ts
+++ b/src/locale/sr-Latn/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)\./i;

--- a/src/locale/sr/_lib/localize/index.ts
+++ b/src/locale/sr/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["пр.н.е.", "АД"] as const,

--- a/src/locale/sr/_lib/match/index.ts
+++ b/src/locale/sr/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)\./i;

--- a/src/locale/sv/_lib/localize/index.ts
+++ b/src/locale/sv/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["f.Kr.", "e.Kr."] as const,

--- a/src/locale/sv/_lib/match/index.ts
+++ b/src/locale/sv/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(:a|:e)?/i;

--- a/src/locale/ta/_lib/localize/index.ts
+++ b/src/locale/ta/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 // Ref: https://www.unicode.org/cldr/charts/32/summary/ta.html
 

--- a/src/locale/ta/_lib/match/index.ts
+++ b/src/locale/ta/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(வது)?/i;

--- a/src/locale/te/_lib/localize/index.ts
+++ b/src/locale/te/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 // Source: https://www.unicode.org/cldr/charts/32/summary/te.html
 // Source: https://dsal.uchicago.edu/dictionaries/brown/

--- a/src/locale/te/_lib/match/index.ts
+++ b/src/locale/te/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(వ)?/i;

--- a/src/locale/th/_lib/localize/index.ts
+++ b/src/locale/th/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["B", "คศ"] as const,

--- a/src/locale/th/_lib/match/index.ts
+++ b/src/locale/th/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^\d+/i;

--- a/src/locale/tr/_lib/localize/index.ts
+++ b/src/locale/tr/_lib/localize/index.ts
@@ -1,7 +1,7 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
 import type { Quarter } from "../../../../types.ts";
 
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["MÖ", "MS"] as const,

--- a/src/locale/tr/_lib/match/index.ts
+++ b/src/locale/tr/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(\.)?/i;

--- a/src/locale/ug/_lib/localize/index.ts
+++ b/src/locale/ug/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["ب", "ك"] as const,

--- a/src/locale/ug/_lib/match/index.ts
+++ b/src/locale/ug/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(th|st|nd|rd)?/i;

--- a/src/locale/uk/_lib/localize/index.ts
+++ b/src/locale/uk/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["до н.е.", "н.е."] as const,

--- a/src/locale/uk/_lib/match/index.ts
+++ b/src/locale/uk/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(-?(е|й|є|а|я))?/i;

--- a/src/locale/uz-Cyrl/_lib/localize/index.ts
+++ b/src/locale/uz-Cyrl/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["М.А", "М"] as const,

--- a/src/locale/uz-Cyrl/_lib/match/index.ts
+++ b/src/locale/uz-Cyrl/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(чи)?/i;

--- a/src/locale/uz/_lib/localize/index.ts
+++ b/src/locale/uz/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["M.A", "M."] as const,

--- a/src/locale/uz/_lib/match/index.ts
+++ b/src/locale/uz/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)(chi)?/i;

--- a/src/locale/vi/_lib/localize/index.ts
+++ b/src/locale/vi/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 // Vietnamese locale reference: http://www.localeplanet.com/icu/vi-VN/index.html
 // Capitalization reference: http://hcmup.edu.vn/index.php?option=com_content&view=article&id=4106%3Avit-hoa-trong-vn-bn-hanh-chinh&catid=2345%3Atham-kho&Itemid=4103&lang=vi&site=134

--- a/src/locale/vi/_lib/match/index.ts
+++ b/src/locale/vi/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(\d+)/i;

--- a/src/locale/zh-CN/_lib/localize/index.ts
+++ b/src/locale/zh-CN/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["前", "公元"] as const,

--- a/src/locale/zh-CN/_lib/match/index.ts
+++ b/src/locale/zh-CN/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(第\s*)?\d+(日|时|分|秒)?/i;

--- a/src/locale/zh-HK/_lib/localize/index.ts
+++ b/src/locale/zh-HK/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["前", "公元"] as const,

--- a/src/locale/zh-HK/_lib/match/index.ts
+++ b/src/locale/zh-HK/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(第\s*)?\d+(日|時|分|秒)?/i;

--- a/src/locale/zh-TW/_lib/localize/index.ts
+++ b/src/locale/zh-TW/_lib/localize/index.ts
@@ -1,5 +1,5 @@
 import type { Localize, LocalizeFn } from "../../../types.ts";
-import { buildLocalizeFn } from "../../../_lib/buildLocalizeFn/index.ts";
+import { buildLocalizeFn } from "../../../buildLocalizeFn/index.ts";
 
 const eraValues = {
   narrow: ["前", "公元"] as const,

--- a/src/locale/zh-TW/_lib/match/index.ts
+++ b/src/locale/zh-TW/_lib/match/index.ts
@@ -1,6 +1,6 @@
 import type { Quarter } from "../../../../types.ts";
 import type { Match } from "../../../types.ts";
-import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchFn } from "../../../buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
 const matchOrdinalNumberPattern = /^(第\s*)?\d+(日|時|分|秒)?/i;

--- a/typedoc.json
+++ b/typedoc.json
@@ -250,5 +250,7 @@
     "./src/constants/index.ts"
   ],
   "json": "./tmp/docs.json",
-  "plugin": ["typedoc-plugin-missing-exports"]
+  "plugin": [
+    "typedoc-plugin-missing-exports"
+  ]
 }


### PR DESCRIPTION
Expose the locale build helpers so custom locale's can be created externally. E.g. based on server input.

Closes #1116

To do so, I've moved the two libraries one level up and ignored them when generating the locales. Let me know what you think of this approach.