### PR TITLE
feat(format): add W token for week of month

### DIFF
--- a/src/_lib/format/formatters/index.ts
+++ b/src/_lib/format/formatters/index.ts
@@ -2,6 +2,7 @@ import { getDayOfYear } from "../../../getDayOfYear/index.ts";
 import { getISOWeek } from "../../../getISOWeek/index.ts";
 import { getISOWeekYear } from "../../../getISOWeekYear/index.ts";
 import { getWeek } from "../../../getWeek/index.ts";
+import { getWeekOfMonth } from "../../../getWeekOfMonth/index.ts";
 import { getWeekYear } from "../../../getWeekYear/index.ts";
 import type { LocaleDayPeriod, Localize } from "../../../locale/types.ts";
 import type {
@@ -61,7 +62,7 @@ type Formatter = (
  * |  t! | Seconds timestamp              |  T! | Milliseconds timestamp         |
  * |  u  | Extended year                  |  U* | Cyclic year                    |
  * |  v* | Timezone (generic non-locat.)  |  V* | Timezone (location)            |
- * |  w  | Local week of year             |  W* | Week of month                  |
+ * |  w  | Local week of year             |  W! | Week of month                  |
  * |  x  | Timezone (ISO-8601 w/o Z)      |  X  | Timezone (ISO-8601)            |
  * |  y  | Year (abs)                     |  Y  | Local week-numbering year      |
  * |  z  | Timezone (specific non-locat.) |  Z* | Timezone (aliases)             |
@@ -69,6 +70,7 @@ type Formatter = (
  * Letters marked by * are not implemented but reserved by Unicode standard.
  *
  * Letters marked by ! are non-standard, but implemented by date-fns:
+ * - `W` is week of the month.
  * - `o` modifies the previous token to turn it into an ordinal (see `format` docs)
  * - `i` is ISO day of week. For `i` and `ii` is returns numeric ISO week days,
  *   i.e. 7 for Sunday, 1 for Monday, etc.
@@ -294,6 +296,17 @@ export const formatters: { [token: string]: Formatter } = {
     const week = getWeek(date, options);
 
     if (token === "wo") {
+      return localize.ordinalNumber(week, { unit: "week" });
+    }
+
+    return addLeadingZeros(week, token.length);
+  },
+
+  // Week of month
+  W: function (date, token, localize, options) {
+    const week = getWeekOfMonth(date, options);
+
+    if (token === "Wo") {
       return localize.ordinalNumber(week, { unit: "week" });
     }
 

--- a/src/format/test.ts
+++ b/src/format/test.ts
@@ -334,6 +334,25 @@ describe("format", () => {
       const result = format(date, "I Io II");
       expect(result).toBe("14 14th 14");
     });
+
+    describe("week of month", () => {
+      it("works as expected", () => {
+        const result = format(new Date(2017, 10 /* Nov */, 9), "W Wo WW");
+        expect(result).toBe("2 2nd 02");
+      });
+
+      it("returns week 1 for the first day of the month", () => {
+        const result = format(new Date(2017, 10 /* Nov */, 1), "W");
+        expect(result).toBe("1");
+      });
+
+      it("allows to specify `weekStartsOn` in options", () => {
+        const result = format(new Date(2017, 10 /* Nov */, 30), "W", {
+          weekStartsOn: 4,
+        });
+        expect(result).toBe("6");
+      });
+    });
   });
 
   describe("day", () => {


### PR DESCRIPTION
## Summary

Adds support for formatting the week of the month using the `W` token in the `format` function.

## Tokens added

| Token | Output | Description |
|-------|--------|-------------|
| `W`   | 1, 2, 3, 4, 5 | Week of month |
| `Wo`  | 1st, 2nd, 3rd | Ordinal (via locale) |
| `WW`  | 01, 02, 03 | Zero-padded |

## Usage

```ts
format(new Date(2019, 3 /* Apr */, 6), "Wo 'week of' MMMM yyyy")
//=> "2nd week of April 2019"
```

## Changes

- `src/_lib/format/formatters/index.ts`: added `W` formatter using `getWeekOfMonth`, updated token table (`W*` → `W!`), added documentation note
- `src/format/test.ts`: added `describe("week of month")` with 3 test cases

Closes #1134

---

> Initial attempt by @wadehrarshpreet in #3216 (opened Oct 2022, never merged due to conflicts with main).