### PR TITLE
fix(parseISO): reject ISO week 53 in 52-week years

### DIFF
--- a/pkgs/core/src/parseISO/index.ts
+++ b/pkgs/core/src/parseISO/index.ts
@@ -292,8 +292,18 @@ function validateDayOfYearDate(year: number, dayOfYear: number): boolean {
   return dayOfYear >= 1 && dayOfYear <= (isLeapYearIndex(year) ? 366 : 365);
 }
 
-function validateWeekDate(_year: number, week: number, day: number): boolean {
-  return week >= 1 && week <= 53 && day >= 0 && day <= 6;
+function isoWeeksInYear(year: number): number {
+  const date = new Date(0);
+  date.setUTCFullYear(year, 0, 1);
+  const jan1Day = date.getUTCDay();
+  // An ISO week-numbering year has 53 weeks if January 1st is a Thursday,
+  // or if it's a leap year and January 1st is a Wednesday; otherwise 52.
+  const has53Weeks = jan1Day === 4 || (jan1Day === 3 && isLeapYearIndex(year));
+  return has53Weeks ? 53 : 52;
+}
+
+function validateWeekDate(year: number, week: number, day: number): boolean {
+  return week >= 1 && week <= isoWeeksInYear(year) && day >= 0 && day <= 6;
 }
 
 function validateTime(

--- a/pkgs/core/src/parseISO/test.ts
+++ b/pkgs/core/src/parseISO/test.ts
@@ -242,6 +242,17 @@ describe("parseISO", () => {
         expect(result instanceof Date).toBe(true);
         expect(isNaN(result.getTime())).toBe(true);
       });
+
+      it("returns `Invalid Date` for week 53 of a 52-week ISO year", () => {
+        const result = parseISO("2021-W53-1");
+        expect(result instanceof Date).toBe(true);
+        expect(isNaN(result.getTime())).toBe(true);
+      });
+
+      it("parses week 53 of a 53-week ISO year", () => {
+        const result = parseISO("2020-W53-1");
+        expect(result).toEqual(new Date(Date.UTC(2020, 11 /* Dec */, 28)));
+      });
     });
 
     describe("calendar dates", () => {


### PR DESCRIPTION
## Problem

`parseISO` accepts ISO week-numbering dates but validated the week number against a hard-coded upper bound of 53. Most ISO years have only 52 weeks, so week 53 of a 52-week year was silently accepted and rolled over into the following year.

```js
parseISO("2021-W53-1")
// expected: Invalid Date  (2021 has only 52 ISO weeks)
// actual:   Sun Jan 03 2022 ...  (rolled into 2022)
```

This affects every 52-week year, including 2014, 2017, 2018, 2019, 2021, 2022, 2025, and so on.

## Fix

Bound the week number by the actual number of ISO weeks in the year. Per ISO 8601, a week-numbering year has 53 weeks only when January 1st falls on a Thursday, or when it is a leap year and January 1st falls on a Wednesday; otherwise it has 52. The check is computed in UTC and reuses the existing leap-year helper, so no new imports are added.

Week 53 of a genuine 53-week year such as 2020 still parses correctly.

## Tests

Added two cases under `validation > weeks`:

- `parseISO("2021-W53-1")` now returns Invalid Date (52-week year rejection)
- `parseISO("2020-W53-1")` still returns the correct date (53-week year guard)

Verified red before / green after, and the wider ISO suite (parseISO, getISOWeek, setISOWeek, getISOWeekYear, getISOWeeksInYear) stays green.
