### PR TITLE
docs(readme): link 'Dozens of locales' to src/locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It's like [Lodash](https://lodash.com) for dates
 - **Native dates**: Uses existing native type. It doesn't extend core objects for safety's sake.
 - **Immutable & Pure**: Built using pure functions and always returns a new date instance.
 - **TypeScript**: The library is 100% TypeScript with brand-new handcrafted types.
-- **I18n**: Dozens of locales. Include only what you need.
+- **I18n**: [Dozens of locales](https://github.com/date-fns/date-fns/tree/main/src/locale). Include only what you need.
 - [and many more benefits](https://date-fns.org/)
 
 ```js


### PR DESCRIPTION
Fixes #2852.

The README bullet "**I18n**: Dozens of locales." didn't link anywhere. The issue (open since 2021) asked for a pointer to the list of supported locales; the maintainer suggested linking `src/locale` as the stopgap. This makes that link live.

```diff
- - **I18n**: Dozens of locales. Include only what you need.
+ - **I18n**: [Dozens of locales](https://github.com/date-fns/date-fns/tree/main/src/locale). Include only what you need.
```

Single-word diff, no runtime / type / test changes.