### PR TITLE
docs: fix intervalToDuration JSDoc example to match actual output

### DIFF
--- a/src/intervalToDuration/index.ts
+++ b/src/intervalToDuration/index.ts
@@ -32,7 +32,7 @@ export interface IntervalToDurationOptions extends ContextOptions<Date> {}
  *   start: new Date(1929, 0, 15, 12, 0, 0),
  *   end: new Date(1968, 3, 4, 19, 5, 0)
  * });
- * //=> { years: 39, months: 2, days: 20, hours: 7, minutes: 5, seconds: 0 }
+ * //=> { years: 39, months: 2, days: 20, hours: 7, minutes: 5 }
  */
 export function intervalToDuration(
   interval: Interval,


### PR DESCRIPTION
Fixes #4131

The JSDoc example for `intervalToDuration` showed `seconds: 0` in the result:

```ts
//=> { years: 39, months: 2, days: 20, hours: 7, minutes: 5, seconds: 0 }
```

But in v4.1.0, the function omits `seconds` when the value is 0 (the code uses `if (seconds) duration.seconds = seconds`, which is falsy for 0).

Updated the example to reflect the actual behavior:

```ts
//=> { years: 39, months: 2, days: 20, hours: 7, minutes: 5 }
```