### PR TITLE
docs: fix unicodeTokens.md links after monorepo migration

### DIFF
--- a/pkgs/core/src/_lib/protectedTokens/index.ts
+++ b/pkgs/core/src/_lib/protectedTokens/index.ts
@@ -23,5 +23,5 @@ export function warnOrThrowProtectedError(
 
 function message(token: string, format: string, input: string) {
   const subject = token[0] === "Y" ? "years" : "days of the month";
-  return `Use \`${token.toLowerCase()}\` instead of \`${token}\` (in \`${format}\`) for formatting ${subject} to the input \`${input}\`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md`;
+  return `Use \`${token.toLowerCase()}\` instead of \`${token}\` (in \`${format}\`) for formatting ${subject} to the input \`${input}\`; see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md`;
 }

--- a/pkgs/core/src/format/index.ts
+++ b/pkgs/core/src/format/index.ts
@@ -69,7 +69,7 @@ export interface FormatOptions
  * Return the formatted date string in the given format. The result may vary by locale.
  *
  * > ⚠️ Please note that the `format` tokens differ from Moment.js and other libraries.
- * > See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * > See: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
  *
  * The characters wrapped between two single quotes characters (') are escaped.
  * Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.
@@ -305,10 +305,10 @@ export interface FormatOptions
  *    - `p`: long localized time
  *
  * 8. `YY` and `YYYY` tokens represent week-numbering years but they are often confused with years.
- *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
  *
  * 9. `D` and `DD` tokens represent days of the year but they are often confused with days of the month.
- *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
  *
  * @param date - The original date
  * @param format - The string of tokens
@@ -319,10 +319,10 @@ export interface FormatOptions
  * @throws `date` must not be Invalid Date
  * @throws `options.locale` must contain `localize` property
  * @throws `options.locale` must contain `formatLong` property
- * @throws use `yyyy` instead of `YYYY` for formatting years using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
- * @throws use `yy` instead of `YY` for formatting years using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
- * @throws use `d` instead of `D` for formatting days of the month using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
- * @throws use `dd` instead of `DD` for formatting days of the month using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * @throws use `yyyy` instead of `YYYY` for formatting years using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
+ * @throws use `yy` instead of `YY` for formatting years using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
+ * @throws use `d` instead of `D` for formatting days of the month using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
+ * @throws use `dd` instead of `DD` for formatting days of the month using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
  * @throws format string contains an unescaped latin alphabet character
  *
  * @example

--- a/pkgs/core/src/format/test.ts
+++ b/pkgs/core/src/format/test.ts
@@ -881,7 +881,7 @@ describe("format", () => {
         expect(warn).toBeCalledWith(
           "Use `d` instead of `D` (in `yyyy-MM-D`) for formatting days of the month to the input `" +
             date +
-            "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md",
+            "`; see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md",
         );
       });
 
@@ -894,7 +894,7 @@ describe("format", () => {
         expect(warn).toBeCalledWith(
           "Use `dd` instead of `DD` (in `yyyy-MM-DD`) for formatting days of the month to the input `" +
             date +
-            "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md",
+            "`; see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md",
         );
       });
 
@@ -907,7 +907,7 @@ describe("format", () => {
         expect(warn).toBeCalledWith(
           "Use `ddd` instead of `DDD` (in `yyyy-MM-DDD`) for formatting days of the month to the input `" +
             date +
-            "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md",
+            "`; see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md",
         );
       });
 
@@ -920,7 +920,7 @@ describe("format", () => {
         expect(warn).toBeCalledWith(
           "Use `dddd` instead of `DDDD` (in `yyyy-MM-DDDD`) for formatting days of the month to the input `" +
             date +
-            "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md",
+            "`; see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md",
         );
       });
 
@@ -933,7 +933,7 @@ describe("format", () => {
         expect(warn).toBeCalledWith(
           "Use `ddddd` instead of `DDDDD` (in `yyyy-MM-DDDDD`) for formatting days of the month to the input `" +
             date +
-            "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md",
+            "`; see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md",
         );
       });
 
@@ -946,7 +946,7 @@ describe("format", () => {
         expect(warn).toBeCalledWith(
           "Use `y` instead of `Y` (in `Y-MM-dd`) for formatting years to the input `" +
             date +
-            "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md",
+            "`; see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md",
         );
       });
 
@@ -959,7 +959,7 @@ describe("format", () => {
         expect(warn).toBeCalledWith(
           "Use `yy` instead of `YY` (in `YY-MM-dd`) for formatting years to the input `" +
             date +
-            "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md",
+            "`; see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md",
         );
       });
 
@@ -972,7 +972,7 @@ describe("format", () => {
         expect(warn).toBeCalledWith(
           "Use `yyy` instead of `YYY` (in `YYY-MM-dd`) for formatting years to the input `" +
             date +
-            "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md",
+            "`; see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md",
         );
       });
 
@@ -985,7 +985,7 @@ describe("format", () => {
         expect(warn).toBeCalledWith(
           "Use `yyyy` instead of `YYYY` (in `YYYY-MM-dd`) for formatting years to the input `" +
             date +
-            "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md",
+            "`; see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md",
         );
       });
 
@@ -998,7 +998,7 @@ describe("format", () => {
         expect(warn).toBeCalledWith(
           "Use `yyyyy` instead of `YYYYY` (in `YYYYY-MM-dd`) for formatting years to the input `" +
             date +
-            "`; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md",
+            "`; see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md",
         );
       });
     });

