### PR TITLE
Add tests to fill unit test coverage gaps

### DIFF
--- a/pkgs/core/src/formatDuration/test.ts
+++ b/pkgs/core/src/formatDuration/test.ts
@@ -73,4 +73,17 @@ describe("formatDuration", () => {
       "9 months, 2 days",
     );
   });
+
+  it("returns an empty string if the locale has no formatDistance", () => {
+    // characterizes current behavior; not asserting correctness
+    expect(
+      formatDuration(
+        { months: 9 },
+        {
+          // @ts-expect-error - It's ok to have incomplete locale
+          locale: {},
+        },
+      ),
+    ).toBe("");
+  });
 });

--- a/pkgs/core/src/intlFormatDistance/test.ts
+++ b/pkgs/core/src/intlFormatDistance/test.ts
@@ -624,6 +624,46 @@ describe("intlFormatDistance", () => {
           expect(result).toBe("53 weeks ago");
         });
       });
+
+      describe("months", () => {
+        it("works with the future", () => {
+          const result = intlFormatDistance(
+            new Date(1986, 7, 4, 10, 30, 0),
+            new Date(1986, 3, 4, 10, 30, 0),
+            { unit: "month" },
+          );
+          expect(result).toBe("in 4 months");
+        });
+
+        it("works with the past", () => {
+          const result = intlFormatDistance(
+            new Date(1986, 3, 4, 10, 30, 0),
+            new Date(1986, 7, 4, 10, 30, 0),
+            { unit: "month" },
+          );
+          expect(result).toBe("4 months ago");
+        });
+      });
+
+      describe("years", () => {
+        it("works with the future", () => {
+          const result = intlFormatDistance(
+            new Date(1988, 3, 4, 10, 30, 0),
+            new Date(1986, 3, 4, 10, 30, 0),
+            { unit: "year" },
+          );
+          expect(result).toBe("in 2 years");
+        });
+
+        it("works with the past", () => {
+          const result = intlFormatDistance(
+            new Date(1986, 3, 4, 10, 30, 0),
+            new Date(1988, 3, 4, 10, 30, 0),
+            { unit: "year" },
+          );
+          expect(result).toBe("2 years ago");
+        });
+      });
     });
 
     describe("numeric option", () => {

--- a/pkgs/core/src/locale/eo/test.ts
+++ b/pkgs/core/src/locale/eo/test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { format } from "../../format/index.ts";
+import { formatDistance } from "../../formatDistance/index.ts";
+import { parse } from "../../parse/index.ts";
+import { eo } from "./index.ts";
+
+describe("eo locale", () => {
+  describe("formatDistance", () => {
+    it("returns the singular form for one unit", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 4, 10, 33),
+        new Date(1986, 3 /* Apr */, 4, 10, 32),
+        { locale: eo },
+      );
+      expect(result).toBe("1 minuto");
+    });
+
+    it("returns the plural form with the count for multiple units", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 19),
+        new Date(1986, 3 /* Apr */, 4),
+        { locale: eo },
+      );
+      expect(result).toBe("15 tagoj");
+    });
+
+    it("returns the invariable form for half a minute", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 4, 10, 32, 25),
+        new Date(1986, 3 /* Apr */, 4, 10, 32, 0),
+        { locale: eo, includeSeconds: true },
+      );
+      expect(result).toBe("duonminuto");
+    });
+
+    it("adds the future suffix when `addSuffix` is true", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 19),
+        new Date(1986, 3 /* Apr */, 4),
+        { locale: eo, addSuffix: true },
+      );
+      expect(result).toBe("post 15 tagoj");
+    });
+
+    it("adds the past suffix when `addSuffix` is true", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 4),
+        new Date(1986, 3 /* Apr */, 19),
+        { locale: eo, addSuffix: true },
+      );
+      expect(result).toBe("antaŭ 15 tagoj");
+    });
+  });
+
+  describe("ordinalNumber", () => {
+    it("formats an ordinal number with the `-a` suffix", () => {
+      const result = format(new Date(2014, 3 /* Apr */, 7), "do", {
+        locale: eo,
+      });
+      expect(result).toBe("7-a");
+    });
+  });
+
+  describe("quarter", () => {
+    it("formats a wide quarter", () => {
+      const result = format(new Date(2014, 3 /* Apr */, 7), "QQQQ", {
+        locale: eo,
+      });
+      expect(result).toBe("2-a kvaronjaro");
+    });
+
+    it("parses a wide quarter", () => {
+      const result = parse(
+        "1-a kvaronjaro",
+        "QQQQ",
+        new Date(1986, 3 /* Apr */, 4),
+        { locale: eo },
+      );
+      expect(result).toEqual(new Date(1986, 0 /* Jan */, 1));
+    });
+  });
+});

--- a/pkgs/core/src/locale/fr/test.ts
+++ b/pkgs/core/src/locale/fr/test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { format } from "../../format/index.ts";
+import { formatDistance } from "../../formatDistance/index.ts";
+import { formatRelative } from "../../formatRelative/index.ts";
+import { parse } from "../../parse/index.ts";
 import { fr } from "./index.ts";
 
 describe("fr locale", () => {
@@ -32,6 +35,106 @@ describe("fr locale", () => {
         });
         expect(result).toBe(expectedResult);
       });
