### PR TITLE
Fix transpose invalid date handling

### DIFF
--- a/pkgs/core/src/transpose/index.ts
+++ b/pkgs/core/src/transpose/index.ts
@@ -39,6 +39,9 @@ export function transpose<InputDate extends Date, ResultDate extends Date>(
   const date_ = isConstructor(constructor)
     ? new constructor(0)
     : constructFrom(constructor, 0);
+
+  if (isNaN(+date)) return constructFrom(date_, NaN);
+
   date_.setFullYear(date.getFullYear(), date.getMonth(), date.getDate());
   date_.setHours(
     date.getHours(),

--- a/pkgs/core/src/transpose/test.ts
+++ b/pkgs/core/src/transpose/test.ts
@@ -15,4 +15,10 @@ describe("transpose", () => {
     expect(result.getSeconds()).toBe(56);
     expect(result.getMilliseconds()).toBe(789);
   });
+
+  it("preserves invalid dates", () => {
+    const result = transpose(new Date(NaN), Date);
+    expect(result instanceof Date).toBe(true);
+    expect(isNaN(+result)).toBe(true);
+  });
 });


### PR DESCRIPTION
Fixes #4161.

## Problem
`transpose()` currently starts from a valid target date and then copies calendar fields from the input. When the input date is invalid, those copied fields are `NaN`, which can behave inconsistently across custom date constructors.

## Approach
Detect invalid input dates up front and return an invalid result date constructed with the requested target context/constructor. This preserves the target date type while making invalid-date handling explicit.

A regression test covers the invalid input case.

## Tradeoffs
Valid dates continue through the existing field-copying path unchanged.