### PR TITLE
docs: clarify yyyy/YYYY and dd/DD pitfalls in format/parse/isMatch

### DIFF
--- a/src/format/index.ts
+++ b/src/format/index.ts
@@ -69,6 +69,11 @@ export interface FormatOptions
  *
  * > ⚠️ Please note that the `format` tokens differ from Moment.js and other libraries.
  * > See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * >
+ * > **Common Pitfalls:**
+ * > - Use `yyyy` instead of `YYYY` for calendar years; use `yy` instead of `YY`.
+ * > - Use `dd` instead of `DD` for days of the month; use `d` instead of `D`.
+ * > - See [Unicode Tokens](https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md) for more details.
  *
  * The characters wrapped between two single quotes characters (') are escaped.
  * Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.
@@ -90,12 +95,12 @@ export interface FormatOptions
  * |                                 | yyy     | 044, 001, 1900, 2017              | 5     |
  * |                                 | yyyy    | 0044, 0001, 1900, 2017            | 5     |
  * |                                 | yyyyy   | ...                               | 3,5   |
- * | Local week-numbering year       | Y       | 44, 1, 1900, 2017                 | 5     |
- * |                                 | Yo      | 44th, 1st, 1900th, 2017th         | 5,7   |
+ * | Local week-numbering year       | Y       | 44, 1, 1900, 2017                 | 5,8   |
+ * |                                 | Yo      | 44th, 1st, 1900th, 2017th         | 5,7,8 |
  * |                                 | YY      | 44, 01, 00, 17                    | 5,8   |
- * |                                 | YYY     | 044, 001, 1900, 2017              | 5     |
+ * |                                 | YYY     | 044, 001, 1900, 2017              | 5,8   |
  * |                                 | YYYY    | 0044, 0001, 1900, 2017            | 5,8   |
- * |                                 | YYYYY   | ...                               | 3,5   |
+ * |                                 | YYYYY   | ...                               | 3,5,8 |
  * | ISO week-numbering year         | R       | -43, 0, 1, 1900, 2017             | 5,7   |
  * |                                 | RR      | -43, 00, 01, 1900, 2017           | 5,7   |
  * |                                 | RRR     | -043, 000, 001, 1900, 2017        | 5,7   |
@@ -140,10 +145,10 @@ export interface FormatOptions
  * |                                 | do      | 1st, 2nd, ..., 31st               | 7     |
  * |                                 | dd      | 01, 02, ..., 31                   |       |
  * | Day of year                     | D       | 1, 2, ..., 365, 366               | 9     |
- * |                                 | Do      | 1st, 2nd, ..., 365th, 366th       | 7     |
+ * |                                 | Do      | 1st, 2nd, ..., 365th, 366th       | 7,9   |
  * |                                 | DD      | 01, 02, ..., 365, 366             | 9     |
- * |                                 | DDD     | 001, 002, ..., 365, 366           |       |
- * |                                 | DDDD    | ...                               | 3     |
+ * |                                 | DDD     | 001, 002, ..., 365, 366           | 9     |
+ * |                                 | DDDD    | ...                               | 3,9   |
  * | Day of week (formatting)        | E..EEE  | Mon, Tue, Wed, ..., Sun           |       |
  * |                                 | EEEE    | Monday, Tuesday, ..., Sunday      | 2     |
  * |                                 | EEEEE   | M, T, W, T, F, S, S               |       |
@@ -303,10 +308,12 @@ export interface FormatOptions
  *    - `P`: long localized date
  *    - `p`: long localized time
  *
- * 8. `YY` and `YYYY` tokens represent week-numbering years but they are often confused with years.
+ * 8. `Y` tokens represent week-numbering years but they are often confused with calendar years.
+ *    For calendar year, use `y`.
  *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  *
- * 9. `D` and `DD` tokens represent days of the year but they are often confused with days of the month.
+ * 9. `D` tokens represent days of the year but they are often confused with days of the month.
+ *    For day of month, use `d`.
  *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  *
  * @param date - The original date

--- a/src/isMatch/index.ts
+++ b/src/isMatch/index.ts
@@ -27,6 +27,11 @@ export interface IsMatchOptions
  *
  * > ⚠️ Please note that the `format` tokens differ from Moment.js and other libraries.
  * > See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * >
+ * > **Common Pitfalls:**
+ * > - Use `yyyy` instead of `YYYY` for calendar years; use `yy` instead of `YY`.
+ * > - Use `dd` instead of `DD` for days of the month; use `d` instead of `D`.
+ * > - See [Unicode Tokens](https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md) for more details.
  *
  * The characters in the format string wrapped between two single quotes characters (') are escaped.
  * Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.
@@ -57,12 +62,12 @@ export interface IsMatchOptions
  * |                                 |     | yyy     | 044, 001, 123, 999                | 4     |
  * |                                 |     | yyyy    | 0044, 0001, 1900, 2017            | 4     |
  * |                                 |     | yyyyy   | ...                               | 2,4   |
- * | Local week-numbering year       | 130 | Y       | 44, 1, 1900, 2017, 9000           | 4     |
- * |                                 |     | Yo      | 44th, 1st, 1900th, 9999999th      | 4,5   |
+ * | Local week-numbering year       | 130 | Y       | 44, 1, 1900, 2017, 9000           | 4,6   |
+ * |                                 |     | Yo      | 44th, 1st, 1900th, 9999999th      | 4,5,6 |
  * |                                 |     | YY      | 44, 01, 00, 17                    | 4,6   |
- * |                                 |     | YYY     | 044, 001, 123, 999                | 4     |
+ * |                                 |     | YYY     | 044, 001, 123, 999                | 4,6   |
  * |                                 |     | YYYY    | 0044, 0001, 1900, 2017            | 4,6   |
- * |                                 |     | YYYYY   | ...                               | 2,4   |
+ * |                                 |     | YYYYY   | ...                               | 2,4,6 |
  * | ISO week-numbering year         | 130 | R       | -43, 1, 1900, 2017, 9999, -9999   | 4,5   |
  * |                                 |     | RR      | -43, 01, 00, 17                   | 4,5   |
  * |                                 |     | RRR     | -043, 001, 123, 999, -999         | 4,5   |
@@ -107,10 +112,10 @@ export interface IsMatchOptions
  * |                                 |     | do      | 1st, 2nd, ..., 31st               | 5     |
  * |                                 |     | dd      | 01, 02, ..., 31                   |       |
  * | Day of year                     |  90 | D       | 1, 2, ..., 365, 366               | 7     |
- * |                                 |     | Do      | 1st, 2nd, ..., 365th, 366th       | 5     |
+ * |                                 |     | Do      | 1st, 2nd, ..., 365th, 366th       | 5,7   |
  * |                                 |     | DD      | 01, 02, ..., 365, 366             | 7     |
- * |                                 |     | DDD     | 001, 002, ..., 365, 366           |       |
- * |                                 |     | DDDD    | ...                               | 2     |
+ * |                                 |     | DDD     | 001, 002, ..., 365, 366           | 7     |
+ * |                                 |     | DDDD    | ...                               | 2,7   |
  * | Day of week (formatting)        |  90 | E..EEE  | Mon, Tue, Wed, ..., Su            |       |
  * |                                 |     | EEEE    | Monday, Tuesday, ..., Sunday      | 2     |
  * |                                 |     | EEEEE   | M, T, W, T, F, S, S               |       |
@@ -248,10 +253,12 @@ export interface IsMatchOptions
  *    - `P`: long localized date
  *    - `p`: long localized time
  *
- * 6. `YY` and `YYYY` tokens represent week-numbering years but they are often confused with years.
+ * 6. `Y` tokens represent week-numbering years but they are often confused with calendar years.
+ *    For calendar year, use `y`.
  *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  *
- * 7. `D` and `DD` tokens represent days of the year but they are often confused with days of the month.
+ * 7. `D` tokens represent days of the year but they are often confused with days of the month.
+ *    For day of month, use `d`.
  *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  *
  * 8. `P+` tokens do not have a defined priority since they are merely aliases to other tokens based

--- a/src/lightFormat/index.ts
+++ b/src/lightFormat/index.ts
@@ -38,6 +38,11 @@ type Token = keyof typeof lightFormatters;
  *
  * > ⚠️ Please note that the `lightFormat` tokens differ from Moment.js and other libraries.
  * > See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * >
+ * > **Common Pitfalls:**
+ * > - Use `yyyy` instead of `YYYY` for calendar years; use `yy` instead of `YY`.
+ * > - Use `dd` instead of `DD` for days of the month; use `d` instead of `D`.
+ * > - See [Unicode Tokens](https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md) for more details.
  *
  * The characters wrapped between two single quotes characters (') are escaped.
  * Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.

--- a/src/parse/index.ts
+++ b/src/parse/index.ts
@@ -69,6 +69,11 @@ const unescapedLatinCharacterRegExp = /[a-zA-Z]/;
  *
  * > ⚠️ Please note that the `format` tokens differ from Moment.js and other libraries.
  * > See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * >
+ * > **Common Pitfalls:**
+ * > - Use `yyyy` instead of `YYYY` for calendar years; use `yy` instead of `YY`.
+ * > - Use `dd` instead of `DD` for days of the month; use `d` instead of `D`.
+ * > - See [Unicode Tokens](https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md) for more details.
  *
  * The characters in the format string wrapped between two single quotes characters (') are escaped.
  * Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.
@@ -99,12 +104,12 @@ const unescapedLatinCharacterRegExp = /[a-zA-Z]/;
  * |                                 |     | yyy     | 044, 001, 123, 999                | 4     |
  * |                                 |     | yyyy    | 0044, 0001, 1900, 2017            | 4     |
  * |                                 |     | yyyyy   | ...                               | 2,4   |
- * | Local week-numbering year       | 130 | Y       | 44, 1, 1900, 2017, 9000           | 4     |
- * |                                 |     | Yo      | 44th, 1st, 1900th, 9999999th      | 4,5   |
+ * | Local week-numbering year       | 130 | Y       | 44, 1, 1900, 2017, 9000           | 4,6   |
+ * |                                 |     | Yo      | 44th, 1st, 1900th, 9999999th      | 4,5,6 |
  * |                                 |     | YY      | 44, 01, 00, 17                    | 4,6   |
- * |                                 |     | YYY     | 044, 001, 123, 999                | 4     |
+ * |                                 |     | YYY     | 044, 001, 123, 999                | 4,6   |
  * |                                 |     | YYYY    | 0044, 0001, 1900, 2017            | 4,6   |
- * |                                 |     | YYYYY   | ...                               | 2,4   |
+ * |                                 |     | YYYYY   | ...                               | 2,4,6 |
  * | ISO week-numbering year         | 130 | R       | -43, 1, 1900, 2017, 9999, -9999   | 4,5   |
  * |                                 |     | RR      | -43, 01, 00, 17                   | 4,5   |
  * |                                 |     | RRR     | -043, 001, 123, 999, -999         | 4,5   |
@@ -149,10 +154,10 @@ const unescapedLatinCharacterRegExp = /[a-zA-Z]/;
  * |                                 |     | do      | 1st, 2nd, ..., 31st               | 5     |
  * |                                 |     | dd      | 01, 02, ..., 31                   |       |
  * | Day of year                     |  90 | D       | 1, 2, ..., 365, 366               | 7     |
- * |                                 |     | Do      | 1st, 2nd, ..., 365th, 366th       | 5     |
+ * |                                 |     | Do      | 1st, 2nd, ..., 365th, 366th       | 5,7   |
  * |                                 |     | DD      | 01, 02, ..., 365, 366             | 7     |
- * |                                 |     | DDD     | 001, 002, ..., 365, 366           |       |
- * |                                 |     | DDDD    | ...                               | 2     |
+ * |                                 |     | DDD     | 001, 002, ..., 365, 366           | 7     |
+ * |                                 |     | DDDD    | ...                               | 2,7   |
  * | Day of week (formatting)        |  90 | E..EEE  | Mon, Tue, Wed, ..., Sun           |       |
  * |                                 |     | EEEE    | Monday, Tuesday, ..., Sunday      | 2     |
  * |                                 |     | EEEEE   | M, T, W, T, F, S, S               |       |
@@ -290,10 +295,12 @@ const unescapedLatinCharacterRegExp = /[a-zA-Z]/;
  *    - `P`: long localized date
  *    - `p`: long localized time
  *
- * 6. `YY` and `YYYY` tokens represent week-numbering years but they are often confused with years.
+ * 6. `Y` tokens represent week-numbering years but they are often confused with calendar years.
+ *    For calendar year, use `y`.
  *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  *
- * 7. `D` and `DD` tokens represent days of the year but they are often confused with days of the month.
+ * 7. `D` tokens represent days of the year but they are often confused with days of the month.
+ *    For day of month, use `d`.
  *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
  *
  * 8. `P+` tokens do not have a defined priority since they are merely aliases to other tokens based


### PR DESCRIPTION
### Description
    This PR improves the documentation for the most common pitfalls in `date-fns`: the confusion between calendar years (`yyyy`) and week-numbering years (`YYYY`), as well as days of the month (`dd`) and days of the year (`DD`).
    
### Changes
- Added a prominent **Common Pitfalls** section to the JSDoc of `format`, `parse`, `isMatch`, and `lightFormat`.
- Updated the Unicode token tables to ensure all variations (e.g., `Y`, `Yo`, `D`, `Do`) point to the warning notes.
- Refined Notes 8 & 9 (in `format`) and Notes 6 & 7 (in `parse`/`isMatch`) to explicitly suggest using `y` and `d` for standard use cases.
    
This should help reduce the number of issues opened by developers who accidentally use week-numbering year tokens for standard date formatting.
   
Fixes #2954
