### PR TITLE
docs: fix intervalToDuration example output

### DIFF
--- a/pkgs/core/src/intervalToDuration/index.ts
+++ b/pkgs/core/src/intervalToDuration/index.ts
@@ -32,7 +32,7 @@ export interface IntervalToDurationOptions extends ContextOptions<Date> {}
  *   start: new Date(1929, 0, 15, 12, 0, 0),
  *   end: new Date(1968, 3, 4, 19, 5, 0)
  * });
- * //=> { years: 39, months: 2, days: 20, hours: 7, minutes: 5, seconds: 0 }
+ * //=> { years: 39, months: 2, days: 20, hours: 7, minutes: 5 }
  */
 export function intervalToDuration(
   interval: Interval,


### PR DESCRIPTION
## Summary

- Removes `seconds: 0` from the `intervalToDuration` JSDoc example
- Matches actual behavior where zero duration fields are omitted from the result

Fixes #4131

## Test plan

- [x] Ran `pnpm vitest run src/intervalToDuration/test.ts` in `pkgs/core` (20 tests passed)
- [x] Verified the existing test for the documented example already expects output without `seconds`