### PR TITLE
docs: fix remaining monorepo doc links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,8 @@ Help is always welcome. There are areas where you can help:
 - The core functionality (performance improvements, bug fixes,
   new features, etc.).
 
-- Documentation ([markdown documents](https://github.com/date-fns/date-fns/tree/master/docs),
-  [TSDoc annotations in source code](https://github.com/date-fns/date-fns/blob/master/src/toDate/index.ts)).
+- Documentation ([markdown documents](https://github.com/date-fns/date-fns/tree/main/pkgs/core/docs),
+  [TSDoc annotations in source code](https://github.com/date-fns/date-fns/blob/main/pkgs/core/src/toDate/index.ts)).
 
 - Test suite & development environment improvements.
 

--- a/pkgs/core/docs/i18n.md
+++ b/pkgs/core/docs/i18n.md
@@ -82,10 +82,10 @@ use this quick guide:
 
 - First of all, [create an issue](https://github.com/date-fns/date-fns/issues/new?title=XXX%20language%20support)
   so you won't overlap with others.
-- A detailed explanation of how to [add a new locale](https://github.com/date-fns/date-fns/blob/master/docs/i18nContributionGuide.md#adding-a-new-locale).
-- Use [English locale](https://github.com/date-fns/date-fns/tree/master/src/locale/en-US)
+- A detailed explanation of how to [add a new locale](https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/i18nContributionGuide.md#adding-a-new-locale).
+- Use [English locale](https://github.com/date-fns/date-fns/tree/main/pkgs/core/src/locale/en-US)
   as the basis and then incrementally adjust the tests and the code.
-- Directions on [adding a locale with the same language as another locale](https://github.com/date-fns/date-fns/blob/master/docs/i18nContributionGuide.md#creating-a-locale-with-the-same-language-as-another-locale).
+- Directions on [adding a locale with the same language as another locale](https://github.com/date-fns/date-fns/blob/main/pkgs/core/docs/i18nContributionGuide.md#creating-a-locale-with-the-same-language-as-another-locale).
 - If you have questions or need guidance, leave a comment in the issue.
 
 Thank you for your support!

--- a/pkgs/core/docs/i18nContributionGuide.md
+++ b/pkgs/core/docs/i18nContributionGuide.md
@@ -1011,7 +1011,7 @@ Your best guess is to copy `formatDistance` property from another locale and cha
 
 ### Tests
 
-To test locales we use snapshots. See [`en-US` snapshot](https://github.com/date-fns/date-fns/blob/master/src/locale/en-US/snapshot.md) for an example.
+To test locales we use snapshots. See [`en-US` snapshot](https://github.com/date-fns/date-fns/blob/main/pkgs/core/src/locale/en-US/snapshot.md) for an example.
 
 To generate snapshots, run `pnpm run locale-snapshots`. The snapshot for the locale
 you're working on will appear in the root locale directory (e.g. `src/locales/ru/snapshot.md`).


### PR DESCRIPTION
## Summary

- Updates broken `master/docs` and `master/src` links in `CONTRIBUTING.md`, `i18n.md`, and `i18nContributionGuide.md`
- Points links to the new `main/pkgs/core/...` paths after the monorepo migration

Related to #4226. Complements #4243, which fixes the `unicodeTokens.md` source links.

## Test plan

- [x] Verified updated URLs match existing files in the repository
- [x] Confirmed no remaining `blob/master` or `tree/master` links in the changed markdown files