### PR TITLE
fix(parse): reject Z for lowercase timezone tokens

### DIFF
--- a/pkgs/core/src/parse/_lib/constants.ts
+++ b/pkgs/core/src/parse/_lib/constants.ts
@@ -23,9 +23,17 @@ export const numericPatterns = {
 };
 
 export const timezonePatterns = {
-  basicOptionalMinutes: /^([+-])(\d{2})(\d{2})?|Z/,
-  basic: /^([+-])(\d{2})(\d{2})|Z/,
-  basicOptionalSeconds: /^([+-])(\d{2})(\d{2})((\d{2}))?|Z/,
-  extended: /^([+-])(\d{2}):(\d{2})|Z/,
-  extendedOptionalSeconds: /^([+-])(\d{2}):(\d{2})(:(\d{2}))?|Z/,
+  basicOptionalMinutes: /^([+-])(\d{2})(\d{2})?/,
+  basic: /^([+-])(\d{2})(\d{2})/,
+  basicOptionalSeconds: /^([+-])(\d{2})(\d{2})((\d{2}))?/,
+  extended: /^([+-])(\d{2}):(\d{2})/,
+  extendedOptionalSeconds: /^([+-])(\d{2}):(\d{2})(:(\d{2}))?/,
+};
+
+export const timezonePatternsWithZ = {
+  basicOptionalMinutes: /^(?:([+-])(\d{2})(\d{2})?|Z)/,
+  basic: /^(?:([+-])(\d{2})(\d{2})|Z)/,
+  basicOptionalSeconds: /^(?:([+-])(\d{2})(\d{2})((\d{2}))?|Z)/,
+  extended: /^(?:([+-])(\d{2}):(\d{2})|Z)/,
+  extendedOptionalSeconds: /^(?:([+-])(\d{2}):(\d{2})(:(\d{2}))?|Z)/,
 };

--- a/pkgs/core/src/parse/_lib/parsers/ISOTimezoneWithZParser.ts
+++ b/pkgs/core/src/parse/_lib/parsers/ISOTimezoneWithZParser.ts
@@ -1,6 +1,6 @@
 import { constructFrom } from "../../../constructFrom/index.ts";
 import { getTimezoneOffsetInMilliseconds } from "../../../_lib/getTimezoneOffsetInMilliseconds/index.ts";
-import { timezonePatterns } from "../constants.ts";
+import { timezonePatternsWithZ } from "../constants.ts";
 import { Parser } from "../Parser.ts";
 import type { ParseFlags, ParseResult } from "../types.ts";
 import { parseTimezonePattern } from "../utils.ts";
@@ -13,24 +13,24 @@ export class ISOTimezoneWithZParser extends Parser<number> {
     switch (token) {
       case "X":
         return parseTimezonePattern(
-          timezonePatterns.basicOptionalMinutes,
+          timezonePatternsWithZ.basicOptionalMinutes,
           dateString,
         );
       case "XX":
-        return parseTimezonePattern(timezonePatterns.basic, dateString);
+        return parseTimezonePattern(timezonePatternsWithZ.basic, dateString);
       case "XXXX":
         return parseTimezonePattern(
-          timezonePatterns.basicOptionalSeconds,
+          timezonePatternsWithZ.basicOptionalSeconds,
           dateString,
         );
       case "XXXXX":
         return parseTimezonePattern(
-          timezonePatterns.extendedOptionalSeconds,
+          timezonePatternsWithZ.extendedOptionalSeconds,
           dateString,
         );
       case "XXX":
       default:
-        return parseTimezonePattern(timezonePatterns.extended, dateString);
+        return parseTimezonePattern(timezonePatternsWithZ.extended, dateString);
     }
   }
 

--- a/pkgs/core/src/parse/test.ts
+++ b/pkgs/core/src/parse/test.ts
@@ -1735,6 +1735,15 @@ describe("parse", () => {
         expect(result).toEqual(new Date("2016-11-25T16:38:38.123Z"));
       });
 
+      it("rejects Z designator", () => {
+        const result = parse(
+          "2016-11-25T16:38:38.123Z",
+          "yyyy-MM-dd'T'HH:mm:ss.SSSx",
+          referenceDate,
+        );
+        expect(result).toEqual(new Date(NaN));
+      });
+
       it("hours", () => {
         const result = parse(
           "2016-11-25T16:38:38.123+05",


### PR DESCRIPTION
Fixes #4114.

### Summary
- split timezone parser regexes so lowercase `x` tokens only accept numeric ISO-8601 offsets
- keep uppercase `X` tokens accepting the `Z` UTC designator
- add a regression test for parsing `Z` with lowercase `x`

### Tests
- `pnpm test src/parse/test.ts -t 'rejects Z designator'` (failed before implementation, passed after)\n- `pnpm test src/parse/test.ts -t 'timezone \\(ISO-8601'`\n- `pnpm test src/parse/test.ts`\n- `pnpm exec oxfmt --check src/parse/_lib/constants.ts src/parse/_lib/parsers/ISOTimezoneWithZParser.ts src/parse/test.ts`\n- `pnpm exec oxlint --type-aware src/parse/_lib/constants.ts src/parse/_lib/parsers/ISOTimezoneWithZParser.ts src/parse/test.ts`\n- `pnpm exec tsgo --build --pretty`\n- `pnpm lint`\n- `git diff --check`\n\nNote: `pnpm run types` currently invokes `tsc`, but this checkout only provides `tsgo`; the equivalent `tsgo --build --pretty` passed.\n\nAI-assisted: yes