### PR TITLE
docs: add bun installation step to contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,9 +61,15 @@ Please follow the main contributing rules, to maintain date-fns' top quality:
 
 1. Install [Node.js 22 or greater (LTS recommended)](https://nodejs.org/en/download/)
 
-2. Fork the project, and clone your fork of the repo
+2. Install [bun](https://bun.sh/) (required for the CDN build step):
 
-3. Run `pnpm install` to install the dependencies
+   ```sh
+   npm install -g bun
+   ```
+
+3. Fork the project, and clone your fork of the repo
+
+4. Run `pnpm install` to install the dependencies
 
 ## Testing
 
@@ -108,6 +114,9 @@ undefined
 ### Test build
 
 To test the build, run:
+
+> **Note:** The build script requires [bun](https://bun.sh/) for the CDN build step.
+> Install it with `npm install -g bun` if you haven't already (see [Getting Started](#getting-started)).
 
 ```sh
 ./scripts/build/package.sh


### PR DESCRIPTION

## Summary
The build script `scripts/build/package.sh` uses `bun` directly (for the CDN build step), but `CONTRIBUTING.md` never mentions installing it. This causes confusion for first-time contributors who follow the guide and get an error when running the build.
## Changes
- **Getting Started**: Added a new step to install [bun](https://bun.sh/) via `npm install -g bun` as a prerequisite, before forking/cloning.
- **Test build**: Added a note explaining that `bun` is required for the CDN build step, with a cross-reference back to the Getting Started section.
This is a documentation-only change with no code impact.