### PR TITLE
docs: add format example for literal text in patterns

### DIFF
--- a/pkgs/core/src/format/index.ts
+++ b/pkgs/core/src/format/index.ts
@@ -339,6 +339,11 @@ export interface FormatOptions
  * //=> '2-a de julio 2014'
  *
  * @example
+ * // Include literal text by wrapping it in single quotes:
+ * const result = format(new Date(2014, 6, 2), "'Date:' MM/dd/yyyy")
+ * //=> 'Date: 07/02/2014'
+ *
+ * @example
  * // Escape string by single quote characters:
  * const result = format(new Date(2014, 6, 2, 15), "h 'o''clock'")
  * //=> "3 o'clock"


### PR DESCRIPTION
## Summary

- Adds a JSDoc example showing how to include literal text in a `format` pattern using single quotes
- Addresses confusion called out in #4209 where the escaping rules are easy to miss without a concrete example

Fixes #4209

## Test plan

- [x] Verified `format(new Date(2014, 6, 2), "'Date:' MM/dd/yyyy")` returns `Date: 07/02/2014`