### PR TITLE
fix: align eachMinuteOfInterval to minute starts for reversed intervals

### DIFF
--- a/pkgs/core/src/eachMinuteOfInterval/index.ts
+++ b/pkgs/core/src/eachMinuteOfInterval/index.ts
@@ -65,12 +65,12 @@ export function eachMinuteOfInterval<
   options?: Options,
 ): EachMinuteOfIntervalResult<IntervalType, Options> {
   const { start, end } = normalizeInterval(options?.in, interval);
-  // Set to the start of the minute
-  start.setSeconds(0, 0);
 
   let reversed = +start > +end;
   const endTime = reversed ? +start : +end;
   let date = reversed ? end : start;
+  // Set to the start of the minute
+  date.setSeconds(0, 0);
 
   let step = options?.step ?? 1;
   if (!step) return [];

--- a/pkgs/core/src/eachMinuteOfInterval/test.ts
+++ b/pkgs/core/src/eachMinuteOfInterval/test.ts
@@ -71,6 +71,20 @@ describe("eachMinuteOfInterval", () => {
     ]);
   });
 
+  it("aligns the reversed result to the start of each minute when the end date has seconds", () => {
+    const result = eachMinuteOfInterval({
+      start: new Date(2020, 10, 14, 13, 3, 0),
+      end: new Date(2020, 10, 14, 13, 0, 30),
+    });
+
+    expect(result).toEqual([
+      new Date(2020, 10, 14, 13, 3),
+      new Date(2020, 10, 14, 13, 2),
+      new Date(2020, 10, 14, 13, 1),
+      new Date(2020, 10, 14, 13, 0),
+    ]);
+  });
+
   it("returns an empty array if the start date is `Invalid Date`", () => {
     const result = eachMinuteOfInterval({
       start: new Date(NaN),


### PR DESCRIPTION
`eachMinuteOfInterval` returns minute-aligned dates, but for a reversed interval (start after end) the results carried the wrong seconds and dropped the last minute.

The function zeroes the seconds on `start`, then iterates from `start` for a normal interval but from `end` for a reversed one. Since `end` is never floored, any sub-minute component on it leaks into every returned date, and because the loop steps by whole minutes from that offset base, the final minute is also skipped.

```js
eachMinuteOfInterval({
  start: new Date(2020, 10, 14, 13, 3, 0),
  end: new Date(2020, 10, 14, 13, 0, 30),
})
// before: [13:02:30, 13:01:30, 13:00:30]
// after:  [13:03:00, 13:02:00, 13:01:00, 13:00:00]
```

`eachHourOfInterval` already does this correctly: it picks the iteration endpoint first and floors that, instead of flooring `start`. This applies the same approach to `eachMinuteOfInterval`. The forward path is unchanged (in that case the iteration date is `start`, which is what was being floored before).

Added a regression test for the reversed case with a sub-minute end. Existing tests still pass.
