### PR TITLE
docs: Put documentation for subSeconds/subMilliseconds back in the correct categories

### DIFF
--- a/pkgs/core/src/subMilliseconds/index.ts
+++ b/pkgs/core/src/subMilliseconds/index.ts
@@ -9,6 +9,11 @@ export interface SubMillisecondsOptions<
 > extends ContextOptions<DateType> {}
 
 /**
+ * @name subMilliseconds
+ * @category Millisecond Helpers
+ * @summary Subtract the specified number of milliseconds from the given date.
+ *
+ * @description
  * Subtract the specified number of milliseconds from the given date.
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).

--- a/pkgs/core/src/subSeconds/index.ts
+++ b/pkgs/core/src/subSeconds/index.ts
@@ -9,6 +9,11 @@ export interface SubSecondsOptions<
 > extends ContextOptions<DateType> {}
 
 /**
+ * @name subSeconds
+ * @category Second Helpers
+ * @summary Subtract the specified number of seconds from the given date.
+ *
+ * @description
  * Subtract the specified number of seconds from the given date.
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).


### PR DESCRIPTION
Fixes #3918

From v4.0.0 onwards, the documentation from these functions has been in the "misc" category. This pull request re-adds the documentation attributes to place the functions in the correct place on the docs site.