### PR TITLE
ci: add CVE Lite dependency audit workflow

### DIFF
--- a/.github/workflows/cve-lite.yml
+++ b/.github/workflows/cve-lite.yml
@@ -1,0 +1,37 @@
+name: CVE Lite dependency audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly on Monday at 06:00 UTC - catches new advisories between pushes
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    name: Scan dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Scan for vulnerabilities
+        uses: OWASP/cve-lite-cli@2eed959b8641042472d2810444393b88d5454e62 # v1
+        with:
+          fail-on: high
+          sarif: 'true'
+
+      - name: Upload SARIF to Code Scanning
+        if: always() && hashFiles('*.sarif') != ''
+        uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
+        with:
+          sarif_file: cve-lite-*.sarif
+          category: cve-lite


### PR DESCRIPTION
This PR adds a CVE Lite CLI dependency audit workflow to date-fns's CI pipeline.

A scan of the current `pnpm-lock.yaml` found **5 critical-severity** and **18 high-severity** advisories, including 8 direct dependencies with available fixes:

**Direct critical-severity findings:**
- `@vitest/browser@4.0.x` - GHSA affecting browser test runner - fix: `pnpm add -D --filter ./pkgs/core @vitest/browser@4.1.8`
- `simple-git@3.x` - argument injection via crafted input (GHSA-9p95-fxvg-qgq2) - fix: `pnpm add -D --filter ./pkgs/core simple-git@3.36.0`

**Direct high-severity findings:**
- `minimatch@3.x` in `pkgs/tz` and `pkgs/utc` - ReDoS via crafted glob - fix: `pnpm add --filter ./pkgs/tz --filter ./pkgs/utc minimatch@10.2.3`
- `glob@7.x` - ReDoS / path traversal - fix: `pnpm add -D --filter ./pkgs/tz --filter ./pkgs/utc glob@11.1.0`
- `lodash@4.17.x` - prototype pollution - fix: `pnpm add -D --filter ./pkgs/core lodash@4.18.0`

The workflow runs on push, pull request, and weekly schedule. Findings are uploaded to GitHub's Security tab as SARIF.

**Tool:** [CVE Lite CLI](https://github.com/OWASP/cve-lite-cli) is an OWASP Lab Project. It reads the lockfile locally, queries the OSV database, and produces actionable fix commands that distinguish direct from transitive findings.
