### PR TITLE
docs: fix minutesToHours example comment (140 → 120 minutes)

### DIFF
--- a/pkgs/core/src/minutesToHours/index.ts
+++ b/pkgs/core/src/minutesToHours/index.ts
@@ -13,7 +13,7 @@ import { minutesInHour } from "../constants/index.ts";
  * @returns The number of minutes converted in hours
  *
  * @example
- * // Convert 140 minutes to hours:
+ * // Convert 120 minutes to hours:
  * const result = minutesToHours(120)
  * //=> 2
  *


### PR DESCRIPTION
The JSDoc `@example` for `minutesToHours` describes converting **140** minutes, but the call passes `120`:

```ts
 * @example
 * // Convert 140 minutes to hours:
 * const result = minutesToHours(120)
 * //=> 2
```

`120` minutes is what yields the documented `//=> 2` result (140 minutes would be `2.33…` → floored to `2`, which still works, but the prose number does not match the argument). Every sibling unit-conversion helper keeps the example comment in sync with its argument — e.g. `hoursToMinutes`:

```ts
 * @example
 * // Convert 2 hours to minutes:
 * const result = hoursToMinutes(2)
 * //=> 120
```

This updates the comment to `120` so the example is self-consistent. Docs/comment only — no behavior change.