### PR TITLE
Add bugs metadata to package.json

### DIFF
--- a/pkgs/core/package.json
+++ b/pkgs/core/package.json
@@ -8204,5 +8204,8 @@
     "typedoc": "^0.28.19",
     "typedoc-plugin-missing-exports": "^4.1.3",
     "vitest": "^4.1.6"
+  },
+  "bugs": {
+    "url": "https://github.com/date-fns/date-fns/issues"
   }
 }


### PR DESCRIPTION
﻿Adds bugs.url metadata to the core package.json so npm consumers and tooling can find the issue tracker.

- Added: "bugs": { "url": "https://github.com/date-fns/date-fns/issues" }

Related: charles-openclaw/charles-microbounties#384
