### PR TITLE
fix(parseISO): reject float hours above 24 as Invalid Date

### DIFF
--- a/pkgs/core/src/parseISO/index.ts
+++ b/pkgs/core/src/parseISO/index.ts
@@ -311,7 +311,7 @@ function validateTime(
     minutes >= 0 &&
     minutes < 60 &&
     hours >= 0 &&
-    hours < 25
+    hours < 24
   );
 }
 

--- a/pkgs/core/src/parseISO/test.ts
+++ b/pkgs/core/src/parseISO/test.ts
@@ -316,6 +316,12 @@ describe("parseISO", () => {
         expect(isNaN(result.getTime())).toBe(true);
       });
 
+      it("returns `Invalid Date` for float hours above 24 (e.g. 24.5)", () => {
+        const result = parseISO("2014-02-11T24.5");
+        expect(result instanceof Date).toBe(true);
+        expect(isNaN(result.getTime())).toBe(true);
+      });
+
       it("returns `Invalid Date` for invalid minutes", () => {
         const result = parseISO("2014-02-11T21:60");
         expect(result instanceof Date).toBe(true);


### PR DESCRIPTION
## Bug

`parseISO` incorrectly parses ISO 8601 strings with fractional hours above 24 (e.g. `"2014-02-11T24.5"`) as a valid `Date` instead of `Invalid Date`.

### Root cause

The internal `validateTime` helper guards hour range with:

```ts
// before
hours >= 0 && hours < 25
```

Integer hours of exactly `24` are caught first by the special-case check:

```ts
if (hours === 24) {
  return minutes === 0 && seconds === 0;
}
```

But **fractional** values such as `24.5` are *not* strictly equal to `24`, so they skip the early return and pass the `< 25` guard — allowing `parseISO("2014-02-11T24.5")` to return a valid date (roughly 2014-02-12 00:30:00) instead of `Invalid Date`.

ISO 8601 only permits the special end-of-day representation `24:00:00`; any time with hours ≥ 24 (including fractional like 24.5) is invalid.

## Fix

Change the upper bound from `< 25` to `< 24`. The `=== 24` branch, which runs before the general check, continues to handle the `24:00:00` case correctly.

```diff
- hours < 25
+ hours < 24
```

## Verification

```sh
pnpm --filter ./pkgs/core vitest run src/parseISO/test.ts
# 59 passed (was 58; new test added for float hours above 24)
```

> AI-assisted: bug analysis and fix written with Claude.