### PR TITLE
Fix differenceInMonths reporting a full month one DST offset short

### DIFF
--- a/pkgs/core/src/differenceInMonths/index.ts
+++ b/pkgs/core/src/differenceInMonths/index.ts
@@ -1,5 +1,4 @@
 import { normalizeDates } from "../_lib/normalizeDates/index.ts";
-import { compareAsc } from "../compareAsc/index.ts";
 import { differenceInCalendarMonths } from "../differenceInCalendarMonths/index.ts";
 import { isLastDayOfMonth } from "../isLastDayOfMonth/index.ts";
 import type { ContextOptions, DateArg } from "../types.ts";
@@ -37,7 +36,7 @@ export function differenceInMonths(
     earlierDate,
   );
 
-  const sign = compareAsc(workingLaterDate, earlierDate_);
+  const sign = compareLocalAsc(workingLaterDate, earlierDate_);
   const difference = Math.abs(
     differenceInCalendarMonths(workingLaterDate, earlierDate_),
   );
@@ -49,16 +48,59 @@ export function differenceInMonths(
 
   workingLaterDate.setMonth(workingLaterDate.getMonth() - sign * difference);
 
-  let isLastMonthNotFull = compareAsc(workingLaterDate, earlierDate_) === -sign;
+  // Only `workingLaterDate`'s year/month/day are used below, not its
+  // time-of-day. Navigating a Date `difference` months back (above) can land
+  // on a nonexistent local time during a DST "spring forward" gap, which gets
+  // silently renormalized to a different hour, masking the very discrepancy
+  // this comparison is meant to catch. Its year/month/day are unaffected by
+  // that (a DST gap never changes the date), so they're still trustworthy.
+  // `laterDate_` was never renavigated, so its time-of-day is used instead.
+  let isLastMonthNotFull =
+    compareCalendarAndTime(workingLaterDate, laterDate_, earlierDate_) ===
+    -sign;
 
   if (
     isLastDayOfMonth(laterDate_) &&
     difference === 1 &&
-    compareAsc(laterDate_, earlierDate_) === 1
+    compareLocalAsc(laterDate_, earlierDate_) === 1
   ) {
     isLastMonthNotFull = false;
   }
 
   const result = sign * (difference - +isLastMonthNotFull);
   return result === 0 ? 0 : result;
+}
+
+// Like `compareAsc` but uses local time not UTC, which is needed
+// for accurate equality comparisons of UTC timestamps that end up
+// having the same representation in local time, e.g. one hour before
+// DST ends vs. the instant that DST ends.
+function compareLocalAsc(laterDate: Date, earlierDate: Date): number {
+  return compareCalendarAndTime(laterDate, laterDate, earlierDate);
+}
+
+// Compares a year/month/day (`calendar`'s) & time-of-day (`time`'s
+// hours/minutes/seconds/ms) against `other`'s. `calendar` and `time` are
+// passed separately so callers can supply a year/month/day derived from a
+// Date that may have been renavigated (and so shouldn't be trusted for its
+// time-of-day), alongside a `time` value that wasn't.
+function compareCalendarAndTime(
+  calendar: Date,
+  time: Date,
+  other: Date,
+): number {
+  const diff =
+    calendar.getFullYear() - other.getFullYear() ||
+    calendar.getMonth() - other.getMonth() ||
+    calendar.getDate() - other.getDate() ||
+    time.getHours() - other.getHours() ||
+    time.getMinutes() - other.getMinutes() ||
+    time.getSeconds() - other.getSeconds() ||
+    time.getMilliseconds() - other.getMilliseconds();
+
+  if (diff < 0) return -1;
+  if (diff > 0) return 1;
+
+  // Return 0 if diff is 0; return NaN if diff is NaN
+  return diff;
 }

--- a/pkgs/core/src/differenceInMonths/test.ts
+++ b/pkgs/core/src/differenceInMonths/test.ts
@@ -1,5 +1,6 @@
 import { TZDate, tz } from "@date-fns/tz";
 import { describe, expect, it } from "vitest";
