### PR TITLE
Add isWorkingDay helper

### DIFF
--- a/pkgs/core/package.json
+++ b/pkgs/core/package.json
@@ -173,6 +173,7 @@
     "./isWednesday": "./src/isWednesday/index.ts",
     "./isWeekend": "./src/isWeekend/index.ts",
     "./isWithinInterval": "./src/isWithinInterval/index.ts",
+    "./isWorkingDay": "./src/isWorkingDay/index.ts",
     "./isYesterday": "./src/isYesterday/index.ts",
     "./lastDayOfDecade": "./src/lastDayOfDecade/index.ts",
     "./lastDayOfISOWeek": "./src/lastDayOfISOWeek/index.ts",
@@ -504,6 +505,8 @@
     "./fp/isWeekendWithOptions": "./fp/src/isWeekendWithOptions/index.ts",
     "./fp/isWithinInterval": "./fp/src/isWithinInterval/index.ts",
     "./fp/isWithinIntervalWithOptions": "./fp/src/isWithinIntervalWithOptions/index.ts",
+    "./fp/isWorkingDay": "./fp/src/isWorkingDay/index.ts",
+    "./fp/isWorkingDayWithOptions": "./fp/src/isWorkingDayWithOptions/index.ts",
     "./fp/lastDayOfDecade": "./fp/src/lastDayOfDecade/index.ts",
     "./fp/lastDayOfDecadeWithOptions": "./fp/src/lastDayOfDecadeWithOptions/index.ts",
     "./fp/lastDayOfISOWeek": "./fp/src/lastDayOfISOWeek/index.ts",
