### PR TITLE
feat: getAge: exact calendar age in years, months, days

### DIFF
--- a/pkgs/core/src/getAge/index.ts
+++ b/pkgs/core/src/getAge/index.ts
@@ -1,0 +1,44 @@
+import { intervalToDuration } from "../intervalToDuration/index.js";
+
+/**
+ * @name getAge
+ * @category Interval Helpers
+ * @summary Returns the exact calendar age of `dateOfBirth` as of `today` (or now),
+ * broken into years, months, and days.
+ *
+ * @description
+ * Computes the calendar-accurate age of a person (or thing) — e.g.
+ * `22 years 6 months 27 days` — accounting for varying month lengths (28–31
+ * days) and leap years, unlike naive 365-day/30-day approximations. Built on
+ * {@link intervalToDuration}. See issue #840.
+ *
+ * @param dateOfBirth - The date of birth.
+ * @param options - Optional `{ today }` reference date (defaults to the current
+ * time). Pass a fixed `today` for deterministic results.
+ * @returns An object with `years`, `months`, and `days`. If `today` is on or
+ * before `dateOfBirth`, all values are `0`.
+ *
+ * @example
+ * // Exact age as of a reference date
+ * getAge(new Date(2000, 0, 1), { today: new Date(2022, 6, 28) })
+ * //=> { years: 22, months: 6, days: 27 }
+ */
+export function getAge(
+  dateOfBirth: Date,
+  options: { today?: Date | number | string } = {},
+): { years: number; months: number; days: number } {
+  const todayRaw = options.today ?? Date.now();
+  const today = todayRaw instanceof Date ? todayRaw : new Date(todayRaw);
+
+  if (today.getTime() <= dateOfBirth.getTime()) {
+    return { years: 0, months: 0, days: 0 };
+  }
+
+  const duration = intervalToDuration({ start: dateOfBirth, end: today });
+
+  return {
+    years: duration.years ?? 0,
+    months: duration.months ?? 0,
+    days: duration.days ?? 0,
+  };
+}

--- a/pkgs/core/src/index.ts
+++ b/pkgs/core/src/index.ts
@@ -72,6 +72,7 @@ export * from "./formatDuration/index.ts";
 export * from "./formatISO/index.ts";
 export * from "./formatISO9075/index.ts";
 export * from "./formatISODuration/index.ts";
+export { getAge } from "./getAge/index.ts";
 export * from "./formatRFC3339/index.ts";
 export * from "./formatRFC7231/index.ts";
 export * from "./formatRelative/index.ts";


### PR DESCRIPTION
Closes #840.

Add getAge(dateOfBirth, { today }): built on intervalToDuration: returning { years, months, days }, the calendar accurate age as of an optional reference date (defaults to now). Accepts today as a Date, timestamp number, or ISO string. Returns zeros if today is on or before the birthdate.