### PR TITLE
fix: add missing npm metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,13 @@
     "oxlint": "^1.68.0",
     "oxlint-tsgolint": "^0.22.1",
     "vitest": "^4.1.6"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/date-fns/date-fns/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/date-fns/date-fns.git"
+  },
+  "homepage": "https://github.com/date-fns/date-fns#readme"
 }


### PR DESCRIPTION
Adds missing npm metadata fields to improve package discoverability.