### PR TITLE
fix(fromUnixTime): document that fractional seconds are preserved as milliseconds

### DIFF
--- a/pkgs/core/src/fromUnixTime/index.ts
+++ b/pkgs/core/src/fromUnixTime/index.ts
@@ -14,7 +14,8 @@ export interface FromUnixTimeOptions<
  * @summary Create a date from a Unix timestamp.
  *
  * @description
- * Create a date from a Unix timestamp (in seconds). Decimal values will be discarded.
+ * Create a date from a Unix timestamp (in seconds). Fractional seconds are
+ * preserved as milliseconds.
  *
  * @param unixTime - The given Unix timestamp (in seconds)
  * @param options - An object with options. Allows to pass a context.

--- a/pkgs/core/src/fromUnixTime/test.ts
+++ b/pkgs/core/src/fromUnixTime/test.ts
@@ -9,6 +9,23 @@ describe("fromUnixTime", () => {
     expect(result.getTime()).toBe(1330515499000);
   });
 
+  it("preserves fractional seconds as milliseconds", () => {
+    // The implementation multiplies by 1000, so fractional seconds in the
+    // Unix timestamp become milliseconds. The docs previously (incorrectly)
+    // stated that decimal values would be discarded — these tests pin the
+    // actual behavior. See #4248.
+    const result = fromUnixTime(1640888727.872);
+    expect(result.getTime()).toBe(1640888727872);
+  });
+
+  it("preserves small fractional values as milliseconds", () => {
+    expect(fromUnixTime(0.001).getTime()).toBe(1);
+  });
+
+  it("preserves negative fractional values as milliseconds", () => {
+    expect(fromUnixTime(-0.001).getTime()).toBe(-1);
+  });
+
   it("returns invalid if the given timestamp is invalid", () => {
     const result = fromUnixTime(NaN);
     expect(isNaN(result.getTime())).toBe(true);


### PR DESCRIPTION
## Summary

Closes #4248 — the `fromUnixTime` documentation said "Decimal values will be discarded," but the implementation (`toDate(unixTime * 1000, ...)`) **preserves fractional seconds as milliseconds** and has done so since the function was introduced (see #1917).

## The fix

Two parts:

**`pkgs/core/src/fromUnixTime/index.ts`** — corrected the `@description` to state that fractional seconds are preserved as milliseconds (one-line doc fix; no behavior change).

**`pkgs/core/src/fromUnixTime/test.ts`** — added three regression tests pinning the actual behavior:
- `fromUnixTime(1640888727.872)` → `1640888727872` (fractional seconds → ms)
- `fromUnixTime(0.001)` → `1` (small fractional → 1ms)
- `fromUnixTime(-0.001)` → `-1` (negative fractional → -1ms)

I chose to fix the docs (not change the implementation to truncate), because truncating would be a breaking change for anyone relying on the current fractional-second behavior, while the doc fix is safe and aligns the documented contract with the actual behavior. The reporter provided the exact test cases.

## AI usage

An AI assistant was used to help locate the relevant code and draft this change. I have reviewed and understand every line of the diff, and I am the sole author of this contribution.

Closes #4248