### PR TITLE
fix(roundToNearestMinutes): honor the in option when nearestTo is out of range

### DIFF
--- a/pkgs/core/src/roundToNearestMinutes/index.ts
+++ b/pkgs/core/src/roundToNearestMinutes/index.ts
@@ -64,7 +64,8 @@ export function roundToNearestMinutes<
 ): ResultDate {
   const nearestTo = options?.nearestTo ?? 1;
 
-  if (nearestTo < 1 || nearestTo > 30) return constructFrom(date, NaN);
+  if (nearestTo < 1 || nearestTo > 30)
+    return constructFrom(options?.in || date, NaN);
 
   const date_ = toDate(date, options?.in);
   const fractionalSeconds = date_.getSeconds() / 60;

--- a/pkgs/core/src/roundToNearestMinutes/test.ts
+++ b/pkgs/core/src/roundToNearestMinutes/test.ts
@@ -294,6 +294,15 @@ describe("roundToNearestMinutes", () => {
       expect(result).toBeInstanceOf(TZDate);
       assertType<assertType.Equal<TZDate, typeof result>>(true);
     });
+
+    it("resolves the context date type when nearestTo is out of range", () => {
+      const result = roundToNearestMinutes("2014-09-01T00:00:00Z", {
+        nearestTo: 31,
+        in: tz("Asia/Tokyo"),
+      });
+      expect(result).toBeInstanceOf(TZDate);
+      expect(isNaN(+result)).toBe(true);
+    });
   });
 });
 


### PR DESCRIPTION
`roundToNearestMinutes` returns an Invalid Date when `nearestTo` is outside the 1 to 30 range, but it builds that date from the input argument and ignores the `in` context:

```ts
if (nearestTo < 1 || nearestTo > 30) return constructFrom(date, NaN);
```

Its sibling `roundToNearestHours` already builds the out-of-range result from the context:

```ts
if (nearestTo < 1 || nearestTo > 12)
  return constructFrom(options?.in || date, NaN);
```

Both functions resolve the result type from `options.in` on the normal path via `toDate(date, options?.in)`, and both ship a "resolves the context date type" test for it, so the out-of-range branch should do the same. As is, `roundToNearestMinutes("2014-09-01T00:00:00Z", { nearestTo: 31, in: tz("Asia/Tokyo") })` returns a plain `Date`, while the equivalent `roundToNearestHours(..., { nearestTo: 13, in: tz("Asia/Tokyo") })` returns a `TZDate`.

This mirrors the sibling so the `in` context is honored in both branches. When `in` is not passed the behavior is unchanged. Added a test in the existing `context` block.
