### PR TITLE
Fix differenceInMonths negative duration and de-AT locale matching

### DIFF
--- a/src/differenceInMonths/index.ts
+++ b/src/differenceInMonths/index.ts
@@ -1,7 +1,7 @@
 import { normalizeDates } from "../_lib/normalizeDates/index.ts";
 import { compareAsc } from "../compareAsc/index.ts";
 import { differenceInCalendarMonths } from "../differenceInCalendarMonths/index.ts";
-import { isLastDayOfMonth } from "../isLastDayOfMonth/index.ts";
+import { addMonths } from "../addMonths/index.ts";
 import type { ContextOptions, DateArg } from "../types.ts";
 
 /**
@@ -30,34 +30,22 @@ export function differenceInMonths(
   earlierDate: DateArg<Date> & {},
   options?: DifferenceInMonthsOptions | undefined,
 ): number {
-  const [laterDate_, workingLaterDate, earlierDate_] = normalizeDates(
+  const [laterDate_, , earlierDate_] = normalizeDates(
     options?.in,
     laterDate,
     laterDate,
     earlierDate,
   );
 
-  const sign = compareAsc(workingLaterDate, earlierDate_);
+  const sign = compareAsc(laterDate_, earlierDate_);
   const difference = Math.abs(
-    differenceInCalendarMonths(workingLaterDate, earlierDate_),
+    differenceInCalendarMonths(laterDate_, earlierDate_),
   );
 
   if (difference < 1) return 0;
 
-  if (workingLaterDate.getMonth() === 1 && workingLaterDate.getDate() > 27)
-    workingLaterDate.setDate(30);
-
-  workingLaterDate.setMonth(workingLaterDate.getMonth() - sign * difference);
-
-  let isLastMonthNotFull = compareAsc(workingLaterDate, earlierDate_) === -sign;
-
-  if (
-    isLastDayOfMonth(laterDate_) &&
-    difference === 1 &&
-    compareAsc(laterDate_, earlierDate_) === 1
-  ) {
-    isLastMonthNotFull = false;
-  }
+  const fullMonthsDate = addMonths(earlierDate_, sign * difference, options);
+  const isLastMonthNotFull = compareAsc(laterDate_, fullMonthsDate) === -sign;
 
   const result = sign * (difference - +isLastMonthNotFull);
   return result === 0 ? 0 : result;

--- a/src/intervalToDuration/test.ts
+++ b/src/intervalToDuration/test.ts
@@ -235,6 +235,21 @@ describe("intervalToDuration", () => {
     });
   });
 
+  describe("issue 4150 reproduction", () => {
+    it("should not produce negative hours/minutes when end is after start", () => {
+      // 2026-01-28 22:45:00+00
+      // 2026-02-28 16:23:00+00
+      const start = new Date(Date.UTC(2026, 0, 28, 22, 45, 0));
+      const end = new Date(Date.UTC(2026, 1, 28, 16, 23, 0));
+
+      const result = intervalToDuration({ start, end });
+
+      expect(result.hours || 0).toBeGreaterThanOrEqual(0);
+      expect(result.minutes || 0).toBeGreaterThanOrEqual(0);
+      expect(result.seconds || 0).toBeGreaterThanOrEqual(0);
+    });
+  });
+
   it("normalizes the dates", () => {
     const laterDate = new TZDate(2027, 0, 1, "Asia/Singapore");
     const earlierDate = new TZDate(2024, 0, 1, "America/New_York");

--- a/src/locale/de-AT/_lib/match/index.ts
+++ b/src/locale/de-AT/_lib/match/index.ts
@@ -1,0 +1,135 @@
+import type { Quarter } from "../../../../types.ts";
+import type { Match } from "../../../types.ts";
+import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
+import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
+
+const matchOrdinalNumberPattern = /^(\d+)(\.)?/i;
+const parseOrdinalNumberPattern = /\d+/i;
+
+const matchEraPatterns = {
+  narrow: /^(v\.? ?Chr\.?|n\.? ?Chr\.?)/i,
+  abbreviated: /^(v\.? ?Chr\.?|n\.? ?Chr\.?)/i,
+  wide: /^(vor Christus|vor unserer Zeitrechnung|nach Christus|unserer Zeitrechnung)/i,
+};
+const parseEraPatterns = {
+  any: [/^v/i, /^n/i] as const,
+};
+
+const matchQuarterPatterns = {
+  narrow: /^[1234]/i,
+  abbreviated: /^q[1234]/i,
+  wide: /^[1234](\.)? Quartal/i,
+};
+const parseQuarterPatterns = {
+  any: [/1/i, /2/i, /3/i, /4/i] as const,
+};
+
+const matchMonthPatterns = {
+  narrow: /^[jfmasond]/i,
+  abbreviated:
+    /^(j[aä]n|feb|mär[z]?|apr|mai|jun[i]?|jul[i]?|aug|sep|okt|nov|dez)\.?/i,
+  wide: /^(jänn?er|januar|februar|märz|april|mai|juni|juli|august|september|oktober|november|dezember)/i,
+};
+const parseMonthPatterns = {
+  narrow: [
+    /^j/i,
+    /^f/i,
+    /^m/i,
+    /^a/i,
+    /^m/i,
+    /^j/i,
+    /^j/i,
+    /^a/i,
+    /^s/i,
+    /^o/i,
+    /^n/i,
+    /^d/i,
+  ] as const,
+  any: [
+    /^j[aä]/i,
+    /^f/i,
+    /^mär/i,
+    /^ap/i,
+    /^mai/i,
+    /^jun/i,
+    /^jul/i,
+    /^au/i,
+    /^s/i,
+    /^o/i,
+    /^n/i,
+    /^d/i,
+  ] as const,
+};
+
+const matchDayPatterns = {
+  narrow: /^[smdmf]/i,
+  short: /^(so|mo|di|mi|do|fr|sa)/i,
+  abbreviated: /^(son?|mon?|die?|mit?|don?|fre?|sam?)\.?/i,
+  wide: /^(sonntag|montag|dienstag|mittwoch|donnerstag|freitag|samstag)/i,
+};
+const parseDayPatterns = {
+  any: [/^so/i, /^mo/i, /^di/i, /^mi/i, /^do/i, /^f/i, /^sa/i] as const,
+};
+
+const matchDayPeriodPatterns = {
+  narrow: /^(vm\.?|nm\.?|Mitternacht|Mittag|morgens|nachm\.?|abends|nachts)/i,
+  abbreviated:
+    /^(vorm\.?|nachm\.?|Mitternacht|Mittag|morgens|nachm\.?|abends|nachts)/i,
+  wide: /^(vormittags|nachmittags|Mitternacht|Mittag|morgens|nachmittags|abends|nachts)/i,
+};
+const parseDayPeriodPatterns = {
+  any: {
+    am: /^v/i,
+    pm: /^n/i,
+    midnight: /^Mitte/i,
+    noon: /^Mitta/i,
+    morning: /morgens/i,
+    afternoon: /nachmittags/i, // will never be matched. Afternoon is matched by `pm`
+    evening: /abends/i,
+    night: /nachts/i, // will never be matched. Night is matched by `pm`
+  },
+};
+
+export const match: Match = {
+  ordinalNumber: buildMatchPatternFn({
+    matchPattern: matchOrdinalNumberPattern,
+    parsePattern: parseOrdinalNumberPattern,
+    valueCallback: (value) => parseInt(value),
+  }),
+
+  era: buildMatchFn({
+    matchPatterns: matchEraPatterns,
+    defaultMatchWidth: "wide",
+    parsePatterns: parseEraPatterns,
+    defaultParseWidth: "any",
+  }),
+
+  quarter: buildMatchFn({
+    matchPatterns: matchQuarterPatterns,
+    defaultMatchWidth: "wide",
+    parsePatterns: parseQuarterPatterns,
+    defaultParseWidth: "any",
+    valueCallback: (index) => (index + 1) as Quarter,
+  }),
+
+  month: buildMatchFn({
+    matchPatterns: matchMonthPatterns,
+    defaultMatchWidth: "wide",
+    parsePatterns: parseMonthPatterns,
+    defaultParseWidth: "any",
+  }),
+
+  day: buildMatchFn({
+    matchPatterns: matchDayPatterns,
+    defaultMatchWidth: "wide",
+    parsePatterns: parseDayPatterns,
+    defaultParseWidth: "any",
+  }),
+
+  dayPeriod: buildMatchFn({
+    matchPatterns: matchDayPeriodPatterns,
+    defaultMatchWidth: "wide",
+    parsePatterns: parseDayPeriodPatterns,
+    defaultParseWidth: "any",
+  }),
+};

--- a/src/locale/de-AT/index.ts
+++ b/src/locale/de-AT/index.ts
@@ -1,10 +1,9 @@
 import { formatDistance } from "../de/_lib/formatDistance/index.ts";
 import { formatLong } from "../de/_lib/formatLong/index.ts";
 import { formatRelative } from "../de/_lib/formatRelative/index.ts";
-import { match } from "../de/_lib/match/index.ts";
 import type { Locale } from "../types.ts";
-// difference to 'de' locale
 import { localize } from "./_lib/localize/index.ts";
+import { match } from "./_lib/match/index.ts";
 
 /**
  * @category Locales

--- a/src/locale/de-AT/test.ts
+++ b/src/locale/de-AT/test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { parse } from "../../parse/index.ts";
+import { deAT } from "./index.ts";
+
+describe("issue 4148 reproduction", () => {
+  it("should parse 'Jänner' with deAT locale", () => {
+    const result = parse("16. Jänner", "dd. MMMM", new Date(2026, 0, 1), {
+      locale: deAT,
+    });
+    
+    expect(result.getMonth()).toBe(0); // January
+    expect(result.getDate()).toBe(16);
+    expect(result.getTime()).not.toBeNaN();
+  });
+
+  it("should parse 'Januar' with deAT locale", () => {
+    const result = parse("16. Januar", "dd. MMMM", new Date(2026, 0, 1), {
+      locale: deAT,
+    });
+    
+    expect(result.getMonth()).toBe(0); // January
+    expect(result.getDate()).toBe(16);
+    expect(result.getTime()).not.toBeNaN();
+  });
+});

--- a/src/transpose/test.ts
+++ b/src/transpose/test.ts
@@ -15,4 +15,17 @@ describe("transpose", () => {
     expect(result.getSeconds()).toBe(56);
     expect(result.getMilliseconds()).toBe(789);
   });
+
+  it("transpose to UTCDate (issue 4161 reproduction)", async () => {
+    const { UTCDate } = await import("../../submodules/utc/src/index.ts");
+    const date = new Date(2022, 6, 10, 0, 0, 0); // July 10 2022 00:00 local
+    const transposed = transpose(date, UTCDate);
+    
+    expect(transposed).toBeInstanceOf(UTCDate);
+    expect(transposed.getFullYear()).toBe(2022);
+    expect(transposed.getMonth()).toBe(6);
+    expect(transposed.getDate()).toBe(10);
+    expect(transposed.getHours()).toBe(0);
+    expect(transposed.toString()).toMatch(/GMT\+0000 \(Coordinated Universal Time\)/);
+  });
 });


### PR DESCRIPTION
This PR fixes two bugs:

1. **Issue #4150: intervalToDuration producing negative hours/minutes.**
   Refactored `differenceInMonths` to use `addMonths` for more accurate, time-aware calculation of full months. This resolves cases where it wrongly reported a full month on the last day of the month when the time component made it slightly less than a month.

2. **Issue #4148: deAT locale missing "Jänner" in match patterns.**
   Customized `match` for the `de-AT` locale to include "Jänner" for January, ensuring correct parsing of Austrian dates.

Verified with unit tests for both cases. Added regression tests to `intervalToDuration` and `de-AT` locale. Also added a test case for `transpose` to verify it correctly handles `UTCDate` as reported in #4161 (though no bug was found there).