### PR TITLE
fix(locale): repair parse/format mismatches in az locale

### DIFF
--- a/pkgs/core/src/locale/az/_lib/formatDistance/index.ts
+++ b/pkgs/core/src/locale/az/_lib/formatDistance/index.ts
@@ -10,7 +10,7 @@ type FormatDistanceTokenValue =
 const formatDistanceLocale: FormatDistanceLocale<FormatDistanceTokenValue> = {
   lessThanXSeconds: {
     one: "bir saniyədən az",
-    other: "{{count}} bir saniyədən az",
+    other: "{{count}} saniyədən az",
   },
 
   xSeconds: {
@@ -22,7 +22,7 @@ const formatDistanceLocale: FormatDistanceLocale<FormatDistanceTokenValue> = {
 
   lessThanXMinutes: {
     one: "bir dəqiqədən az",
-    other: "{{count}} bir dəqiqədən az",
+    other: "{{count}} dəqiqədən az",
   },
 
   xMinutes: {

--- a/pkgs/core/src/locale/az/_lib/formatRelative/index.ts
+++ b/pkgs/core/src/locale/az/_lib/formatRelative/index.ts
@@ -3,7 +3,7 @@ import type { FormatRelativeFn } from "../../../types.ts";
 const formatRelativeLocale = {
   lastWeek: "'sonuncu' eeee p -'də'",
   yesterday: "'dünən' p -'də'",
-  today: "'bugün' p -'də'",
+  today: "'bu gün' p -'də'",
   tomorrow: "'sabah' p -'də'",
   nextWeek: "eeee p -'də'",
   other: "P",

--- a/pkgs/core/src/locale/az/_lib/match/index.ts
+++ b/pkgs/core/src/locale/az/_lib/match/index.ts
@@ -7,12 +7,12 @@ const matchOrdinalNumberPattern = /^(\d+)(-?(ci|inci|nci|uncu|üncü|ncı))?/i;
 const parseOrdinalNumberPattern = /\d+/i;
 
 const matchEraPatterns = {
-  narrow: /^(b|a)$/i,
-  abbreviated: /^(b\.?\s?c\.?|b\.?\s?c\.?\s?e\.?|a\.?\s?d\.?|c\.?\s?e\.?)$/i,
-  wide: /^(bizim eradan əvvəl|bizim era)$/i,
+  narrow: /^(e\.ə\.?|b\.e\.?)$/i,
+  abbreviated: /^(e\.ə\.?|b\.e\.?)$/i,
+  wide: /^(eramızdan əvvəl|bizim era)$/i,
 };
 const parseEraPatterns = {
-  any: [/^b$/i, /^(a|c)$/i] as const,
+  any: [/^e/i, /^b/i] as const,
 };
 
 const matchQuarterPatterns = {
@@ -27,7 +27,7 @@ const parseQuarterPatterns = {
 const matchMonthPatterns = {
   narrow: /^[(?-i)yfmaisond]$/i,
   abbreviated: /^(Yan|Fev|Mar|Apr|May|İyun|İyul|Avq|Sen|Okt|Noy|Dek)$/i,
-  wide: /^(Yanvar|Fevral|Mart|Aprel|May|İyun|İyul|Avgust|Sentyabr|Oktyabr|Noyabr|Dekabr)$/i,
+  wide: /^(Yanvar|Fevral|Mart|Aprel|May|İyun|İyul|Avqust|Sentyabr|Oktyabr|Noyabr|Dekabr)$/i,
 };
 const parseMonthPatterns = {
   narrow: [
@@ -52,7 +52,7 @@ const parseMonthPatterns = {
     /^May$/i,
     /^İyun$/i,
     /^İyul$/i,
-    /^Avg$/i,
+    /^Avq$/i,
     /^Sen$/i,
     /^Okt$/i,
     /^Noy$/i,
@@ -66,7 +66,7 @@ const parseMonthPatterns = {
     /^May$/i,
     /^İyun$/i,
     /^İyul$/i,
-    /^Avgust$/i,
+    /^Avqust$/i,
     /^Sentyabr$/i,
     /^Oktyabr$/i,
     /^Noyabr$/i,


### PR DESCRIPTION
Several Azerbaijani locale strings produce `Invalid Date` when round-tripped through `format() → parse()`. The committed [`snapshot.md`](https://github.com/date-fns/date-fns/blob/main/pkgs/core/src/locale/az/snapshot.md) captures these failures verbatim — for example:

```
| MMM  | 2019-08-10 | Avq    | Invalid Date |
| MMMM | 2019-08-10 | Avqust | Invalid Date |
```

Root causes addressed in this PR:

1. **August month names** (`_lib/match/index.ts`). `localize` emits `Avq` / `Avqust` (correct Azerbaijani transliteration), but `match` patterns expected the English-style `Avg` / `Avgust`. So the formatter's own output never parsed back. Fixed in three places: `matchMonthPatterns.wide`, and the August entries of `parseMonthPatterns.abbreviated` and `parseMonthPatterns.wide`.

2. **Era patterns** (`_lib/match/index.ts`). `matchEraPatterns` and `parseEraPatterns` were matching English `BC` / `AD` / `CE` rather than what `localize` emits in `eraValues` — `e.ə` / `b.e` for narrow & abbreviated, and `eramızdan əvvəl` / `bizim era` for wide. Era parsing was effectively broken in every width. Aligned the patterns to the localize values.

3. **`formatDistance` plurals** (`_lib/formatDistance/index.ts`). `lessThanXSeconds.other` and `lessThanXMinutes.other` carried a stray `bir` ("one") in the plural form, producing output like `"5 bir saniyədən az"` ("5 one less than a second") instead of `"5 saniyədən az"` ("less than 5 seconds"). The singular `one` form is unchanged.

4. **`formatRelative` "today"** (`_lib/formatRelative/index.ts`). The literal was written as `bugün` (one word). Standard Azerbaijani spelling is `bu gün` (two words).

The PR is intentionally scoped to correctness fixes that the committed `snapshot.md` (or basic AZ orthography) shows are broken. Other items I noticed but did not touch here — e.g. the `dateTime` format using `- 'də'` with a stray space-dash-space before the locative suffix, or quarter labels like `1ci kvartal` lacking the standard `-` separator (`1-ci kvartal`) — are stylistic/idiomatic and can be a separate PR if the maintainers prefer.

`snapshot.md` itself will need to be regenerated to reflect the new `parse` results; happy to add that commit if you can point me at the script — I didn't find it referenced in `CONTRIBUTING.md`.