+    });
+  });
+
+  describe("formatDistance", () => {
+    it("returns the singular form for one unit", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 4, 10, 33),
+        new Date(1986, 3 /* Apr */, 4, 10, 32),
+        { locale: fr },
+      );
+      expect(result).toBe("1 minute");
+    });
+
+    it("returns the plural form with the count for multiple units", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 4, 10, 32, 3),
+        new Date(1986, 3 /* Apr */, 4, 10, 32, 0),
+        { locale: fr, includeSeconds: true },
+      );
+      expect(result).toBe("moins de 5 secondes");
+    });
+
+    it("returns the invariable form for half a minute", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 4, 10, 32, 25),
+        new Date(1986, 3 /* Apr */, 4, 10, 32, 0),
+        { locale: fr, includeSeconds: true },
+      );
+      expect(result).toBe("30 secondes");
+    });
+
+    it("adds the future suffix when `addSuffix` is true", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 19),
+        new Date(1986, 3 /* Apr */, 4),
+        { locale: fr, addSuffix: true },
+      );
+      expect(result).toBe("dans 15 jours");
+    });
+
+    it("adds the past suffix when `addSuffix` is true", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 4),
+        new Date(1986, 3 /* Apr */, 19),
+        { locale: fr, addSuffix: true },
+      );
+      expect(result).toBe("il y a 15 jours");
+    });
+  });
+
+  describe("formatRelative", () => {
+    it("formats a date from the last week", () => {
+      const result = formatRelative(
+        new Date(1986, 3 /* Apr */, 1, 10, 32),
+        new Date(1986, 3 /* Apr */, 4, 10, 32),
+        { locale: fr },
+      );
+      expect(result).toBe("mardi dernier à 10:32");
+    });
+  });
+
+  describe("ordinalNumber", () => {
+    it("returns `0` without a suffix for zero", () => {
+      const result = format(new Date(2014, 3 /* Apr */, 7, 5, 9, 0), "so", {
+        locale: fr,
+      });
+      expect(result).toBe("0");
+    });
+
+    it("uses the feminine suffix for feminine units", () => {
+      const result = format(new Date(2014, 3 /* Apr */, 7, 1), "ho", {
+        locale: fr,
+      });
+      expect(result).toBe("1ère");
+    });
+
+    it("parses an ordinal day of the month", () => {
+      const result = parse("2e", "do", new Date(1986, 3 /* Apr */, 4), {
+        locale: fr,
+      });
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 2));
+    });
+  });
+
+  describe("quarter", () => {
+    it("formats an abbreviated quarter", () => {
+      const result = format(new Date(2014, 3 /* Apr */, 7), "QQQ", {
+        locale: fr,
+      });
+      expect(result).toBe("2ème trim.");
+    });
+
+    it("parses a wide quarter", () => {
+      const result = parse(
+        "1er trimestre",
+        "QQQQ",
+        new Date(1986, 3 /* Apr */, 4),
+        { locale: fr },
+      );
+      expect(result).toEqual(new Date(1986, 0 /* Jan */, 1));
     });
   });
 });

--- a/pkgs/core/src/locale/zh-CN/test.ts
+++ b/pkgs/core/src/locale/zh-CN/test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { format } from "../../format/index.ts";
+import { formatDistance } from "../../formatDistance/index.ts";
+import { formatRelative } from "../../formatRelative/index.ts";
 import { parse } from "../../parse/index.ts";
 import { zhCN } from "./index.ts";
 
@@ -29,5 +32,164 @@ describe("zh-CN locale", () => {
         locale: zhCN,
       }),
     ).toEqual(new Date(2022, 11 /* Dec */, 27));
