### PR TITLE
Return Invalid Date from min/max when given null

### DIFF
--- a/pkgs/core/src/max/index.ts
+++ b/pkgs/core/src/max/index.ts
@@ -43,10 +43,13 @@ export function max<DateType extends Date, ResultDate extends Date = DateType>(
 
   dates.forEach((date) => {
     // Use the first date object as the context function
-    if (!context && typeof date === "object")
+    if (!context && date && typeof date === "object")
       context = constructFrom.bind(null, date) as ContextFn<ResultDate>;
 
-    const date_ = toDate(date, context);
+    // `toDate` coerces `null` to the epoch, but like any other invalid input
+    // it must result in an invalid date (v3 parity).
+    const date_ =
+      date === null ? constructFrom(context, NaN) : toDate(date, context);
     if (!result || result < date_ || isNaN(+date_)) result = date_;
   });
 

--- a/pkgs/core/src/max/test.ts
+++ b/pkgs/core/src/max/test.ts
@@ -40,6 +40,20 @@ describe("max", () => {
     expect(isNaN(+result)).toBe(true);
   });
 
+  it("returns `Invalid Date` if any given date is `null`", () => {
+    // `null` used to poison the shared context and coerce to the epoch
+    // instead of an invalid date: https://github.com/date-fns/date-fns/issues/3999
+    const result = max([null as unknown as Date]);
+    expect(isNaN(+result)).toBe(true);
+
+    const mixed = max([
+      new Date(1989, 6 /* Jul */, 10),
+      null as unknown as Date,
+      new Date(1987, 1 /* Feb */, 11),
+    ]);
+    expect(isNaN(+mixed)).toBe(true);
+  });
+
   it("returns `Invalid Date` for empty array", () => {
     const result = max([]);
     expect(isNaN(+result)).toBe(true);

--- a/pkgs/core/src/min/index.ts
+++ b/pkgs/core/src/min/index.ts
@@ -43,10 +43,13 @@ export function min<DateType extends Date, ResultDate extends Date = DateType>(
 
   dates.forEach((date) => {
     // Use the first date object as the context function
-    if (!context && typeof date === "object")
+    if (!context && date && typeof date === "object")
       context = constructFrom.bind(null, date) as ContextFn<ResultDate>;
 
-    const date_ = toDate(date, context);
+    // `toDate` coerces `null` to the epoch, but like any other invalid input
+    // it must result in an invalid date (v3 parity).
+    const date_ =
+      date === null ? constructFrom(context, NaN) : toDate(date, context);
     if (!result || result > date_ || isNaN(+date_)) result = date_;
   });
 

--- a/pkgs/core/src/min/test.ts
+++ b/pkgs/core/src/min/test.ts
@@ -40,6 +40,20 @@ describe("min", () => {
     expect(isNaN(+result)).toBe(true);
   });
 
+  it("returns `Invalid Date` if any given date is `null`", () => {
+    // `null` used to poison the shared context and coerce to the epoch
+    // instead of an invalid date: https://github.com/date-fns/date-fns/issues/3999
+    const result = min([null as unknown as Date]);
+    expect(isNaN(+result)).toBe(true);
+
+    const mixed = min([
+      new Date(1989, 6 /* Jul */, 10),
+      null as unknown as Date,
+      new Date(1987, 1 /* Feb */, 11),
+    ]);
+    expect(isNaN(+mixed)).toBe(true);
+  });
+
   it("returns `Invalid Date` for empty array", () => {
     const result = min([]);
     expect(isNaN(+result)).toBe(true);


### PR DESCRIPTION
Fixes #3999

## Problem

In v3, `min([null])` and `max([null])` returned `Invalid Date`. Since v4 they return the **epoch** (`1970-01-01`), and a single `null` even poisons results when valid dates are present:

```js
// v4.4.0
min([null]) //=> 1970-01-01T00:00:00.000Z
min([null, new Date(2024, 0, 1)]) //=> 1970-01-01T00:00:00.000Z
// v3.6.0: both => Invalid Date
```

## Cause

Two interactions in `min`/`max`:

- `typeof null === "object"`, so a `null` entry becomes the shared context (`constructFrom.bind(null, null)`), which constructs plain epoch dates for every subsequent entry.
- `toDate(null, context)` coerces `null` to `new Date(0)` rather than an invalid date.

`null` isn't part of `DateArg`'s type, but it flows in easily from nullable data at runtime, and every other invalid input (`NaN`, `undefined`, invalid dates, empty arrays) already produces `Invalid Date` in both v3 and v4 — `null` is the one inconsistent case.

## Fix

Scoped to `min`/`max` (no `toDate`/`constructFrom` blast radius): guard the context binding against `null`, and map `null` entries to `constructFrom(context, NaN)` so they behave like any other invalid input, restoring v3 parity.

## Tests

Regression tests in both `min/test.ts` and `max/test.ts`, modeled on the existing "returns `Invalid Date` if any given date is invalid" cases — covering `[null]` alone and `null` mixed with valid dates. They fail on the current code (epoch returned) and pass with the fix; the full `min`/`max`/`toDate` suites (169 tests) pass.
