### PR TITLE
fix(formatRFC3339): pad years below 1000 to four digits

### DIFF
--- a/pkgs/core/src/formatRFC3339/index.ts
+++ b/pkgs/core/src/formatRFC3339/index.ts
@@ -52,7 +52,7 @@ export function formatRFC3339(
 
   const day = addLeadingZeros(date_.getDate(), 2);
   const month = addLeadingZeros(date_.getMonth() + 1, 2);
-  const year = date_.getFullYear();
+  const year = addLeadingZeros(date_.getFullYear(), 4);
 
   const hour = addLeadingZeros(date_.getHours(), 2);
   const minute = addLeadingZeros(date_.getMinutes(), 2);

--- a/pkgs/core/src/formatRFC3339/test.ts
+++ b/pkgs/core/src/formatRFC3339/test.ts
@@ -21,6 +21,13 @@ describe("formatRFC3339", () => {
     getTimezoneOffsetStub.mockRestore();
   });
 
+  it("pads years before 1000 to four digits", () => {
+    const date = new Date(999, 0 /* Jan */, 1, 0, 0, 0);
+    expect(formatRFC3339(date)).toBe(
+      `0999-01-01T00:00:00${generateOffset(date)}`,
+    );
+  });
+
   it("accepts a timestamp", () => {
     const date = new Date(2019, 9 /* Oct */, 4, 12, 30, 13, 456);
     const time = date.getTime();


### PR DESCRIPTION
Fixes #4004

## Problem
`formatRFC3339` emits fewer than four year digits for years below 1000 (year `999` formats as `999-...`), which violates RFC 3339 (`date-fullyear = 4DIGIT`). Every other field is zero-padded; the year was the one exception.

## Fix
Pad the year with the existing `addLeadingZeros` helper, matching the rest of the function:
`const year = addLeadingZeros(date_.getFullYear(), 4)`. Year `999` now formats as `0999-...`.

Edited `pkgs/core/src/formatRFC3339/index.ts` (the v4 source), not built output.

## Tests
Added a regression test ("pads years before 1000 to four digits") using the existing offset/vitest pattern in the same test file.
