### PR TITLE
Fix transpose invalid date handling

### DIFF
--- a/pkgs/core/src/transpose/index.ts
+++ b/pkgs/core/src/transpose/index.ts
@@ -39,6 +39,9 @@ export function transpose<InputDate extends Date, ResultDate extends Date>(
   const date_ = isConstructor(constructor)
     ? new constructor(0)
     : constructFrom(constructor, 0);
+
+  if (isNaN(+date)) return constructFrom(date_, NaN);
+
   date_.setFullYear(date.getFullYear(), date.getMonth(), date.getDate());
   date_.setHours(
     date.getHours(),

--- a/pkgs/core/src/transpose/test.ts
+++ b/pkgs/core/src/transpose/test.ts
@@ -15,4 +15,10 @@ describe("transpose", () => {
     expect(result.getSeconds()).toBe(56);
     expect(result.getMilliseconds()).toBe(789);
   });
+
+  it("preserves invalid dates", () => {
+    const result = transpose(new Date(NaN), Date);
+    expect(result instanceof Date).toBe(true);
+    expect(isNaN(+result)).toBe(true);
+  });
 });


### PR DESCRIPTION
Recreated from the previously prepared PR, now using the correct GitHub identity (Subharup-31) and fork.

This applies the same transpose invalid date handling fix as the earlier PR from the wrong account.