### PR TITLE
[codex] Avoid sorting interval endpoint pairs

### DIFF
--- a/pkgs/core/src/areIntervalsOverlapping/index.ts
+++ b/pkgs/core/src/areIntervalsOverlapping/index.ts
@@ -61,14 +61,21 @@ export function areIntervalsOverlapping(
   intervalRight: Interval,
   options?: AreIntervalsOverlappingOptions,
 ): boolean {
-  const [leftStartTime, leftEndTime] = [
-    +toDate(intervalLeft.start, options?.in),
-    +toDate(intervalLeft.end, options?.in),
-  ].sort((a, b) => a - b);
-  const [rightStartTime, rightEndTime] = [
-    +toDate(intervalRight.start, options?.in),
-    +toDate(intervalRight.end, options?.in),
-  ].sort((a, b) => a - b);
+  let leftStartTime = +toDate(intervalLeft.start, options?.in);
+  let leftEndTime = +toDate(intervalLeft.end, options?.in);
+  if (leftStartTime > leftEndTime) {
+    const swap = leftStartTime;
+    leftStartTime = leftEndTime;
+    leftEndTime = swap;
+  }
+
+  let rightStartTime = +toDate(intervalRight.start, options?.in);
+  let rightEndTime = +toDate(intervalRight.end, options?.in);
+  if (rightStartTime > rightEndTime) {
+    const swap = rightStartTime;
+    rightStartTime = rightEndTime;
+    rightEndTime = swap;
+  }
 
   if (options?.inclusive)
     return leftStartTime <= rightEndTime && rightStartTime <= leftEndTime;

--- a/pkgs/core/src/getOverlappingDaysInIntervals/index.ts
+++ b/pkgs/core/src/getOverlappingDaysInIntervals/index.ts
@@ -43,14 +43,21 @@ export function getOverlappingDaysInIntervals(
   intervalLeft: Interval,
   intervalRight: Interval,
 ): number {
-  const [leftStart, leftEnd] = [
-    +toDate(intervalLeft.start),
-    +toDate(intervalLeft.end),
-  ].sort((a, b) => a - b);
-  const [rightStart, rightEnd] = [
-    +toDate(intervalRight.start),
-    +toDate(intervalRight.end),
-  ].sort((a, b) => a - b);
+  let leftStart = +toDate(intervalLeft.start);
+  let leftEnd = +toDate(intervalLeft.end);
+  if (leftStart > leftEnd) {
+    const swap = leftStart;
+    leftStart = leftEnd;
+    leftEnd = swap;
+  }
+
+  let rightStart = +toDate(intervalRight.start);
+  let rightEnd = +toDate(intervalRight.end);
+  if (rightStart > rightEnd) {
+    const swap = rightStart;
+    rightStart = rightEnd;
+    rightEnd = swap;
+  }
 
   // Prevent NaN result if intervals don't overlap at all.
   const isOverlapping = leftStart < rightEnd && rightStart < leftEnd;

--- a/pkgs/core/src/isWithinInterval/index.ts
+++ b/pkgs/core/src/isWithinInterval/index.ts
@@ -52,10 +52,14 @@ export function isWithinInterval(
   options?: IsWithinIntervalOptions | undefined,
 ): boolean {
   const time = +toDate(date, options?.in);
-  const [startTime, endTime] = [
-    +toDate(interval.start, options?.in),
-    +toDate(interval.end, options?.in),
-  ].sort((a, b) => a - b);
+  let startTime = +toDate(interval.start, options?.in);
+  let endTime = +toDate(interval.end, options?.in);
+
+  if (startTime > endTime) {
+    const swap = startTime;
+    startTime = endTime;
+    endTime = swap;
+  }
 
   return time >= startTime && time <= endTime;
 }


### PR DESCRIPTION
## Summary
- Replace two-element array sort calls with direct endpoint swaps in interval helpers.

## Validation
- targeted vitest, core main vitest, and tsgo build passed; local endpoint-normalization measurement improved.

## Notes
- Opened as a draft PR for maintainer review.
