### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ To install the package run:
 
 ```bash
 npm install date-fns --save
+# or
+deno install date-fns
 ```
 
 ## Docs


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The README shows `npm install date-fns`. Since Deno is a drop-in replacement for npm these days, this adds a Deno line alongside it:

```sh
deno install date-fns
```

Docs-only change (date-fns resolves and installs the same way under Deno). Totally fine to close this if you'd rather keep it npm-only. Happy to adjust.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