@@ -2292,6 +2295,16 @@
         "import": {
           "types": "./isWithinInterval.d.ts",
           "default": "./isWithinInterval.js"
+        }
+      },
+      "./isWorkingDay": {
+        "require": {
+          "types": "./isWorkingDay.d.cts",
+          "default": "./isWorkingDay.cjs"
+        },
+        "import": {
+          "types": "./isWorkingDay.d.ts",
+          "default": "./isWorkingDay.js"
         }
       },
       "./isYesterday": {
@@ -5602,6 +5615,26 @@
         "import": {
           "types": "./fp/isWithinIntervalWithOptions.d.ts",
           "default": "./fp/isWithinIntervalWithOptions.js"
+        }
+      },
+      "./fp/isWorkingDay": {
+        "require": {
+          "types": "./fp/isWorkingDay.d.cts",
+          "default": "./fp/isWorkingDay.cjs"
+        },
+        "import": {
+          "types": "./fp/isWorkingDay.d.ts",
+          "default": "./fp/isWorkingDay.js"
+        }
+      },
+      "./fp/isWorkingDayWithOptions": {
+        "require": {
+          "types": "./fp/isWorkingDayWithOptions.d.cts",
+          "default": "./fp/isWorkingDayWithOptions.cjs"
+        },
+        "import": {
+          "types": "./fp/isWorkingDayWithOptions.d.ts",
+          "default": "./fp/isWorkingDayWithOptions.js"
         }
       },
       "./fp/lastDayOfDecade": {

--- a/pkgs/core/src/fp/index.ts
+++ b/pkgs/core/src/fp/index.ts
@@ -235,6 +235,8 @@ export * from "./isWeekend/index.ts";
 export * from "./isWeekendWithOptions/index.ts";
 export * from "./isWithinInterval/index.ts";
 export * from "./isWithinIntervalWithOptions/index.ts";
+export * from "./isWorkingDay/index.ts";
+export * from "./isWorkingDayWithOptions/index.ts";
 export * from "./lastDayOfDecade/index.ts";
 export * from "./lastDayOfDecadeWithOptions/index.ts";
 export * from "./lastDayOfISOWeek/index.ts";

--- a/pkgs/core/src/fp/isWorkingDay/index.ts
+++ b/pkgs/core/src/fp/isWorkingDay/index.ts
@@ -1,0 +1,6 @@
+// This file is generated automatically by `scripts/build/fp.ts`. Please, don't change it.
+
+import { isWorkingDay as fn } from "../../isWorkingDay/index.ts";
+import { convertToFP } from "../_lib/convertToFP/index.ts";
+
+export const isWorkingDay = convertToFP(fn, 1);

--- a/pkgs/core/src/fp/isWorkingDayWithOptions/index.ts
+++ b/pkgs/core/src/fp/isWorkingDayWithOptions/index.ts
@@ -1,0 +1,6 @@
+// This file is generated automatically by `scripts/build/fp.ts`. Please, don't change it.
+
+import { isWorkingDay as fn } from "../../isWorkingDay/index.ts";
+import { convertToFP } from "../_lib/convertToFP/index.ts";
+
+export const isWorkingDayWithOptions = convertToFP(fn, 2);

--- a/pkgs/core/src/index.ts
+++ b/pkgs/core/src/index.ts
@@ -149,6 +149,7 @@ export * from "./isValid/index.ts";
 export * from "./isWednesday/index.ts";
 export * from "./isWeekend/index.ts";
 export * from "./isWithinInterval/index.ts";
+export * from "./isWorkingDay/index.ts";
 export * from "./isYesterday/index.ts";
 export * from "./lastDayOfDecade/index.ts";
 export * from "./lastDayOfISOWeek/index.ts";

--- a/pkgs/core/src/isWorkingDay/index.ts
+++ b/pkgs/core/src/isWorkingDay/index.ts
@@ -1,0 +1,71 @@
+import { isSameDay } from "../isSameDay/index.ts";
+import { toDate } from "../toDate/index.ts";
+import type { ContextOptions, DateArg, Day } from "../types.ts";
+
+/**
+ * The {@link isWorkingDay} function options.
+ */
+export interface IsWorkingDayOptions extends ContextOptions<Date> {
+  /** The days of the week considered weekends. Defaults to `[0, 6]` (Sunday and Saturday). */
+  weekendDays?: Day[];
+  /** The dates considered non-working days, such as holidays or company shutdowns. Matched by year, month, and day; time is ignored. */
+  nonWorkingDays?: DateArg<Date>[];
+}
+
+/**
+ * @name isWorkingDay
+ * @category Weekday Helpers
+ * @summary Is the given date a working day?
+ *
+ * @description
+ * Is the given date a working day? A working day is a day that is neither
+ * a weekend day nor listed as a non-working day. By default, Saturday (`6`)
+ * and Sunday (`0`) are considered weekend days, but you can pass any
+ * combination via `weekendDays`. Non-working days are matched by year, month,
+ * and day; times are ignored. Recurring holidays must be supplied for each
+ * year. When the `in` option is provided, the date and non-working days are
+ * compared as calendar days in that context.
+ *
+ * @param date - The date to check
+ * @param options - An object with options
+ *
+ * @returns The date is a working day
+ *
+ * @example
+ * // Is 25 December 2014 a working day if it is listed as a non-working day?
+ * const result = isWorkingDay(new Date(2014, 11, 25), {
+ *   nonWorkingDays: [new Date(2014, 11, 25)]
+ * })
+ * //=> false
+ *
+ * @example
+ * // Is Sunday 21 September 2014 a working day if the weekend is
+ * // Friday-Saturday but that Sunday is listed as a non-working day?
+ * const result = isWorkingDay(new Date(2014, 8, 21), {
+ *   weekendDays: [5, 6],
+ *   nonWorkingDays: [new Date(2014, 8, 21)]
+ * })
+ * //=> false
+ *
+ * @example
+ * // Is Sunday a working day if the weekend is Friday and Saturday?
+ * const result = isWorkingDay(new Date(2014, 8, 21), {
+ *   weekendDays: [5, 6]
+ * })
+ * //=> true
+ */
+export function isWorkingDay(
+  date: DateArg<Date> & {},
+  options?: IsWorkingDayOptions | undefined,
+): boolean {
+  const _date = toDate(date, options?.in);
+  if (isNaN(+_date)) return false;
+
+  const day = _date.getDay() as Day;
+  const weekendDays = options?.weekendDays ?? [0, 6];
+  if (weekendDays.includes(day)) return false;
+
+  return !options?.nonWorkingDays?.some((nonWorkingDay) =>
+    isSameDay(_date, nonWorkingDay, options),
+  );
+}

--- a/pkgs/core/src/isWorkingDay/test.ts
+++ b/pkgs/core/src/isWorkingDay/test.ts
@@ -1,0 +1,158 @@
+import { tz } from "@date-fns/tz";
+import { describe, expect, it } from "vitest";
+import type { ContextOptions, DateArg } from "../types.ts";
+import { isWorkingDay } from "./index.ts";
+
+describe("isWorkingDay", () => {
+  it("returns true if the given date is a working day", () => {
+    const result = isWorkingDay(new Date(2014, 8 /* Sep */, 22));
+    expect(result).toBe(true);
+  });
+
+  it("returns false if the given date is a default weekend day", () => {
+    expect(isWorkingDay(new Date(2014, 8 /* Sep */, 20))).toBe(false);
+    expect(isWorkingDay(new Date(2014, 8 /* Sep */, 21))).toBe(false);
+  });
+
+  it("allows to specify custom weekend days", () => {
+    expect(
+      isWorkingDay(new Date(2014, 8 /* Sep */, 19), {
+        weekendDays: [5, 6],
+      }),
+    ).toBe(false);
+    expect(
+      isWorkingDay(new Date(2014, 8 /* Sep */, 21), {
+        weekendDays: [5, 6],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false if the given date is a non-working day", () => {
+    const result = isWorkingDay(new Date(2014, 11 /* Dec */, 25), {
+      nonWorkingDays: [new Date(2014, 11 /* Dec */, 25)],
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("matches non-working days by calendar day", () => {
+    const result = isWorkingDay(new Date(2014, 11 /* Dec */, 25, 18, 30), {
+      nonWorkingDays: [new Date(2014, 11 /* Dec */, 25, 9, 0)],
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("does not match non-working days across different years", () => {
+    const result = isWorkingDay(new Date(2015, 11 /* Dec */, 25), {
+      nonWorkingDays: [new Date(2014, 11 /* Dec */, 25)],
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("accepts timestamps in non-working days", () => {
+    const result = isWorkingDay(new Date(2014, 11 /* Dec */, 25), {
+      nonWorkingDays: [new Date(2014, 11, 25).getTime()],
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false when a non-working day also falls on a weekend", () => {
+    const result = isWorkingDay(new Date(2014, 11 /* Dec */, 27) /* Sat */, {
+      nonWorkingDays: [new Date(2014, 11 /* Dec */, 27)],
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("returns true for every day when weekendDays is empty", () => {
+    expect(
+      isWorkingDay(new Date(2014, 8 /* Sep */, 20) /* Sat */, {
+        weekendDays: [],
+      }),
+    ).toBe(true);
+    expect(
+      isWorkingDay(new Date(2014, 8 /* Sep */, 21) /* Sun */, {
+        weekendDays: [],
+      }),
+    ).toBe(true);
+  });
+
+  it("combines custom weekendDays with nonWorkingDays", () => {
+    const sunday = new Date(2014, 8 /* Sep */, 21);
+    // Sunday is a working day under a Friday-Saturday weekend
+    expect(isWorkingDay(sunday, { weekendDays: [5, 6] })).toBe(true);
+    // ...unless it is also listed as a non-working day
+    expect(
+      isWorkingDay(sunday, {
+        weekendDays: [5, 6],
+        nonWorkingDays: [sunday],
+      }),
+    ).toBe(false);
+    // Non-working days do not bleed into other days in the same week
+    expect(
+      isWorkingDay(sunday, {
+        weekendDays: [5, 6],
+        nonWorkingDays: [new Date(2014, 8 /* Sep */, 19) /* Fri */],
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts a timestamp", () => {
+    const result = isWorkingDay(new Date(2014, 8 /* Sep */, 22).getTime());
+    expect(result).toBe(true);
+  });
+
+  it("returns false if the given date is `Invalid Date`", () => {
+    const result = isWorkingDay(new Date(NaN));
+    expect(result).toBe(false);
+  });
+
+  it("ignores invalid non-working days", () => {
+    const result = isWorkingDay(new Date(2014, 8 /* Sep */, 22), {
+      nonWorkingDays: [new Date(NaN)],
+    });
+    expect(result).toBe(true);
+  });
+
+  describe("context", () => {
+    it("allows to specify the context", () => {
+      expect(
+        isWorkingDay("2024-08-18T17:00:00Z", {
+          in: tz("Asia/Singapore"),
+        }),
+      ).toBe(true);
+      expect(
+        isWorkingDay("2024-08-17T04:00:00Z", {
+          in: tz("America/New_York"),
+        }),
+      ).toBe(false);
+    });
+
+    it("matches non-working days in the specified context", () => {
+      expect(
+        isWorkingDay("2024-08-18T17:00:00Z", {
+          in: tz("Asia/Singapore"),
+          nonWorkingDays: ["2024-08-19T00:00:00+08:00"],
+        }),
+      ).toBe(false);
+      expect(
+        isWorkingDay("2024-08-17T03:00:00Z", {
+          in: tz("America/New_York"),
+          nonWorkingDays: ["2024-08-16T00:00:00-04:00"],
+        }),
+      ).toBe(false);
+    });
+
+    it("doesn't enforce argument and context to be of the same type", () => {
+      function _test<DateType extends Date, ResultDate extends Date = DateType>(
+        arg: DateArg<DateType>,
+        options?: ContextOptions<ResultDate>,
+      ) {
+        isWorkingDay(arg, { in: options?.in });
+      }
+    });
+  });
+});

--- a/pkgs/core/typedoc.json
+++ b/pkgs/core/typedoc.json
@@ -151,6 +151,7 @@
     "./src/isWednesday/index.ts",
     "./src/isWeekend/index.ts",
     "./src/isWithinInterval/index.ts",
+    "./src/isWorkingDay/index.ts",
     "./src/isYesterday/index.ts",
     "./src/lastDayOfDecade/index.ts",
     "./src/lastDayOfISOWeek/index.ts",


### PR DESCRIPTION
## Summary

Adds `isWorkingDay(date, { weekendDays, nonWorkingDays })`, a configurable predicate for checking whether a date is a working day in a caller defined calendar.

## Why

`isWeekend` only models Saturday/Sunday weekends and has no concept of holidays or other caller-defined non-working dates.

In scheduling, payroll, SLA, and calendar workflows, a working day often depends on both:

- custom weekend days, such as Friday/Saturday weekends
- caller-owned calendars, such as public holidays, company shutdowns, or other non-working dates

This helper composes those concerns without bundling any holiday data.

## Why no bundled holiday data

Holidays are jurisdiction-specific, year-specific, and often employer-specific. This PR keeps date-fns responsible for the predicate only; callers provide their own calendar through `nonWorkingDays`.