### PR TITLE
docs: fix set example description

### DIFF
--- a/pkgs/core/src/set/index.ts
+++ b/pkgs/core/src/set/index.ts
@@ -40,7 +40,7 @@ export interface SetOptions<
  * //=> Tue Oct 20 2015 00:00:00
  *
  * @example
- * // Set 12 PM to 1 September 2014 01:23:45 to 1 September 2014 12:00:00:
+ * // Set 12 PM to 1 September 2014 01:23:45 to 1 September 2014 12:23:45:
  * const result = set(new Date(2014, 8, 1, 1, 23, 45), { hours: 12 })
  * //=> Mon Sep 01 2014 12:23:45
  */


### PR DESCRIPTION
Fixes #4129.

## Problem
The `set()` documentation example says setting `hours: 12` changes `2014-09-01 01:23:45` to `12:00:00`, but the example output correctly preserves the existing minutes and seconds as `12:23:45`.

## Approach
Update the example sentence so it matches the demonstrated output.

## Tradeoffs
Documentation-only change; no runtime behavior changes.