### PR TITLE
Fix differenceInWeeks doc example (wrong dates and result)

### DIFF
--- a/pkgs/core/src/differenceInWeeks/index.ts
+++ b/pkgs/core/src/differenceInWeeks/index.ts
@@ -37,16 +37,16 @@ export interface DifferenceInWeeksOptions
  *
  * @example
  * // How many full weeks are between
- * // 1 March 2020 0:00 and 6 June 2020 0:00 ?
+ * // 6 March 2020 0:00 and 1 June 2020 0:00 ?
  * // Note: because local time is used, the
- * // result will always be 8 weeks (54 days),
+ * // result will always be 12 weeks (87 days),
  * // even if DST starts and the period has
- * // only 54*24-1 hours.
+ * // only 87*24-1 hours.
  * const result = differenceInWeeks(
  *   new Date(2020, 5, 1),
  *   new Date(2020, 2, 6)
  * )
- * //=> 8
+ * //=> 12
  */
 export function differenceInWeeks(
   laterDate: DateArg<Date> & {},

--- a/pkgs/core/src/differenceInWeeks/test.ts
+++ b/pkgs/core/src/differenceInWeeks/test.ts
@@ -80,6 +80,14 @@ describe("differenceInWeeks", () => {
     expect(result).toBe(1);
   });
 
+  it("matches the documented example spanning a DST change (6 March 2020 to 1 June 2020)", () => {
+    const result = differenceInWeeks(
+      new Date(2020, 5 /* Jun */, 1),
+      new Date(2020, 2 /* Mar */, 6),
+    );
+    expect(result).toBe(12);
+  });
+
   describe("edge cases", () => {
     it("the difference is less than a week, but the given dates are in different calendar weeks", () => {
       const result = differenceInWeeks(


### PR DESCRIPTION
The DST example in the `differenceInWeeks` JSDoc is inconsistent: the prose talks about "1 March" and "6 June", but the code actually uses `new Date(2020, 2, 6)` (March 6) and `new Date(2020, 5, 1)` (June 1), and claims the result is 8 weeks / 54 days. Running the actual dates from the code gives 87 days, which is 12 weeks truncated - not 8. 54 days wouldn't even truncate to 8 weeks in the first place (54/7 ≈ 7.7 → 7).

This was already reported in #3496 with the same numbers, and there's an old PR (#3529) for it, but that one targets the pre-monorepo file layout and is now conflicting with main, so it can't land as-is.

I fixed the prose and the expected result to match what the code actually returns for those dates (kept the original dates since they still nicely demonstrate the "DST doesn't affect the day count" point - 87*24-1 hours elapse in a DST-observing zone), and added a test that pins this example so it can't silently drift again.