+  });
+
+  describe("formatDistance", () => {
+    it("returns the singular form for one unit", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 4, 10, 33),
+        new Date(1986, 3 /* Apr */, 4, 10, 32),
+        { locale: zhCN },
+      );
+      expect(result).toBe("1 分钟");
+    });
+
+    it("returns the plural form with the count for multiple units", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 4, 10, 32, 3),
+        new Date(1986, 3 /* Apr */, 4, 10, 32, 0),
+        { locale: zhCN, includeSeconds: true },
+      );
+      expect(result).toBe("不到 5 秒");
+    });
+
+    it("returns the invariable form for half a minute", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 4, 10, 32, 25),
+        new Date(1986, 3 /* Apr */, 4, 10, 32, 0),
+        { locale: zhCN, includeSeconds: true },
+      );
+      expect(result).toBe("半分钟");
+    });
+
+    it("adds the future suffix when `addSuffix` is true", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 19),
+        new Date(1986, 3 /* Apr */, 4),
+        { locale: zhCN, addSuffix: true },
+      );
+      expect(result).toBe("15 天内");
+    });
+
+    it("adds the past suffix when `addSuffix` is true", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 4),
+        new Date(1986, 3 /* Apr */, 19),
+        { locale: zhCN, addSuffix: true },
+      );
+      expect(result).toBe("15 天前");
+    });
+  });
+
+  describe("formatRelative", () => {
+    // In these tests the base date is Friday, April 4, 1986, and the week
+    // starts on Monday (see `zhCN.options.weekStartsOn`).
+    const baseDate = new Date(1986, 3 /* Apr */, 4, 10, 32);
+
+    it("uses no qualifier for a date within the same week", () => {
+      const result = formatRelative(
+        new Date(1986, 3 /* Apr */, 2, 10, 32),
+        baseDate,
+        { locale: zhCN },
+      );
+      expect(result).toBe("星期三 上午 10:32");
+    });
+
+    it("uses the last week qualifier for a date in the previous week", () => {
+      const result = formatRelative(
+        new Date(1986, 2 /* Mar */, 30, 10, 32),
+        baseDate,
+        { locale: zhCN },
+      );
+      expect(result).toBe("上个星期日 上午 10:32");
+    });
+
+    it("uses the next week qualifier for a date in the following week", () => {
+      const result = formatRelative(
+        new Date(1986, 3 /* Apr */, 7, 10, 32),
+        baseDate,
+        { locale: zhCN },
+      );
+      expect(result).toBe("下个星期一 上午 10:32");
+    });
+
+    it("uses no qualifier for a later date within the same week", () => {
+      const result = formatRelative(
+        new Date(1986, 3 /* Apr */, 6, 10, 32),
+        baseDate,
+        { locale: zhCN },
+      );
+      expect(result).toBe("星期日 上午 10:32");
+    });
+
+    it("formats tomorrow", () => {
+      const result = formatRelative(
+        new Date(1986, 3 /* Apr */, 5, 10, 32),
+        baseDate,
+        { locale: zhCN },
+      );
+      expect(result).toBe("明天 上午 10:32");
+    });
+  });
+
+  describe("ordinalNumber", () => {
+    it("formats ordinal date, hour, minute and second", () => {
+      const date = new Date(2014, 3 /* Apr */, 7, 5, 9, 3);
+      expect(format(date, "do", { locale: zhCN })).toBe("7日");
+      expect(format(date, "ho", { locale: zhCN })).toBe("5时");
+      expect(format(date, "mo", { locale: zhCN })).toBe("9分");
+      expect(format(date, "so", { locale: zhCN })).toBe("3秒");
+    });
+
+    it("formats other ordinal units with the generic prefix", () => {
+      const result = format(new Date(2014, 3 /* Apr */, 7), "wo", {
+        locale: zhCN,
+      });
+      expect(result).toBe("第 15");
+    });
+
+    it("parses an ordinal date", () => {
+      const result = parse("7日", "do", new Date(1986, 3 /* Apr */, 4), {
+        locale: zhCN,
+      });
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 7));
+    });
+  });
+
+  describe("quarter", () => {
+    it("formats an abbreviated and a wide quarter", () => {
+      const date = new Date(2014, 3 /* Apr */, 7);
+      expect(format(date, "QQQ", { locale: zhCN })).toBe("第二季");
+      expect(format(date, "QQQQ", { locale: zhCN })).toBe("第二季度");
+    });
+
+    it("parses an ordinal quarter", () => {
+      const result = parse("第 3", "Qo", new Date(1986, 3 /* Apr */, 4), {
+        locale: zhCN,
+      });
+      expect(result).toEqual(new Date(1986, 6 /* Jul */, 1));
+    });
+  });
+
+  describe("era", () => {
+    it("parses the narrow B.C. era when the abbreviated one doesn't match", () => {
+      const result = parse("前", "G", new Date(1986, 3 /* Apr */, 4), {
+        locale: zhCN,
+      });
+      const expectedResult = new Date(0);
+      expectedResult.setFullYear(0, 0 /* Jan */, 1);
+      expectedResult.setHours(0, 0, 0, 0);
+      expect(result).toEqual(expectedResult);
+    });
+
+    it("parses the narrow B.C. era with the wide token", () => {
+      const result = parse("前", "GGGG", new Date(1986, 3 /* Apr */, 4), {
+        locale: zhCN,
+      });
+      const expectedResult = new Date(0);
+      expectedResult.setFullYear(0, 0 /* Jan */, 1);
+      expectedResult.setHours(0, 0, 0, 0);
+      expect(result).toEqual(expectedResult);
+    });
   });
 });

--- a/pkgs/core/src/locale/zh-HK/test.ts
+++ b/pkgs/core/src/locale/zh-HK/test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { format } from "../../format/index.ts";
+import { formatDistance } from "../../formatDistance/index.ts";
+import { formatRelative } from "../../formatRelative/index.ts";
 import { parse } from "../../parse/index.ts";
 import { zhHK } from "./index.ts";
 
@@ -29,5 +32,109 @@ describe("zh-HK locale", () => {
         locale: zhHK,
       }),
     ).toEqual(new Date(2022, 11 /* Dec */, 27));
+  });
+
+  describe("formatDistance", () => {
+    it("returns the singular form for one unit", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 4, 10, 33),
+        new Date(1986, 3 /* Apr */, 4, 10, 32),
+        { locale: zhHK },
+      );
+      expect(result).toBe("1 分鐘");
+    });
+
+    it("returns the plural form with the count for multiple units", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 4, 10, 32, 3),
+        new Date(1986, 3 /* Apr */, 4, 10, 32, 0),
+        { locale: zhHK, includeSeconds: true },
+      );
+      expect(result).toBe("少於 5 秒");
+    });
+
+    it("returns the invariable form for half a minute", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 4, 10, 32, 25),
+        new Date(1986, 3 /* Apr */, 4, 10, 32, 0),
+        { locale: zhHK, includeSeconds: true },
+      );
+      expect(result).toBe("半分鐘");
+    });
+
+    it("adds the future suffix when `addSuffix` is true", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 19),
+        new Date(1986, 3 /* Apr */, 4),
+        { locale: zhHK, addSuffix: true },
+      );
+      expect(result).toBe("15 天內");
+    });
+
+    it("adds the past suffix when `addSuffix` is true", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 4),
+        new Date(1986, 3 /* Apr */, 19),
+        { locale: zhHK, addSuffix: true },
+      );
+      expect(result).toBe("15 天前");
+    });
+  });
+
+  describe("formatRelative", () => {
+    it("formats yesterday", () => {
+      const result = formatRelative(
+        new Date(1986, 3 /* Apr */, 3, 10, 32),
+        new Date(1986, 3 /* Apr */, 4, 10, 32),
+        { locale: zhHK },
+      );
+      expect(result).toBe("昨天 上午 10:32");
+    });
+  });
+
+  describe("ordinalNumber", () => {
+    it("formats ordinal date, hour, minute and second", () => {
+      const date = new Date(2014, 3 /* Apr */, 7, 5, 9, 3);
+      expect(format(date, "do", { locale: zhHK })).toBe("7日");
+      expect(format(date, "ho", { locale: zhHK })).toBe("5時");
+      expect(format(date, "mo", { locale: zhHK })).toBe("9分");
+      expect(format(date, "so", { locale: zhHK })).toBe("3秒");
+    });
+
+    it("formats other ordinal units with the generic prefix", () => {
+      const result = format(new Date(2014, 3 /* Apr */, 7), "wo", {
+        locale: zhHK,
+      });
+      expect(result).toBe("第 15");
+    });
+
+    it("parses an ordinal date", () => {
+      const result = parse("7日", "do", new Date(1986, 3 /* Apr */, 4), {
+        locale: zhHK,
+      });
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 7));
+    });
+  });
+
+  describe("quarter", () => {
+    it("formats an abbreviated and a wide quarter", () => {
+      const date = new Date(2014, 3 /* Apr */, 7);
+      expect(format(date, "QQQ", { locale: zhHK })).toBe("第二季");
+      expect(format(date, "QQQQ", { locale: zhHK })).toBe("第二季度");
+    });
+
+    it("parses an ordinal quarter", () => {
+      const result = parse("第 3", "Qo", new Date(1986, 3 /* Apr */, 4), {
+        locale: zhHK,
+      });
+      expect(result).toEqual(new Date(1986, 6 /* Jul */, 1));
+    });
+
+    it("parses an abbreviated quarter", () => {
+      const result = parse("第三季", "QQQ", new Date(1986, 3 /* Apr */, 4), {
+        locale: zhHK,
+      });
+      expect(result).toEqual(new Date(1986, 6 /* Jul */, 1));
+    });
   });
 });

