### PR TITLE
locale(cs): fix v/ve preposition selection in formatRelative

### DIFF
--- a/pkgs/core/src/locale/cs/_lib/formatRelative/index.ts
+++ b/pkgs/core/src/locale/cs/_lib/formatRelative/index.ts
@@ -11,14 +11,26 @@ const accusativeWeekdays = [
   "sobotu",
 ];
 
+function getTimePreposition(date: Date): string {
+  const hour = date.getHours();
+  const VE_HOURS = new Set([2, 3, 4, 12, 13, 14, 20, 21, 22, 23]);
+  return VE_HOURS.has(hour) ? "ve" : "v";
+}
+
+function getDayPreposition(date: Date): string {
+  const day = date.getDay() as Day;
+  const VE_DAYS = new Set([3, 4]);
+  return VE_DAYS.has(day) ? "ve" : "v";
+}
+
 const formatRelativeLocale = {
-  lastWeek: "'poslední' eeee 've' p",
-  yesterday: "'včera v' p",
-  today: "'dnes v' p",
-  tomorrow: "'zítra v' p",
+  lastWeek: (date: Date) => `'poslední' eeee '${getTimePreposition(date)}' p`,
+  yesterday: (date: Date) => `'včera ${getTimePreposition(date)}' p`,
+  today: (date: Date) => `'dnes ${getTimePreposition(date)}' p`,
+  tomorrow: (date: Date) => `'zítra ${getTimePreposition(date)}' p`,
   nextWeek: (date: Date) => {
     const day = date.getDay() as Day;
-    return "'v " + accusativeWeekdays[day] + " o' p";
+    return `'${getDayPreposition(date)} ${accusativeWeekdays[day]} ${getTimePreposition(date)}' p`;
   },
   other: "P",
 };


### PR DESCRIPTION
This pull request updates the Czech locale formatting in `formatRelative` to use the correct Czech prepositions "v" and "ve" based on the specific hour and day, improving the grammatical accuracy of generated date strings.

Locale formatting improvements:

* Added `getTimePreposition` and `getDayPreposition` helper functions to determine whether to use "v" or "ve" for time and weekday prepositions based on the hour and day. (`pkgs/core/src/locale/cs/_lib/formatRelative/index.ts`)
* Updated the `formatRelativeLocale` object to use these new helper functions, ensuring that all relative date strings use the correct Czech prepositions dynamically. (`pkgs/core/src/locale/cs/_lib/formatRelative/index.ts`)