### PR TITLE
docs(minutesToHours): fix mismatched value in JSDoc example

### DIFF
--- a/src/minutesToHours/index.ts
+++ b/src/minutesToHours/index.ts
@@ -13,7 +13,7 @@ import { minutesInHour } from "../constants/index.ts";
  * @returns The number of minutes converted in hours
  *
  * @example
- * // Convert 140 minutes to hours:
+ * // Convert 120 minutes to hours:
  * const result = minutesToHours(120)
  * //=> 2
  *


### PR DESCRIPTION
Fixes #3239.

The JSDoc `@example` for `minutesToHours` said "Convert **140** minutes to hours" but the code underneath called `minutesToHours(120)`. The result `//=> 2` is correct for 120 (120 / 60 = 2), so the comment was the bug — changing `140` → `120` lines them up.

Single-line diff, no runtime / type / test changes.

```diff
- * // Convert 140 minutes to hours:
+ * // Convert 120 minutes to hours:
  * const result = minutesToHours(120)
  * //=> 2
```