--- a/pkgs/core/src/locale/zh-TW/test.ts
+++ b/pkgs/core/src/locale/zh-TW/test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { format } from "../../format/index.ts";
+import { formatDistance } from "../../formatDistance/index.ts";
+import { formatRelative } from "../../formatRelative/index.ts";
 import { parse } from "../../parse/index.ts";
 import { zhTW } from "./index.ts";
 
@@ -29,5 +32,109 @@ describe("zh-TW locale", () => {
         locale: zhTW,
       }),
     ).toEqual(new Date(2022, 11 /* Dec */, 27));
+  });
+
+  describe("formatDistance", () => {
+    it("returns the singular form for one unit", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 4, 10, 33),
+        new Date(1986, 3 /* Apr */, 4, 10, 32),
+        { locale: zhTW },
+      );
+      expect(result).toBe("1 分鐘");
+    });
+
+    it("returns the plural form with the count for multiple units", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 4, 10, 32, 3),
+        new Date(1986, 3 /* Apr */, 4, 10, 32, 0),
+        { locale: zhTW, includeSeconds: true },
+      );
+      expect(result).toBe("少於 5 秒");
+    });
+
+    it("returns the invariable form for half a minute", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 4, 10, 32, 25),
+        new Date(1986, 3 /* Apr */, 4, 10, 32, 0),
+        { locale: zhTW, includeSeconds: true },
+      );
+      expect(result).toBe("半分鐘");
+    });
+
+    it("adds the future suffix when `addSuffix` is true", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 19),
+        new Date(1986, 3 /* Apr */, 4),
+        { locale: zhTW, addSuffix: true },
+      );
+      expect(result).toBe("15 天內");
+    });
+
+    it("adds the past suffix when `addSuffix` is true", () => {
+      const result = formatDistance(
+        new Date(1986, 3 /* Apr */, 4),
+        new Date(1986, 3 /* Apr */, 19),
+        { locale: zhTW, addSuffix: true },
+      );
+      expect(result).toBe("15 天前");
+    });
+  });
+
+  describe("formatRelative", () => {
+    it("formats yesterday", () => {
+      const result = formatRelative(
+        new Date(1986, 3 /* Apr */, 3, 10, 32),
+        new Date(1986, 3 /* Apr */, 4, 10, 32),
+        { locale: zhTW },
+      );
+      expect(result).toBe("昨天 上午 10:32");
+    });
+  });
+
+  describe("ordinalNumber", () => {
+    it("formats ordinal date, hour, minute and second", () => {
+      const date = new Date(2014, 3 /* Apr */, 7, 5, 9, 3);
+      expect(format(date, "do", { locale: zhTW })).toBe("7日");
+      expect(format(date, "ho", { locale: zhTW })).toBe("5時");
+      expect(format(date, "mo", { locale: zhTW })).toBe("9分");
+      expect(format(date, "so", { locale: zhTW })).toBe("3秒");
+    });
+
+    it("formats other ordinal units with the generic prefix", () => {
+      const result = format(new Date(2014, 3 /* Apr */, 7), "wo", {
+        locale: zhTW,
+      });
+      expect(result).toBe("第 15");
+    });
+
+    it("parses an ordinal date", () => {
+      const result = parse("7日", "do", new Date(1986, 3 /* Apr */, 4), {
+        locale: zhTW,
+      });
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 7));
+    });
+  });
+
+  describe("quarter", () => {
+    it("formats an abbreviated and a wide quarter", () => {
+      const date = new Date(2014, 3 /* Apr */, 7);
+      expect(format(date, "QQQ", { locale: zhTW })).toBe("第二刻");
+      expect(format(date, "QQQQ", { locale: zhTW })).toBe("第二刻鐘");
+    });
+
+    it("parses an ordinal quarter", () => {
+      const result = parse("第 3", "Qo", new Date(1986, 3 /* Apr */, 4), {
+        locale: zhTW,
+      });
+      expect(result).toEqual(new Date(1986, 6 /* Jul */, 1));
+    });
+
+    it("parses an abbreviated quarter", () => {
+      const result = parse("第三刻", "QQQ", new Date(1986, 3 /* Apr */, 4), {
+        locale: zhTW,
+      });
+      expect(result).toEqual(new Date(1986, 6 /* Jul */, 1));
+    });
   });
 });

