### PR TITLE
build(cdn): dont generate sourcemaps for cdn files

### DIFF
--- a/pkgs/core/scripts/build/cdn.ts
+++ b/pkgs/core/scripts/build/cdn.ts
@@ -43,7 +43,7 @@ Promise.all([
     const buildOptions = {
       entrypoints: paths,
       outdir: ".",
-      sourcemap: "external" as const,
+      sourcemap: "none" as const,
       root: ".",
     };
 
@@ -55,7 +55,7 @@ Promise.all([
       paths.map((path) => async () => {
         // Use Babel to transpile
         assertShellOutput(
-          await $`env BABEL_ENV=cdn pnpm babel ${path} --out-file ${path} --source-maps`,
+          await $`env BABEL_ENV=cdn pnpm babel ${path} --out-file ${path}`,
         );
 
         // Wrap into IIFE, to avoid polluting global scope


### PR DESCRIPTION
Related to https://github.com/date-fns/date-fns/issues/4120#issuecomment-3629093718, and opened after we interacted on twitter earlier today. I do reccomend this as a first pass on reducing the install size without needing to cut a major to drop CDN only files. By dropping sourcemaps for the CDN files, unpacked size can be reduced by 50%

Right now 100% of the sourcemaps in this package are for the CDN files, and I'd argue that very few folks are relying on them in their development/debugging. Even if they are, this isn't part of the semver contract IMO, so dropping these is the most conservative way to reduce package size (if that is your goal).

Happy to talk in the future about exploring options for your packaging goals! I happen to like this stuff ❤️ 

Stats for the latest version:
```json
{
  "version": "4.3.0",
  "packed_tarball": "2.91 MB",
  "unpacked_total": "20.29 MB",
  "sourcemap_count": 196,
  "sourcemap_bytes_unpacked": "10.45 MB",
  "file_count": 5330
}
```

After this PR:
```json
{
  "version": "4.3.0",
  "packed_tarball": "1.44 MB",
  "unpacked_total": "9.83 MB",
  "sourcemap_count": 0,
  "sourcemap_bytes_unpacked": "0.00 MB",
  "file_count": 5134
}
```

<details>
<summary>stats repro script..</summary>

```sh
# writing a report helper script to /tmp with heredoc
cat > /tmp/report.js <<'EOF'
const p = JSON.parse(require("fs").readFileSync(0))[0];
const maps = p.files.filter(f => f.path.endsWith(".map"));
const MB = n => (n/1048576).toFixed(2)+" MB";
console.log(JSON.stringify({
  version: p.version, packed_tarball: MB(p.size), unpacked_total: MB(p.unpackedSize),
  sourcemap_count: maps.length, sourcemap_bytes_unpacked: MB(maps.reduce((s,f)=>s+f.size,0)),
  file_count: p.entryCount,
}, null, 2));
EOF

# current published, pull down the tarball stats as json and pipe to helper
npm pack date-fns@4.3.0 --dry-run --json | node /tmp/report.js

# local patched build
# cd to repo root, run full build
cd $(git rev-parse --show-toplevel) && ./pkgs/core/scripts/build/package.sh
npm pack ./pkgs/core/dist --dry-run --json | node /tmp/report.js
```
</details>
