### PR TITLE
docs: clarify getQuarter return value

### DIFF
--- a/pkgs/core/src/getQuarter/index.ts
+++ b/pkgs/core/src/getQuarter/index.ts
@@ -9,15 +9,15 @@ export interface GetQuarterOptions extends ContextOptions<Date> {}
 /**
  * @name getQuarter
  * @category Quarter Helpers
- * @summary Get the year quarter of the given date.
+ * @summary Get the year quarter (1-based) of the given date.
  *
  * @description
- * Get the year quarter of the given date.
+ * Get the year quarter (1-based) of the given date.
  *
  * @param date - The given date
  * @param options - An object with options
  *
- * @returns The quarter
+ * @returns The quarter (1 - 4)
  *
  * @example
  * // Which quarter is 2 July 2014?


### PR DESCRIPTION
## Summary
- Clarifies that `getQuarter()` returns a 1-based quarter.
- Updates the return docs to specify the `1 - 4` range.

Fixes #3951

## Verification
- `pnpm --dir pkgs/core exec vitest run src/getQuarter/test.ts`
- `pnpm exec oxlint pkgs/core/src/getQuarter/index.ts`
- `pnpm exec oxfmt --check pkgs/core/src/getQuarter/index.ts`