--- a/pkgs/core/src/parse/test.ts
+++ b/pkgs/core/src/parse/test.ts
@@ -46,6 +46,12 @@ describe("parse", () => {
       expect(result).toEqual(new Date(-43, 0 /* Jan */, 1));
     });
 
+    it("falls back to the abbreviated variant when the wide one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      const result = parse("2018 AD", "yyyy GGGG", referenceDate);
+      expect(result).toEqual(new Date(2018, 0 /* Jan */, 1));
+    });
+
     it("with week-numbering year", () => {
       const result = parse("44 B", "Y GGGGG", referenceDate);
       expect(result).toEqual(new Date(-44, 11 /* Dec */, 30));
@@ -109,6 +115,46 @@ describe("parse", () => {
       it("gets the 100 year range from `referenceDate`", () => {
         const result = parse("02", "yy", new Date(1860, 6 /* Jul */, 2));
         expect(result).toEqual(new Date(1902, 0 /* Jan */, 1));
+      });
+
+      it("gets the previous century when the two-digit year is more than fifty years ahead of `referenceDate`", () => {
+        // See the `yy` example in the docs:
+        // parse('75', 'yy', new Date(2018, 0, 1)) //=> Wed Jan 01 1975 00:00:00
+        const result = parse("75", "yy", new Date(2018, 0 /* Jan */, 1));
+        expect(result).toEqual(new Date(1975, 0 /* Jan */, 1));
+      });
+
+      it("works when `referenceDate` is in the first fifty years of the Common Era", () => {
+        // characterizes current behavior; not asserting correctness
+        const earlyReferenceDate = new Date(1986, 0 /* Jan */, 1);
+        earlyReferenceDate.setFullYear(25);
+        const result = parse("02", "yy", earlyReferenceDate);
+        const expectedResult = new Date(0);
+        expectedResult.setFullYear(2, 0 /* Jan */, 1);
+        expectedResult.setHours(0, 0, 0, 0);
+        expect(result).toEqual(expectedResult);
+      });
+
+      it("interprets the two-digit year zero as year 100 when `referenceDate` is in the first fifty years of the Common Era", () => {
+        // characterizes current behavior; not asserting correctness
+        const earlyReferenceDate = new Date(1986, 0 /* Jan */, 1);
+        earlyReferenceDate.setFullYear(25);
+        const result = parse("00", "yy", earlyReferenceDate);
+        const expectedResult = new Date(0);
+        expectedResult.setFullYear(100, 0 /* Jan */, 1);
+        expectedResult.setHours(0, 0, 0, 0);
+        expect(result).toEqual(expectedResult);
+      });
+
+      it("works when `referenceDate` is a B.C. year", () => {
+        // characterizes current behavior; not asserting correctness
+        const bcReferenceDate = new Date(1986, 0 /* Jan */, 1);
+        bcReferenceDate.setFullYear(-50);
+        const result = parse("02", "yy", bcReferenceDate);
+        const expectedResult = new Date(0);
+        expectedResult.setFullYear(-1, 0 /* Jan */, 1);
+        expectedResult.setHours(0, 0, 0, 0);
+        expect(result).toEqual(expectedResult);
       });
     });
 
@@ -426,6 +472,22 @@ describe("parse", () => {
       expect(result).toEqual(new Date(1986, 0 /* Jan */, 1));
     });
 
+    it("falls back to the narrow variant when the abbreviated one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      const result = parse("1", "QQQ", referenceDate);
+      expect(result).toEqual(new Date(1986, 0 /* Jan */, 1));
+    });
+
+    it("falls back to narrower variants when the wide one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      expect(parse("Q1", "QQQQ", referenceDate)).toEqual(
+        new Date(1986, 0 /* Jan */, 1),
+      );
+      expect(parse("1", "QQQQ", referenceDate)).toEqual(
+        new Date(1986, 0 /* Jan */, 1),
+      );
+    });
+
     describe("validation", () => {
       const tokensToValidate: Array<
         [string, string, { useAdditionalDayOfYearTokens: boolean }?]
@@ -490,6 +552,22 @@ describe("parse", () => {
     it("narrow", () => {
       const result = parse("1", "qqqqq", referenceDate);
       expect(result).toEqual(new Date(1986, 0 /* Jan */, 1));
+    });
+
+    it("falls back to the narrow variant when the abbreviated one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      const result = parse("1", "qqq", referenceDate);
+      expect(result).toEqual(new Date(1986, 0 /* Jan */, 1));
+    });
+
+    it("falls back to narrower variants when the wide one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      expect(parse("Q1", "qqqq", referenceDate)).toEqual(
+        new Date(1986, 0 /* Jan */, 1),
+      );
+      expect(parse("1", "qqqq", referenceDate)).toEqual(
+        new Date(1986, 0 /* Jan */, 1),
+      );
     });
 
     describe("validation", () => {
@@ -558,6 +636,27 @@ describe("parse", () => {
       expect(result).toEqual(new Date(1986, 0 /* Jan */, 1));
     });
 
+    it("falls back to the narrow variant when the abbreviated one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      const result = parse("J", "MMM", referenceDate);
+      expect(result).toEqual(new Date(1986, 0 /* Jan */, 1));
+    });
+
+    it("falls back to narrower variants when the wide one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      expect(parse("Feb", "MMMM", referenceDate)).toEqual(
+        new Date(1986, 1 /* Feb */, 1),
+      );
+      expect(parse("J", "MMMM", referenceDate)).toEqual(
+        new Date(1986, 0 /* Jan */, 1),
+      );
+    });
+
+    it("returns `Invalid Date` when the string doesn't match a numeric month", () => {
+      const result = parse("abc", "MM", referenceDate);
+      expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
+    });
+
     describe("validation", () => {
       const tokensToValidate: Array<
         [string, string, { useAdditionalDayOfYearTokens: boolean }?]
@@ -621,6 +720,22 @@ describe("parse", () => {
     it("narrow", () => {
       const result = parse("J", "LLLLL", referenceDate);
       expect(result).toEqual(new Date(1986, 0 /* Jan */, 1));
+    });
+
+    it("falls back to the narrow variant when the abbreviated one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      const result = parse("J", "LLL", referenceDate);
+      expect(result).toEqual(new Date(1986, 0 /* Jan */, 1));
+    });
+
+    it("falls back to narrower variants when the wide one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      expect(parse("Feb", "LLLL", referenceDate)).toEqual(
+        new Date(1986, 1 /* Feb */, 1),
+      );
+      expect(parse("J", "LLLL", referenceDate)).toEqual(
+        new Date(1986, 0 /* Jan */, 1),
+      );
     });
 
     describe("validation", () => {
@@ -777,6 +892,11 @@ describe("parse", () => {
       expect(result).toEqual(new Date(1986, 3 /* Apr */, 28));
     });
 
+    it("returns `Invalid Date` when the string doesn't match an ordinal number", () => {
+      const result = parse("foobar", "do", referenceDate);
+      expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
+    });
+
     it("zero-padding", () => {
       const result = parse("01", "dd", referenceDate);
       expect(result).toEqual(new Date(1986, 3 /* Apr */, 1));
@@ -901,6 +1021,35 @@ describe("parse", () => {
       expect(result).toEqual(new Date(1986, 3 /* Apr */, 3));
     });
 
+    it("falls back to narrower variants when the abbreviated one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      expect(parse("Mo", "EEE", referenceDate)).toEqual(
+        new Date(1986, 2 /* Mar */, 31),
+      );
+      expect(parse("M", "EEE", referenceDate)).toEqual(
+        new Date(1986, 2 /* Mar */, 31),
+      );
+    });
+
+    it("falls back to the narrow variant when the short one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      const result = parse("M", "EEEEEE", referenceDate);
+      expect(result).toEqual(new Date(1986, 2 /* Mar */, 31));
+    });
+
+    it("falls back to narrower variants when the wide one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      expect(parse("Mon", "EEEE", referenceDate)).toEqual(
+        new Date(1986, 2 /* Mar */, 31),
+      );
+      expect(parse("Mo", "EEEE", referenceDate)).toEqual(
+        new Date(1986, 2 /* Mar */, 31),
+      );
+      expect(parse("M", "EEEE", referenceDate)).toEqual(
+        new Date(1986, 2 /* Mar */, 31),
+      );
+    });
+
     it("allows to specify which day is the first day of the week", () => {
       const result = parse("Thursday", "EEEE", referenceDate, {
         weekStartsOn: /* Fri */ 5,
@@ -969,6 +1118,35 @@ describe("parse", () => {
     it("short", () => {
       const result = parse("Fr", "iiiiii", referenceDate);
       expect(result).toEqual(new Date(1986, 3 /* Apr */, 4));
+    });
+
+    it("falls back to narrower variants when the abbreviated one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      expect(parse("Mo", "iii", referenceDate)).toEqual(
+        new Date(1986, 2 /* Mar */, 31),
+      );
+      expect(parse("M", "iii", referenceDate)).toEqual(
+        new Date(1986, 2 /* Mar */, 31),
+      );
+    });
+
+    it("falls back to the narrow variant when the short one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      const result = parse("M", "iiiiii", referenceDate);
+      expect(result).toEqual(new Date(1986, 2 /* Mar */, 31));
+    });
+
+    it("falls back to narrower variants when the wide one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      expect(parse("Mon", "iiii", referenceDate)).toEqual(
+        new Date(1986, 2 /* Mar */, 31),
+      );
+      expect(parse("Mo", "iiii", referenceDate)).toEqual(
+        new Date(1986, 2 /* Mar */, 31),
+      );
+      expect(parse("M", "iiii", referenceDate)).toEqual(
+        new Date(1986, 2 /* Mar */, 31),
+      );
     });
 
     describe("validation", () => {
@@ -1041,6 +1219,35 @@ describe("parse", () => {
     it("short", () => {
       const result = parse("Fr", "eeeeee", referenceDate);
       expect(result).toEqual(new Date(1986, 3 /* Apr */, 4));
+    });
+
+    it("falls back to narrower variants when the abbreviated one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      expect(parse("Mo", "eee", referenceDate)).toEqual(
+        new Date(1986, 2 /* Mar */, 31),
+      );
+      expect(parse("M", "eee", referenceDate)).toEqual(
+        new Date(1986, 2 /* Mar */, 31),
+      );
+    });
+
+    it("falls back to the narrow variant when the short one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      const result = parse("M", "eeeeee", referenceDate);
+      expect(result).toEqual(new Date(1986, 2 /* Mar */, 31));
+    });
+
+    it("falls back to narrower variants when the wide one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      expect(parse("Mon", "eeee", referenceDate)).toEqual(
+        new Date(1986, 2 /* Mar */, 31),
+      );
+      expect(parse("Mo", "eeee", referenceDate)).toEqual(
+        new Date(1986, 2 /* Mar */, 31),
+      );
+      expect(parse("M", "eeee", referenceDate)).toEqual(
+        new Date(1986, 2 /* Mar */, 31),
+      );
     });
 
     it("allows to specify which day is the first day of the week", () => {
@@ -1122,6 +1329,35 @@ describe("parse", () => {
       expect(result).toEqual(new Date(1986, 3 /* Apr */, 4));
     });
 
+    it("falls back to narrower variants when the abbreviated one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      expect(parse("Mo", "ccc", referenceDate)).toEqual(
+        new Date(1986, 2 /* Mar */, 31),
+      );
+      expect(parse("M", "ccc", referenceDate)).toEqual(
+        new Date(1986, 2 /* Mar */, 31),
+      );
+    });
+
+    it("falls back to the narrow variant when the short one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      const result = parse("M", "cccccc", referenceDate);
+      expect(result).toEqual(new Date(1986, 2 /* Mar */, 31));
+    });
+
+    it("falls back to narrower variants when the wide one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      expect(parse("Mon", "cccc", referenceDate)).toEqual(
+        new Date(1986, 2 /* Mar */, 31),
+      );
+      expect(parse("Mo", "cccc", referenceDate)).toEqual(
+        new Date(1986, 2 /* Mar */, 31),
+      );
+      expect(parse("M", "cccc", referenceDate)).toEqual(
+        new Date(1986, 2 /* Mar */, 31),
+      );
+    });
+
     it("allows to specify which day is the first day of the week", () => {
       const result = parse("7th", "co", referenceDate, {
         weekStartsOn: /* Fri */ 5,
@@ -1191,6 +1427,18 @@ describe("parse", () => {
       expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 11));
     });
 
+    it("falls back to the narrow variant when the abbreviated one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      const result = parse("mi", "aaa", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 0));
+    });
+
+    it("falls back to narrower variants when the wide one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      const result = parse("mi", "aaaa", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 0));
+    });
+
     describe("validation", () => {
       [
         ["a", "AM"],
@@ -1228,6 +1476,18 @@ describe("parse", () => {
 
     it("narrow", () => {
       const result = parse("mi", "bbbbb", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 0));
+    });
+
+    it("falls back to the narrow variant when the abbreviated one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      const result = parse("mi", "bbb", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 0));
+    });
+
+    it("falls back to narrower variants when the wide one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      const result = parse("mi", "bbbb", referenceDate);
       expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 0));
     });
 
