### PR TITLE
fix(differenceInMonths): don't miscount a month across a DST spring-forward gap

### DIFF
--- a/pkgs/core/src/differenceInMonths/index.ts
+++ b/pkgs/core/src/differenceInMonths/index.ts
@@ -1,5 +1,6 @@
 import { normalizeDates } from "../_lib/normalizeDates/index.ts";
 import { compareAsc } from "../compareAsc/index.ts";
+import { constructFrom } from "../constructFrom/index.ts";
 import { differenceInCalendarMonths } from "../differenceInCalendarMonths/index.ts";
 import { isLastDayOfMonth } from "../isLastDayOfMonth/index.ts";
 import type { ContextOptions, DateArg } from "../types.ts";
@@ -47,9 +48,35 @@ export function differenceInMonths(
   if (workingLaterDate.getMonth() === 1 && workingLaterDate.getDate() > 27)
     workingLaterDate.setDate(30);
 
+  // Capture the wall-clock time before shifting the month back so we can
+  // detect a rare case below: if the shift lands on a local time that
+  // doesn't exist (a DST "spring forward" gap, e.g. 2:00 AM on the day
+  // clocks jump to 3:00 AM, or a 30-minute gap in some time zones), the
+  // engine silently normalizes it forward, which would otherwise corrupt
+  // the comparison that follows.
+  const workingLaterDateClockMinutes =
+    workingLaterDate.getHours() * 60 + workingLaterDate.getMinutes();
+
   workingLaterDate.setMonth(workingLaterDate.getMonth() - sign * difference);
 
-  let isLastMonthNotFull = compareAsc(workingLaterDate, earlierDate_) === -sign;
+  let isLastMonthNotFull: boolean;
+  if (
+    workingLaterDate.getHours() * 60 + workingLaterDate.getMinutes() !==
+    workingLaterDateClockMinutes
+  ) {
+    // The backward shift landed in a DST gap and got silently normalized,
+    // corrupting workingLaterDate. Shift earlierDate_ forward by the same
+    // number of months instead and compare against the untouched laterDate_
+    // - moving forward from a valid, already-normalized date can't land back
+    // in the same gap.
+    const workingEarlierDate = constructFrom(earlierDate_, +earlierDate_);
+    workingEarlierDate.setMonth(
+      workingEarlierDate.getMonth() + sign * difference,
+    );
+    isLastMonthNotFull = compareAsc(workingEarlierDate, laterDate_) === sign;
+  } else {
+    isLastMonthNotFull = compareAsc(workingLaterDate, earlierDate_) === -sign;
+  }
 
   if (
     isLastDayOfMonth(laterDate_) &&

--- a/pkgs/core/src/differenceInMonths/test.ts
+++ b/pkgs/core/src/differenceInMonths/test.ts
@@ -1,5 +1,6 @@
 import { TZDate, tz } from "@date-fns/tz";
 import { describe, expect, it } from "vitest";
+import { getDstTransitions } from "../_lib/test/tzOffsetTransitions.ts";
 import type { ContextOptions, DateArg } from "../types.ts";
 import { differenceInMonths } from "./index.ts";
 
@@ -122,6 +123,62 @@ describe("differenceInMonths", () => {
       const resultIsNegative = isNegativeZero(result);
       expect(resultIsNegative).toBe(false);
     });
+  });
+
+  describe("DST", () => {
+    // https://github.com/date-fns/date-fns/issues/1758
+    // Regression test: a period that is one DST-gap-sized interval short of a
+    // full month must not be miscounted as a full month just because the
+    // internal month-shifting arithmetic happens to land on a local time
+    // that doesn't exist (a spring-forward gap, e.g. 2:00-2:59 AM on the day
+    // clocks jump to 3:00 AM).
+    for (const year of [2020, 2021, 2022, 2023, 2024]) {
+      const dstTransitions = getDstTransitions(year);
+      const { start } = dstTransitions;
+      const dstOnly = start ? it : it.skip;
+      const tz =
+        Intl.DateTimeFormat().resolvedOptions().timeZone || process.env.TZ;
+
+      dstOnly(
+        `does not count a month across a DST spring-forward gap (${year}): ${tz || "(unknown)"}`,
+        () => {
+          if (!start) return;
+
+          const gapMinutes =
+            new Date(start.getTime() - 1).getTimezoneOffset() -
+            start.getTimezoneOffset();
+          const gapMinutesTotal =
+            start.getHours() * 60 + start.getMinutes() - gapMinutes;
+          const gapHour = ((Math.floor(gapMinutesTotal / 60) % 24) + 24) % 24;
+          const gapMinute = ((gapMinutesTotal % 60) + 60) % 60;
+
+          // A perfectly ordinary time one month after the transition, at
+          // the wall-clock reading that falls inside the gap back in the
+          // transition month.
+          const laterDate = new Date(
+            start.getFullYear(),
+            start.getMonth() + 1,
+            start.getDate(),
+            gapHour,
+            gapMinute,
+          );
+          // Skip years/zones where the transition day doesn't exist in the
+          // following month (e.g. day 31 in a 30-day month) - not what this
+          // test is checking.
+          if (laterDate.getMonth() !== (start.getMonth() + 1) % 12) return;
+
+          const earlierDate = new Date(
+            start.getFullYear(),
+            start.getMonth(),
+            start.getDate(),
+            start.getHours(),
+            start.getMinutes(),
+          );
+
+          expect(differenceInMonths(laterDate, earlierDate)).toBe(0);
+        },
+      );
+    }
   });
 
   it("returns NaN if the first date is `Invalid Date`", () => {


### PR DESCRIPTION
**Disclosure:** I'm an AI coding agent (operating as `@MayzrBot`), not a human. This PR was written and tested by me, under human supervision but without a human writing the code. Happy to answer questions or make changes if a maintainer would like something done differently.

Fixes #1758.

## The bug

`differenceInMonths` checks whether the final month of a period is "full" by taking a copy of the later date, shifting it *backward* by the candidate month count, and comparing that against the earlier date.

If that backward shift lands on a local wall-clock time that doesn't exist — a DST "spring forward" gap, e.g. 2:00–2:59 AM on the day clocks jump from 2:00 to 3:00 — the JS engine silently normalizes the `Date` forward into the next valid time. That happens the moment the field is set, before any comparison code runs, so the information needed to tell the two dates apart is already gone by the time they're compared. The result: a period that's actually one DST-gap short of a full month gets reported as a full month.

Repro from the issue, under `TZ=America/Los_Angeles`:
```js
differenceInMonths(new Date(2020, 3, 8, 2), new Date(2020, 2, 8, 3)) // => 1, should be 0
```

## The fix

Capture the later date's wall-clock minutes-of-day before the backward shift. If they don't match after `setMonth()`, the shift landed in a gap and got silently renormalized — so fall back to shifting a copy of the *earlier* date *forward* by the same number of months instead, and compare that against the untouched later date. Moving forward from an already-valid date can't land back in the same gap.

This only changes behavior for the specific case that was already provably wrong (the shift landing in a DST gap). Verified the scope is narrow by fuzzing 500k random date pairs against the original (pre-fix) algorithm's output, in both a UTC-only environment and `TZ=America/Los_Angeles`: **zero mismatches**. (I also tried a simpler redesign — always shift the earlier date forward instead of conditionally — but that changed ~0.025% of unrelated date-pair results involving month-end-day comparisons, so I discarded it in favor of the narrower, detect-and-fallback version here.)

## Testing

- Added a `describe("DST")` regression test, modeled on the existing pattern in `differenceInDays/test.ts` (uses `getDstTransitions`, gated to only run in DST-observing zones/years). It constructs a later date one calendar month after a real DST transition, at the wall-clock time that falls inside that transition's gap, and asserts the difference is `0`. Confirmed this construction actually fails on the unpatched code (returns `1`) across multiple real zones, including a 30-minute-offset zone (`Australia/Lord_Howe`), not just US-style 1-hour zones.
- All 13 pre-existing edge-case tests still pass, unchanged.
- Ran the full test file across 8 timezones (`UTC`, `America/Los_Angeles`, `Europe/London`, `Australia/Lord_Howe`, `Europe/Paris`, `Pacific/Chatham`, `Australia/Sydney`, `America/Sao_Paulo`, `Asia/Tokyo`) — all green; non-DST zones/years correctly skip the new DST-only cases.
- Ran the full repo test suite (`vitest run`, no TZ override): 3148 passed, 33 skipped, 37 failed — but confirmed via `git stash` that those same 37 failures (`Temporal is not defined`) exist identically on unmodified `main` in this environment (Node 20 vs. a `Temporal` global gap), unrelated to this change. Zero new failures introduced.
- Ran `oxfmt` on both changed files.
- Could not run `oxlint --type-aware` locally — it fails on unmodified `main` too in my sandbox (`tsgolint` config error), so I couldn't verify lint cleanliness beyond `oxfmt`. Happy to fix anything CI flags.
