### PR TITLE
[zh-TW] Update quarters and ordinalNumber

### DIFF
--- a/pkgs/core/src/locale/zh-TW/_lib/localize/index.ts
+++ b/pkgs/core/src/locale/zh-TW/_lib/localize/index.ts
@@ -9,8 +9,8 @@ const eraValues = {
 
 const quarterValues = {
   narrow: ["1", "2", "3", "4"] as const,
-  abbreviated: ["第一刻", "第二刻", "第三刻", "第四刻"] as const,
-  wide: ["第一刻鐘", "第二刻鐘", "第三刻鐘", "第四刻鐘"] as const,
+  abbreviated: ["第一季", "第二季", "第三季", "第四季"] as const,
+  wide: ["第一季度", "第二季度", "第三季度", "第四季度"] as const,
 };
 
 const monthValues = {
@@ -149,19 +149,10 @@ const formattingDayPeriodValues = {
 
 const ordinalNumber: LocalizeFn<number> = (dirtyNumber, options) => {
   const number = Number(dirtyNumber);
-
-  switch (options?.unit) {
-    case "date":
-      return number + "日";
-    case "hour":
-      return number + "時";
-    case "minute":
-      return number + "分";
-    case "second":
-      return number + "秒";
-    default:
-      return "第 " + number;
-  }
+  // Chinese numbers do not have ordinal numbers (st, nd, rd...).
+  // Instead, we should keep it clean. If developers need unit they
+  // should add it by them self
+  return "第" + number;
 };
 
 export const localize: Localize = {

--- a/pkgs/core/src/locale/zh-TW/_lib/match/index.ts
+++ b/pkgs/core/src/locale/zh-TW/_lib/match/index.ts
@@ -3,7 +3,7 @@ import type { Match } from "../../../types.ts";
 import { buildMatchFn } from "../../../_lib/buildMatchFn/index.ts";
 import { buildMatchPatternFn } from "../../../_lib/buildMatchPatternFn/index.ts";
 
-const matchOrdinalNumberPattern = /^(第\s*)?\d+(日|時|分|秒)?/i;
+const matchOrdinalNumberPattern = /^(第)?\d+/i;
 const parseOrdinalNumberPattern = /\d+/i;
 
 const matchEraPatterns = {
@@ -17,8 +17,8 @@ const parseEraPatterns = {
 
 const matchQuarterPatterns = {
   narrow: /^[1234]/i,
-  abbreviated: /^第[一二三四]刻/i,
-  wide: /^第[一二三四]刻鐘/i,
+  abbreviated: /^第[一二三四]季/i,
+  wide: /^第[一二三四]季度/i,
 };
 const parseQuarterPatterns = {
   any: [/(1|一)/i, /(2|二)/i, /(3|三)/i, /(4|四)/i] as const,


### PR DESCRIPTION
1. The term "quarter" refers to the quarter of a year (e.g., Q1, Q2), not a quarter of an hour (15 minutes).
2. Chinese does not use ordinal suffixes (like st, nd, rd). The old code logic `number + '日'` behaves like saying "day 3rd" in English, rather than just the standalone ordinal "3rd" as expected.