### PR TITLE
docs: clarify 0-indexed month in closestIndexTo example

### DIFF
--- a/pkgs/core/src/closestIndexTo/index.ts
+++ b/pkgs/core/src/closestIndexTo/index.ts
@@ -16,6 +16,7 @@ import type { DateArg } from "../types.ts";
  *
  * @example
  * // Which date is closer to 6 September 2015?
+ * // Note: months are 0-indexed in `Date`, so `8` is September.
  * const dateToCompare = new Date(2015, 8, 6)
  * const datesArray = [
  *   new Date(2015, 0, 1),


### PR DESCRIPTION
## Summary

- Adds a note to the `closestIndexTo` JSDoc example explaining that months are 0-indexed in `Date`
- Clarifies that month index `8` corresponds to September, matching the example description

Fixes #4149

## Test plan

- [x] Ran `pnpm vitest run src/closestIndexTo/test.ts` in `pkgs/core` (6 tests passed)