@@ -1269,6 +1529,23 @@ describe("parse", () => {
     it("narrow", () => {
       const result = parse("5 in the evening", "h BBBBB", referenceDate);
       expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 17));
+    });
+
+    it("morning", () => {
+      const result = parse("in the morning", "BBBB", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 4));
+    });
+
+    it("falls back to the narrow variant when the abbreviated one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      const result = parse("mi", "B", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 0));
+    });
+
+    it("falls back to narrower variants when the wide one doesn't match", () => {
+      // characterizes current behavior; not asserting correctness
+      const result = parse("mi", "BBBB", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 0));
     });
 
     describe("validation", () => {
@@ -1387,6 +1664,11 @@ describe("parse", () => {
     it("zero-padding", () => {
       const result = parse("1", "KK", referenceDate);
       expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 1));
+    });
+
+    it("converts the hour to PM when the day period is PM", () => {
+      const result = parse("11 PM", "K a", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 23));
     });
 
     describe("validation", () => {
@@ -1593,6 +1875,11 @@ describe("parse", () => {
           referenceDate,
         );
         expect(result).toEqual(new Date("2016-11-25T16:38:38.123+05:00"));
+      });
+
+      it("returns `Invalid Date` when the string doesn't match the timezone format", () => {
+        const result = parse("2016-11-25 abc", "yyyy-MM-dd X", referenceDate);
+        expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
       });
     });
 