+import { getDstTransitions } from "../_lib/test/tzOffsetTransitions.ts";
 import type { ContextOptions, DateArg } from "../types.ts";
 import { differenceInMonths } from "./index.ts";
 
@@ -122,6 +123,41 @@ describe("differenceInMonths", () => {
       const resultIsNegative = isNegativeZero(result);
       expect(resultIsNegative).toBe(false);
     });
+
+    const dstTransitions = getDstTransitions(2020);
+    const dstOnly = dstTransitions.start && dstTransitions.end ? it : it.skip;
+    const dstTz =
+      Intl.DateTimeFormat().resolvedOptions().timeZone || process.env.tz;
+    dstOnly(
+      `does not report a full month when the period is a DST offset short of one, in local timezone: ${dstTz || "(unknown)"}`,
+      () => {
+        const { start, end } = dstTransitions;
+        const MINUTE = 1000 * 60;
+
+        expect(start).not.toBe(undefined);
+        expect(end).not.toBe(undefined);
+
+        if (start === undefined || end === undefined) {
+          return;
+        }
+
+        // It's usually 1 hour, but for some timezones, e.g. Australia/Lord_Howe, it is 30 minutes
+        const dstOffset =
+          (end.getTimezoneOffset() - start.getTimezoneOffset()) * MINUTE;
+
+        // Exactly one month later at the same local time is a full month.
+        const fullMonthLater = new Date(start);
+        fullMonthLater.setMonth(fullMonthLater.getMonth() + 1);
+        expect(differenceInMonths(fullMonthLater, start)).toBe(1);
+
+        // One month later, minus the DST offset, is exactly one DST-sized
+        // gap short of a full month and must not round up to 1.
+        const dstOffsetShortOfAMonth = new Date(
+          fullMonthLater.getTime() - dstOffset,
+        );
+        expect(differenceInMonths(dstOffsetShortOfAMonth, start)).toBe(0);
+      },
+    );
   });
 
   it("returns NaN if the first date is `Invalid Date`", () => {


### PR DESCRIPTION
Fixes #1758.

`differenceInMonths` compared dates with the UTC-based `compareAsc`, which is the same bug already fixed for `differenceInDays` in #1754 (comparing UTC milliseconds can disagree with the actual local wall-clock ordering across a DST transition).

But swapping in a local-time comparator alone wasn't enough here. `differenceInMonths` also has its own month-length-overflow handling (the `setDate(30)` / `setMonth()` dance used to make e.g. "Feb 28" comparable to "Jan 30"), which walks a `Date` object `difference` months back for the final comparison. That navigation can land on a nonexistent local time during a DST "spring forward" gap (e.g. "March 8, 2:00 AM" in `America/Los_Angeles`, which doesn't exist since clocks jump straight to 3:00 AM). JS silently renormalizes that to a different hour instead of throwing, which was masking the exact shortfall this comparison exists to catch.

Fixed by comparing local calendar fields (year/month/day/time) throughout, sourcing the day-of-month from the renavigated date (safe, since a DST gap never changes the date) but the time-of-day from the original, never-renavigated date (since that's the part a gap can corrupt).

Added a DST regression test mirroring the existing `differenceInDays` one, gated the same way (skipped in timezones with no DST) and using the shared `getDstTransitions` helper so it runs against whatever DST-observing timezone the test machine is in, rather than hardcoding one.

Ran the full suite locally across several DST timezones (`America/Los_Angeles`, `America/New_York`, `Europe/London`, `Pacific/Auckland`, `Australia/Lord_Howe` for the 30-minute-offset case) plus non-DST ones (`UTC`, `Asia/Tokyo`) — all pass. No other tests affected.

(Used AI assistance to dig into this; verified the root cause and the fix against the full test suite before opening this.)
