### PR TITLE
fix: first day of week in pt is 0

### DIFF
--- a/pkgs/core/src/locale/pt/index.ts
+++ b/pkgs/core/src/locale/pt/index.ts
@@ -21,7 +21,7 @@ export const pt: Locale = {
   localize: localize,
   match: match,
   options: {
-    weekStartsOn: 1 /* Monday */,
+    weekStartsOn: 0 /* Sunday */,
     firstWeekContainsDate: 4,
   },
 };


### PR DESCRIPTION
I am Portuguese and I can say with certainty that the first day of the week in Portugal is most often Sunday. A quick google search also confirms this. This PR fixes that information