--- a/pkgs/core/src/parseISO/test.ts
+++ b/pkgs/core/src/parseISO/test.ts
@@ -218,6 +218,12 @@ describe("parseISO", () => {
         expect(result instanceof Date).toBe(true);
         expect(isNaN(result.getTime())).toBe(true);
       });
+
+      it("returns `Invalid Date` if the date part after the year is malformed", () => {
+        const result = parseISO("2014-!");
+        expect(result instanceof Date).toBe(true);
+        expect(isNaN(result.getTime())).toBe(true);
+      });
     });
   });
 

--- a/pkgs/core/src/roundToNearestHours/test.ts
+++ b/pkgs/core/src/roundToNearestHours/test.ts
@@ -247,6 +247,26 @@ describe("roundToNearestHours", () => {
     });
   });
 
+  it("returns `Invalid Date` if `nearestTo` is out of the [1, 12] range", () => {
+    // `NearestHours` goes from 1 to 12; characterizes current behavior for
+    // out-of-range values; not asserting correctness
+    const resultTooLow = roundToNearestHours(makeDate(15, 10), {
+      // @ts-expect-error - We want to pass an invalid value here
+      nearestTo: 0,
+    });
+    expect(resultTooLow instanceof Date && isNaN(resultTooLow.getTime())).toBe(
+      true,
+    );
+
+    const resultTooHigh = roundToNearestHours(makeDate(15, 10), {
+      // @ts-expect-error - We want to pass an invalid value here
+      nearestTo: 13,
+    });
+    expect(
+      resultTooHigh instanceof Date && isNaN(resultTooHigh.getTime()),
+    ).toBe(true);
+  });
+
   it("resolves the date type by default", () => {
     const result = roundToNearestHours(Date.now());
     expect(result).toBeInstanceOf(Date);

--- a/pkgs/core/src/roundToNearestMinutes/test.ts
+++ b/pkgs/core/src/roundToNearestMinutes/test.ts
@@ -261,6 +261,26 @@ describe("roundToNearestMinutes", () => {
     expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
   });
 
+  it("returns `Invalid Date` if `nearestTo` is out of the [1, 30] range", () => {
+    // `NearestMinutes` goes from 1 to 30; characterizes current behavior for
+    // out-of-range values; not asserting correctness
+    const resultTooLow = roundToNearestMinutes(makeDate(15, 10), {
+      // @ts-expect-error - We want to pass an invalid value here
+      nearestTo: 0,
+    });
+    expect(resultTooLow instanceof Date && isNaN(resultTooLow.getTime())).toBe(
+      true,
+    );
+
+    const resultTooHigh = roundToNearestMinutes(makeDate(15, 10), {
+      // @ts-expect-error - We want to pass an invalid value here
+      nearestTo: 31,
+    });
+    expect(
+      resultTooHigh instanceof Date && isNaN(resultTooHigh.getTime()),
+    ).toBe(true);
+  });
+
   it("resolves the date type by default", () => {
     const result = roundToNearestMinutes(Date.now());
     expect(result).toBeInstanceOf(Date);

--- a/pkgs/core/src/transpose/test.ts
+++ b/pkgs/core/src/transpose/test.ts
@@ -1,4 +1,5 @@
 import { TZDate, tz } from "@date-fns/tz";
+import { UTCDate } from "@date-fns/utc";
 import { describe, expect, it } from "vitest";
 import { transpose } from "./index.ts";
 
@@ -7,6 +8,20 @@ describe("transpose", () => {
     const date = new Date(2022, 6, 10, 12, 34, 56, 789);
     const result = transpose(date, tz("Asia/Singapore"));
     expect(result instanceof TZDate).toBe(true);
+    expect(result.getFullYear()).toBe(2022);
+    expect(result.getMonth()).toBe(6);
+    expect(result.getDate()).toBe(10);
+    expect(result.getHours()).toBe(12);
+    expect(result.getMinutes()).toBe(34);
+    expect(result.getSeconds()).toBe(56);
+    expect(result.getMilliseconds()).toBe(789);
+  });
+
+  it("allows to use a date constructor", () => {
+    // See the docs example: transpose(date, UTCDate)
+    const date = new Date(2022, 6, 10, 12, 34, 56, 789);
+    const result = transpose(date, UTCDate);
+    expect(result instanceof UTCDate).toBe(true);
     expect(result.getFullYear()).toBe(2022);
     expect(result.getMonth()).toBe(6);
     expect(result.getDate()).toBe(10);


### PR DESCRIPTION
## Summary

This PR adds unit tests only (no source changes) to fill coverage gaps in `pkgs/core`, measured with `pnpm vitest run --project main --coverage` (v8 provider) before and after:

| Metric | Before | After | Delta |
|---|---|---|---|
| Statements | 95.25% (2909/3054) | 98.91% (3021/3054) | +3.66 |
| Branches | 89.09% (1504/1688) | 97.21% (1641/1688) | +8.12 |
| Functions | 95.06% (501/527) | 99.62% (525/527) | +4.56 |
| Lines | 95.51% (2830/2963) | 99.15% (2938/2963) | +3.64 |

962 insertions, 0 deletions; +105 tests (3148 → 3253 passing).

## What's covered

- **`parse`**: the text-unit width fallback chains (`E`/`i`/`e`/`c`, `M`/`L`, `Q`/`q`, `G`, `a`/`b`/`B` tokens accepting narrower-width input), two-digit year normalization edge cases (reference date ≤ AD 50, B.C. reference date, and the documented `parse('75', 'yy', new Date(2018, 0, 1))` example), `K` + PM day period, the morning flexible day period, and `Invalid Date` paths for non-matching numeric, ordinal, and timezone input.
- **`parseISO`**: malformed date part after a valid year.
- **`intlFormatDistance`**: explicit `month` and `year` units.
- **`roundToNearestHours` / `roundToNearestMinutes`**: out-of-range `nearestTo`.
- **`transpose`**: date constructor argument (the documented `UTCDate` example).
- **`formatDuration`**: locale without `formatDistance`.
- **Locales `fr`, `zh-CN`, `zh-HK`, `zh-TW`, and a new `eo` test file**: `formatDistance` token forms and suffixes, `formatRelative` (including the zh-CN `checkWeek` branches), `ordinalNumber` units, quarter localize/match callbacks, and the zh narrow era.

Where TSDoc/docs define the behavior, assertions match the documented contract. Where behavior is defined but undocumented (e.g. the parse width fallbacks), tests are labeled `characterizes current behavior; not asserting correctness` in comments.

## Possible bugs noticed while writing these (intentionally *not* pinned by tests)

1. **`zh-CN` cannot parse its own formatted quarter**: `format(date, 'QQQ', { locale: zhCN })` → `第三季`, but `matchQuarterPatterns` in `zh-CN/_lib/match` expects `第[一二三四]刻` (the zh-TW forms), so `parse('第三季', 'QQQ', ..., { locale: zhCN })` returns `Invalid Date`. zh-HK and zh-TW round-trip fine.
2. **en-US narrow noon can't be parsed**: the narrow day-period match pattern accepts `n`, but `parseDayPeriodPatterns` maps noon via `/^no/i`, so `parse('n', 'aaaaa', ...)` silently resolves to an `undefined` day period and sets hour 0 (midnight) instead of 12.
3. **`parseISO` silently ignores a malformed timezone**: `parseISO('2016-11-25T16:38:38+abc')` returns a valid date treating the offset as 0 (`parseTimezone` returns `0` when the timezone string doesn't match), while the docs say non-ISO input yields `Invalid Date`.

Branches that carry these behaviors, plus provably unreachable defensive branches (e.g. `cleanEscapedString`'s no-match path, `Hour1To24Parser`'s `value > 24` after validation, the `timestampIsSet` guards in the `x`/`X` parsers), were left uncovered on purpose.

## Checks run locally

- `pnpm vitest run --project main` — green (also under `TZ=UTC`)
- `pnpm oxlint` — clean
- `pnpm tsgo --build` — clean
- locale snapshots test — clean

## Disclosure

This contribution was generated by an AI agent (Claude Code), with every assertion verified against actual runtime behavior via executed probes before being written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014o7Jr5j8xnoTBFYLjqa798