### PR TITLE
Fix transpose failing under fake timers

### DIFF
--- a/pkgs/core/src/transpose/index.ts
+++ b/pkgs/core/src/transpose/index.ts
@@ -54,6 +54,9 @@ function isConstructor(
 ): constructor is GenericDateConstructor {
   return (
     typeof constructor === "function" &&
-    constructor.prototype?.constructor === constructor
+    // Detect a date constructor by the methods on its prototype rather than by
+    // `prototype.constructor`, which fake timers (e.g. Jest, Vitest) reassign to
+    // the native Date, making the constructor look like a plain function.
+    typeof constructor.prototype?.setFullYear === "function"
   );
 }

--- a/pkgs/core/src/transpose/test.ts
+++ b/pkgs/core/src/transpose/test.ts
@@ -1,6 +1,7 @@
 import { TZDate, tz } from "@date-fns/tz";
 import { describe, expect, it } from "vitest";
 import { transpose } from "./index.ts";
+import { fakeDate } from "../_lib/test/index.ts";
 
 describe("transpose", () => {
   it("allows to use context function", () => {
@@ -14,5 +15,25 @@ describe("transpose", () => {
     expect(result.getMinutes()).toBe(34);
     expect(result.getSeconds()).toBe(56);
     expect(result.getMilliseconds()).toBe(789);
+  });
+
+  describe("with fake timers", () => {
+    // Fake timers (Jest, Vitest) replace the global Date with a mock whose
+    // prototype.constructor points to the native Date, so transpose must still
+    // recognize the constructor instead of calling it without `new`.
+    fakeDate(new Date(2009, 4, 5, 20));
+
+    it("transposes to the native Date constructor", () => {
+      const date = new Date(2022, 6, 10, 12, 34, 56, 789);
+      const result = transpose(date, Date);
+      expect(result instanceof Date).toBe(true);
+      expect(result.getFullYear()).toBe(2022);
+      expect(result.getMonth()).toBe(6);
+      expect(result.getDate()).toBe(10);
+      expect(result.getHours()).toBe(12);
+      expect(result.getMinutes()).toBe(34);
+      expect(result.getSeconds()).toBe(56);
+      expect(result.getMilliseconds()).toBe(789);
+    });
   });
 });


### PR DESCRIPTION
`transpose(date, Date)` throws `TypeError: date_.setFullYear is not a function` when the code runs under fake timers (Jest or Vitest).

The cause is `isConstructor`. It detects a date constructor by checking `prototype.constructor === constructor`, but fake timers replace the global Date with a mock whose `prototype.constructor` still points to the native Date. The check fails, so transpose treats the constructor as a context function and calls it without `new`, which returns a string instead of a date.

The fix detects a date constructor by checking its prototype exposes Date methods (`setFullYear`). That stays correct under fake timers while still rejecting context functions. Added a regression test that runs transpose under fake timers.

Closes #4156