--- a/pkgs/core/src/isMatch/index.ts
+++ b/pkgs/core/src/isMatch/index.ts
@@ -27,7 +27,7 @@ export interface IsMatchOptions
  * will return false.
  *
  * > ⚠️ Please note that the `format` tokens differ from Moment.js and other libraries.
- * > See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * > See: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
  *
  * The characters in the format string wrapped between two single quotes characters (') are escaped.
  * Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.
@@ -250,10 +250,10 @@ export interface IsMatchOptions
  *    - `p`: long localized time
  *
  * 6. `YY` and `YYYY` tokens represent week-numbering years but they are often confused with years.
- *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
  *
  * 7. `D` and `DD` tokens represent days of the year but they are often confused with days of the month.
- *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
  *
  * 8. `P+` tokens do not have a defined priority since they are merely aliases to other tokens based
  *    on the given locale.
@@ -276,16 +276,16 @@ export interface IsMatchOptions
  * @param dateStr - The date string to verify
  * @param format - The string of tokens
  * @param options - An object with options.
- *   see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
- *   see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ *   see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
+ *   see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
  *
  * @returns Is format string a match for date string?
  *
  * @throws `options.locale` must contain `match` property
- * @throws use `yyyy` instead of `YYYY` for formatting years; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
- * @throws use `yy` instead of `YY` for formatting years; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
- * @throws use `d` instead of `D` for formatting days of the month; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
- * @throws use `dd` instead of `DD` for formatting days of the month; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * @throws use `yyyy` instead of `YYYY` for formatting years; see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
+ * @throws use `yy` instead of `YY` for formatting years; see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
+ * @throws use `d` instead of `D` for formatting days of the month; see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
+ * @throws use `dd` instead of `DD` for formatting days of the month; see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
  * @throws format string contains an unescaped latin alphabet character
  *
  * @example

--- a/pkgs/core/src/lightFormat/index.ts
+++ b/pkgs/core/src/lightFormat/index.ts
@@ -37,7 +37,7 @@ type Token = keyof typeof lightFormatters;
  * `lightFormat` doesn't use locales and outputs date using the most popular tokens.
  *
  * > ⚠️ Please note that the `lightFormat` tokens differ from Moment.js and other libraries.
- * > See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * > See: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
  *
  * The characters wrapped between two single quotes characters (') are escaped.
  * Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.

--- a/pkgs/core/src/parse/index.ts
+++ b/pkgs/core/src/parse/index.ts
@@ -69,7 +69,7 @@ const unescapedLatinCharacterRegExp = /[a-zA-Z]/;
  * Return the date parsed from string using the given format string.
  *
  * > ⚠️ Please note that the `format` tokens differ from Moment.js and other libraries.
- * > See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * > See: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
  *
  * The characters in the format string wrapped between two single quotes characters (') are escaped.
  * Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.
@@ -292,10 +292,10 @@ const unescapedLatinCharacterRegExp = /[a-zA-Z]/;
  *    - `p`: long localized time
  *
  * 6. `YY` and `YYYY` tokens represent week-numbering years but they are often confused with years.
- *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ *    You should enable `options.useAdditionalWeekYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
  *
  * 7. `D` and `DD` tokens represent days of the year but they are often confused with days of the month.
- *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ *    You should enable `options.useAdditionalDayOfYearTokens` to use them. See: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
  *
  * 8. `P+` tokens do not have a defined priority since they are merely aliases to other tokens based
  *    on the given locale.
@@ -333,16 +333,16 @@ const unescapedLatinCharacterRegExp = /[a-zA-Z]/;
  * @param formatStr - The string of tokens
  * @param referenceDate - defines values missing from the parsed dateString
  * @param options - An object with options.
- *   see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
- *   see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ *   see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
+ *   see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
  *
  * @returns The parsed date
  *
  * @throws `options.locale` must contain `match` property
- * @throws use `yyyy` instead of `YYYY` for formatting years using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
- * @throws use `yy` instead of `YY` for formatting years using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
- * @throws use `d` instead of `D` for formatting days of the month using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
- * @throws use `dd` instead of `DD` for formatting days of the month using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
+ * @throws use `yyyy` instead of `YYYY` for formatting years using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
+ * @throws use `yy` instead of `YY` for formatting years using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
+ * @throws use `d` instead of `D` for formatting days of the month using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
+ * @throws use `dd` instead of `DD` for formatting days of the month using [format provided] to the input [input provided]; see: https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/unicodeTokens.md
  * @throws format string contains an unescaped latin alphabet character
  *
  * @example


### PR DESCRIPTION
## Summary

- Updates all references to `unicodeTokens.md` from the old `master/docs` path to `main/pkgs/core/docs`
- Fixes broken links in JSDoc comments, runtime error messages, and format tests

Fixes #4226

## Test plan

- [x] Ran `pnpm vitest run src/format/test.ts` in `pkgs/core` (133 tests passed)
- [x] Verified no remaining references to `blob/master/docs/unicodeTokens.md` in source files