### PR TITLE
Add tests for coverage gaps; fix parseISO malformed timezone handling

### DIFF
--- a/pkgs/core/src/format/test.ts
+++ b/pkgs/core/src/format/test.ts
@@ -597,6 +597,10 @@ describe("format", () => {
       const resultNegative30Offset = format(date, "X XX XXX XXXX XXXXX");
       expect(resultNegative30Offset).toBe("-0730 -0730 -07:30 -0730 -07:30");
 
+      getTimezoneOffsetStub.mockReturnValue(-480);
+      const resultPositiveOffset = format(date, "X XX XXX XXXX XXXXX");
+      expect(resultPositiveOffset).toBe("+08 +0800 +08:00 +0800 +08:00");
+
       getTimezoneOffsetStub.mockRestore();
     });
 
@@ -634,6 +638,16 @@ describe("format", () => {
       const resultNegative30Offset = format(date, "O OO OOO OOOO");
       expect(resultNegative30Offset).toBe(
         "GMT-7:30 GMT-7:30 GMT-7:30 GMT-07:30",
+      );
+
+      getTimezoneOffsetStub.mockReturnValue(-480);
+      const resultPositiveOffset = format(date, "O OO OOO OOOO");
+      expect(resultPositiveOffset).toBe("GMT+8 GMT+8 GMT+8 GMT+08:00");
+
+      getTimezoneOffsetStub.mockReturnValue(-330);
+      const resultPositive30Offset = format(date, "O OO OOO OOOO");
+      expect(resultPositive30Offset).toBe(
+        "GMT+5:30 GMT+5:30 GMT+5:30 GMT+05:30",
       );
 
       getTimezoneOffsetStub.mockRestore();

--- a/pkgs/core/src/formatDuration/test.ts
+++ b/pkgs/core/src/formatDuration/test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { Locale } from "../locale/types.ts";
 import { formatDuration } from "./index.ts";
 
 describe("formatDuration", () => {
@@ -72,5 +73,11 @@ describe("formatDuration", () => {
     expect(formatDuration({ months: 9, days: 2 }, { delimiter: ", " })).toBe(
       "9 months, 2 days",
     );
+  });
+
+  it("returns an empty string if the locale has no formatDistance", () => {
+    expect(
+      formatDuration({ months: 9, days: 2 }, { locale: {} as Locale }),
+    ).toBe("");
   });
 });

--- a/pkgs/core/src/intlFormatDistance/test.ts
+++ b/pkgs/core/src/intlFormatDistance/test.ts
@@ -624,6 +624,46 @@ describe("intlFormatDistance", () => {
           expect(result).toBe("53 weeks ago");
         });
       });
+
+      describe("months", () => {
+        it("works with the future", () => {
+          const result = intlFormatDistance(
+            new Date(1986, 6, 4, 10, 30, 0),
+            new Date(1986, 3, 4, 10, 30, 0),
+            { unit: "month" },
+          );
+          expect(result).toBe("in 3 months");
+        });
+
+        it("works with the past", () => {
+          const result = intlFormatDistance(
+            new Date(1986, 3, 4, 10, 30, 0),
+            new Date(1986, 6, 4, 10, 30, 0),
+            { unit: "month" },
+          );
+          expect(result).toBe("3 months ago");
+        });
+      });
+
+      describe("years", () => {
+        it("works with the future", () => {
+          const result = intlFormatDistance(
+            new Date(1988, 3, 4, 10, 30, 0),
+            new Date(1986, 3, 4, 10, 30, 0),
+            { unit: "year" },
+          );
+          expect(result).toBe("in 2 years");
+        });
+
+        it("works with the past", () => {
+          const result = intlFormatDistance(
+            new Date(1986, 3, 4, 10, 30, 0),
+            new Date(1988, 3, 4, 10, 30, 0),
+            { unit: "year" },
+          );
+          expect(result).toBe("2 years ago");
+        });
+      });
     });
 
     describe("numeric option", () => {

--- a/pkgs/core/src/locale/en-US/test.ts
+++ b/pkgs/core/src/locale/en-US/test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { enUS } from "./index.ts";
+import { zhCN } from "../zh-CN/index.ts";
+
+describe("en-US locale", () => {
+  describe("formatLong", () => {
+    it("returns the default width format when no width is given", () => {
+      expect(enUS.formatLong.date({})).toBe("EEEE, MMMM do, y");
+      expect(enUS.formatLong.time({})).toBe("h:mm:ss a zzzz");
+    });
+  });
+
+  describe("localize", () => {
+    it("returns the default width value when no width is given", () => {
+      expect(enUS.localize.month(0)).toBe("January");
+    });
+
+    it("falls back to the default width for an unknown width", () => {
+      expect(enUS.localize.month(0, { width: "short" })).toBe("January");
+    });
+
+    it("returns the default formatting width value when no width is given", () => {
+      expect(zhCN.localize.dayPeriod("am", { context: "formatting" })).toBe(
+        "上午",
+      );
+    });
+
+    it("falls back to the default formatting width for an unknown width", () => {
+      expect(
+        zhCN.localize.dayPeriod("am", {
+          context: "formatting",
+          width: "short",
+        }),
+      ).toBe("上午");
+    });
+  });
+
+  describe("match", () => {
+    it("applies the value callback from the options", () => {
+      const result = enUS.match.ordinalNumber("2nd", {
+        unit: "date",
+        valueCallback: (value) => Number(value) * 2,
+      });
+      expect(result?.value).toBe(4);
+    });
+
+    it("applies the value callback from the options to match functions", () => {
+      const result = enUS.match.era("AD", {
+        width: "abbreviated",
+        valueCallback: (value) => (Number(value) === 1 ? 0 : 1),
+      });
+      expect(result?.value).toBe(0);
+    });
+  });
+});

--- a/pkgs/core/src/locale/eo/test.ts
+++ b/pkgs/core/src/locale/eo/test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { format } from "../../format/index.ts";
+import { parse } from "../../parse/index.ts";
+import { eo } from "./index.ts";
+
+describe("eo locale", () => {
+  describe("formatDistance", () => {
+    it("works with a token without forms", () => {
+      expect(eo.formatDistance("halfAMinute", 30)).toBe("duonminuto");
+    });
+
+    it("works with the one form", () => {
+      expect(eo.formatDistance("xSeconds", 1)).toBe("1 sekundo");
+    });
+
+    it("works with the other form", () => {
+      expect(eo.formatDistance("xSeconds", 30)).toBe("30 sekundoj");
+    });
+
+    it("adds a suffix for the future", () => {
+      expect(
+        eo.formatDistance("xSeconds", 30, { addSuffix: true, comparison: 1 }),
+      ).toBe("post 30 sekundoj");
+    });
+
+    it("adds a suffix for the past", () => {
+      expect(
+        eo.formatDistance("xSeconds", 30, { addSuffix: true, comparison: -1 }),
+      ).toBe("antaŭ 30 sekundoj");
+    });
+  });
+
+  describe("ordinalNumber", () => {
+    it("adds the -a suffix", () => {
+      const result = format(new Date(2017, 0 /* Jan */, 4), "do", {
+        locale: eo,
+      });
+      expect(result).toBe("4-a");
+    });
+  });
+
+  describe("quarter", () => {
+    it("formats a quarter", () => {
+      expect(
+        format(new Date(2017, 0 /* Jan */, 1), "QQQ", { locale: eo }),
+      ).toBe("K1");
+    });
+
+    it("parses a narrow quarter", () => {
+      const result = parse("3", "QQQQQ", new Date(2017, 0 /* Jan */, 1), {
+        locale: eo,
+      });
+      expect(result).toEqual(new Date(2017, 6 /* Jul */, 1));
+    });
+  });
+});

--- a/pkgs/core/src/locale/fr/_lib/formatRelative/index.ts
+++ b/pkgs/core/src/locale/fr/_lib/formatRelative/index.ts
@@ -4,7 +4,7 @@ const formatRelativeLocale = {
   lastWeek: "eeee 'dernier à' p",
   yesterday: "'hier à' p",
   today: "'aujourd’hui à' p",
-  tomorrow: "'demain à' p'",
+  tomorrow: "'demain à' p",
   nextWeek: "eeee 'prochain à' p",
   other: "P",
 };

--- a/pkgs/core/src/locale/fr/test.ts
+++ b/pkgs/core/src/locale/fr/test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { format } from "../../format/index.ts";
+import { formatRelative } from "../../formatRelative/index.ts";
+import { parse } from "../../parse/index.ts";
 import { fr } from "./index.ts";
 
 describe("fr locale", () => {
@@ -32,6 +34,84 @@ describe("fr locale", () => {
         });
         expect(result).toBe(expectedResult);
       });
+    });
+  });
+
+  describe("formatDistance", () => {
+    it("works with a token without forms", () => {
+      expect(fr.formatDistance("halfAMinute", 30)).toBe("30 secondes");
+    });
+
+    it("works with the one form", () => {
+      expect(fr.formatDistance("xSeconds", 1)).toBe("1 seconde");
+    });
+
+    it("works with the other form", () => {
+      expect(fr.formatDistance("xSeconds", 30)).toBe("30 secondes");
+    });
+
+    it("adds a suffix for the future", () => {
+      expect(
+        fr.formatDistance("xDays", 2, { addSuffix: true, comparison: 1 }),
+      ).toBe("dans 2 jours");
+    });
+
+    it("adds a suffix for the past", () => {
+      expect(
+        fr.formatDistance("xDays", 2, { addSuffix: true, comparison: -1 }),
+      ).toBe("il y a 2 jours");
+    });
+  });
+
+  describe("formatRelative", () => {
+    it("works with tomorrow", () => {
+      const result = formatRelative(
+        new Date(1986, 3 /* Apr */, 5, 10, 30),
+        new Date(1986, 3 /* Apr */, 4, 10, 30),
+        { locale: fr },
+      );
+      expect(result).toBe("demain à 10:30");
+    });
+  });
+
+  describe("ordinalNumber", () => {
+    it("returns zero without a suffix", () => {
+      const result = format(new Date(2017, 0 /* Jan */, 1, 10, 30, 0), "so", {
+        locale: fr,
+      });
+      expect(result).toBe("0");
+    });
+
+    it("uses the feminine form for feminine units", () => {
+      const result = format(new Date(2017, 0 /* Jan */, 1, 1, 30), "ho", {
+        locale: fr,
+      });
+      expect(result).toBe("1ère");
+    });
+  });
+
+  describe("quarter", () => {
+    it("formats a quarter", () => {
+      const result = format(new Date(2017, 0 /* Jan */, 1), "QQQ", {
+        locale: fr,
+      });
+      expect(result).toBe("1er trim.");
+    });
+
+    it("parses a narrow quarter", () => {
+      const result = parse("T3", "QQQ", new Date(2017, 0 /* Jan */, 1), {
+        locale: fr,
+      });
+      expect(result).toEqual(new Date(2017, 6 /* Jul */, 1));
+    });
+  });
+
+  describe("ordinal number parsing", () => {
+    it("parses an ordinal day of the month", () => {
+      const result = parse("2ème", "do", new Date(2017, 0 /* Jan */, 1), {
+        locale: fr,
+      });
+      expect(result).toEqual(new Date(2017, 0 /* Jan */, 2));
     });
   });
 });

--- a/pkgs/core/src/locale/zh-CN/test.ts
+++ b/pkgs/core/src/locale/zh-CN/test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { format } from "../../format/index.ts";
 import { parse } from "../../parse/index.ts";
 import { zhCN } from "./index.ts";
 
@@ -29,5 +30,115 @@ describe("zh-CN locale", () => {
         locale: zhCN,
       }),
     ).toEqual(new Date(2022, 11 /* Dec */, 27));
+  });
+
+  describe("formatDistance", () => {
+    it("works with a token without forms", () => {
+      expect(zhCN.formatDistance("halfAMinute", 30)).toBe("半分钟");
+    });
+
+    it("works with the one form", () => {
+      expect(zhCN.formatDistance("xSeconds", 1)).toBe("1 秒");
+    });
+
+    it("works with the other form", () => {
+      expect(zhCN.formatDistance("xSeconds", 30)).toBe("30 秒");
+    });
+
+    it("adds a suffix for the future", () => {
+      expect(
+        zhCN.formatDistance("xDays", 2, { addSuffix: true, comparison: 1 }),
+      ).toBe("2 天内");
+    });
+
+    it("adds a suffix for the past", () => {
+      expect(
+        zhCN.formatDistance("xDays", 2, { addSuffix: true, comparison: -1 }),
+      ).toBe("2 天前");
+    });
+  });
+
+  describe("formatRelative", () => {
+    const baseDate = new Date(1986, 3 /* Apr */, 4, 10, 32);
+
+    it("uses the plain format for dates in the same week", () => {
+      expect(
+        zhCN.formatRelative(
+          "lastWeek",
+          new Date(1986, 3 /* Apr */, 1),
+          baseDate,
+        ),
+      ).toBe("eeee p");
+    });
+
+    it("prefixes the format for dates in the last week", () => {
+      expect(
+        zhCN.formatRelative(
+          "lastWeek",
+          new Date(1986, 2 /* Mar */, 26),
+          baseDate,
+        ),
+      ).toBe("'上个'eeee p");
+    });
+
+    it("prefixes the format for dates in the next week", () => {
+      expect(
+        zhCN.formatRelative(
+          "nextWeek",
+          new Date(1986, 3 /* Apr */, 7),
+          baseDate,
+        ),
+      ).toBe("'下个'eeee p");
+    });
+
+    it("returns the format for other tokens", () => {
+      expect(zhCN.formatRelative("today", baseDate, baseDate)).toBe("'今天' p");
+    });
+  });
+
+  describe("ordinalNumber", () => {
+    const date = new Date(2017, 0 /* Jan */, 4, 10, 32, 5);
+
+    it("suffixes dates", () => {
+      expect(format(date, "do", { locale: zhCN })).toBe("4日");
+    });
+
+    it("suffixes hours", () => {
+      expect(format(date, "ho", { locale: zhCN })).toBe("10时");
+    });
+
+    it("suffixes minutes", () => {
+      expect(format(date, "mo", { locale: zhCN })).toBe("32分");
+    });
+
+    it("suffixes seconds", () => {
+      expect(format(date, "so", { locale: zhCN })).toBe("5秒");
+    });
+
+    it("prefixes other units", () => {
+      expect(format(date, "Qo", { locale: zhCN })).toBe("第 1");
+    });
+  });
+
+  describe("quarter", () => {
+    it("formats a quarter", () => {
+      expect(
+        format(new Date(2017, 0 /* Jan */, 1), "QQQ", { locale: zhCN }),
+      ).toBe("第一季");
+    });
+
+    it("parses an ordinal quarter", () => {
+      const result = parse("第 3", "Qo", new Date(2017, 0 /* Jan */, 1), {
+        locale: zhCN,
+      });
+      expect(result).toEqual(new Date(2017, 6 /* Jul */, 1));
+    });
+
+    it("parses a narrow quarter", () => {
+      const result = parse("3", "QQQQQ", new Date(2017, 0 /* Jan */, 1), {
+        locale: zhCN,
+      });
+      expect(result).toEqual(new Date(2017, 6 /* Jul */, 1));
+    });
   });
 });

--- a/pkgs/core/src/locale/zh-HK/test.ts
+++ b/pkgs/core/src/locale/zh-HK/test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { format } from "../../format/index.ts";
 import { parse } from "../../parse/index.ts";
 import { zhHK } from "./index.ts";
 
@@ -29,5 +30,85 @@ describe("zh-HK locale", () => {
         locale: zhHK,
       }),
     ).toEqual(new Date(2022, 11 /* Dec */, 27));
+  });
+
+  describe("formatDistance", () => {
+    it("works with a token without forms", () => {
+      expect(zhHK.formatDistance("halfAMinute", 30)).toBe("半分鐘");
+    });
+
+    it("works with the one form", () => {
+      expect(zhHK.formatDistance("xSeconds", 1)).toBe("1 秒");
+    });
+
+    it("works with the other form", () => {
+      expect(zhHK.formatDistance("xSeconds", 30)).toBe("30 秒");
+    });
+
+    it("adds a suffix for the future", () => {
+      expect(
+        zhHK.formatDistance("xDays", 2, { addSuffix: true, comparison: 1 }),
+      ).toBe("2 天內");
+    });
+
+    it("adds a suffix for the past", () => {
+      expect(
+        zhHK.formatDistance("xDays", 2, { addSuffix: true, comparison: -1 }),
+      ).toBe("2 天前");
+    });
+  });
+
+  describe("formatRelative", () => {
+    const baseDate = new Date(1986, 3 /* Apr */, 4, 10, 32);
+
+    it("returns the format for the token", () => {
+      expect(zhHK.formatRelative("today", baseDate, baseDate)).toBe("'今天' p");
+    });
+  });
+
+  describe("ordinalNumber", () => {
+    const date = new Date(2017, 0 /* Jan */, 4, 10, 32, 5);
+
+    it("suffixes dates", () => {
+      expect(format(date, "do", { locale: zhHK })).toBe("4日");
+    });
+
+    it("suffixes hours", () => {
+      expect(format(date, "ho", { locale: zhHK })).toBe("10時");
+    });
+
+    it("suffixes minutes", () => {
+      expect(format(date, "mo", { locale: zhHK })).toBe("32分");
+    });
+
+    it("suffixes seconds", () => {
+      expect(format(date, "so", { locale: zhHK })).toBe("5秒");
+    });
+
+    it("prefixes other units", () => {
+      expect(format(date, "Qo", { locale: zhHK })).toBe("第 1");
+    });
+  });
+
+  describe("quarter", () => {
+    it("formats a quarter", () => {
+      expect(
+        format(new Date(2017, 0 /* Jan */, 1), "QQQ", { locale: zhHK }),
+      ).toBe("第一季");
+    });
+
+    it("parses an ordinal quarter", () => {
+      const result = parse("第 3", "Qo", new Date(2017, 0 /* Jan */, 1), {
+        locale: zhHK,
+      });
+      expect(result).toEqual(new Date(2017, 6 /* Jul */, 1));
+    });
+
+    it("parses a narrow quarter", () => {
+      const result = parse("3", "QQQQQ", new Date(2017, 0 /* Jan */, 1), {
+        locale: zhHK,
+      });
+      expect(result).toEqual(new Date(2017, 6 /* Jul */, 1));
+    });
   });
 });

--- a/pkgs/core/src/locale/zh-TW/test.ts
+++ b/pkgs/core/src/locale/zh-TW/test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { format } from "../../format/index.ts";
 import { parse } from "../../parse/index.ts";
 import { zhTW } from "./index.ts";
 
@@ -29,5 +30,85 @@ describe("zh-TW locale", () => {
         locale: zhTW,
       }),
     ).toEqual(new Date(2022, 11 /* Dec */, 27));
+  });
+
+  describe("formatDistance", () => {
+    it("works with a token without forms", () => {
+      expect(zhTW.formatDistance("halfAMinute", 30)).toBe("半分鐘");
+    });
+
+    it("works with the one form", () => {
+      expect(zhTW.formatDistance("xSeconds", 1)).toBe("1 秒");
+    });
+
+    it("works with the other form", () => {
+      expect(zhTW.formatDistance("xSeconds", 30)).toBe("30 秒");
+    });
+
+    it("adds a suffix for the future", () => {
+      expect(
+        zhTW.formatDistance("xDays", 2, { addSuffix: true, comparison: 1 }),
+      ).toBe("2 天內");
+    });
+
+    it("adds a suffix for the past", () => {
+      expect(
+        zhTW.formatDistance("xDays", 2, { addSuffix: true, comparison: -1 }),
+      ).toBe("2 天前");
+    });
+  });
+
+  describe("formatRelative", () => {
+    const baseDate = new Date(1986, 3 /* Apr */, 4, 10, 32);
+
+    it("returns the format for the token", () => {
+      expect(zhTW.formatRelative("today", baseDate, baseDate)).toBe("'今天' p");
+    });
+  });
+
+  describe("ordinalNumber", () => {
+    const date = new Date(2017, 0 /* Jan */, 4, 10, 32, 5);
+
+    it("suffixes dates", () => {
+      expect(format(date, "do", { locale: zhTW })).toBe("4日");
+    });
+
+    it("suffixes hours", () => {
+      expect(format(date, "ho", { locale: zhTW })).toBe("10時");
+    });
+
+    it("suffixes minutes", () => {
+      expect(format(date, "mo", { locale: zhTW })).toBe("32分");
+    });
+
+    it("suffixes seconds", () => {
+      expect(format(date, "so", { locale: zhTW })).toBe("5秒");
+    });
+
+    it("prefixes other units", () => {
+      expect(format(date, "Qo", { locale: zhTW })).toBe("第 1");
+    });
+  });
+
+  describe("quarter", () => {
+    it("formats a quarter", () => {
+      expect(
+        format(new Date(2017, 0 /* Jan */, 1), "QQQ", { locale: zhTW }),
+      ).toBe("第一刻");
+    });
+
+    it("parses an ordinal quarter", () => {
+      const result = parse("第 3", "Qo", new Date(2017, 0 /* Jan */, 1), {
+        locale: zhTW,
+      });
+      expect(result).toEqual(new Date(2017, 6 /* Jul */, 1));
+    });
+
+    it("parses a narrow quarter", () => {
+      const result = parse("3", "QQQQQ", new Date(2017, 0 /* Jan */, 1), {
+        locale: zhTW,
+      });
+      expect(result).toEqual(new Date(2017, 6 /* Jul */, 1));
+    });
   });
 });

--- a/pkgs/core/src/parse/test.ts
+++ b/pkgs/core/src/parse/test.ts
@@ -46,6 +46,21 @@ describe("parse", () => {
       expect(result).toEqual(new Date(-43, 0 /* Jan */, 1));
     });
 
+    it("narrow fallback for the abbreviated token", () => {
+      const result = parse("44 B", "y G", referenceDate);
+      expect(result).toEqual(new Date(-43, 0 /* Jan */, 1));
+    });
+
+    it("abbreviated fallback for the wide token", () => {
+      const result = parse("2018 AD", "yyyy GGGG", referenceDate);
+      expect(result).toEqual(new Date(2018, 0 /* Jan */, 1));
+    });
+
+    it("narrow fallback for the wide token", () => {
+      const result = parse("44 B", "y GGGG", referenceDate);
+      expect(result).toEqual(new Date(-43, 0 /* Jan */, 1));
+    });
+
     it("with week-numbering year", () => {
       const result = parse("44 B", "Y GGGGG", referenceDate);
       expect(result).toEqual(new Date(-44, 11 /* Dec */, 30));
@@ -109,6 +124,41 @@ describe("parse", () => {
       it("gets the 100 year range from `referenceDate`", () => {
         const result = parse("02", "yy", new Date(1860, 6 /* Jul */, 2));
         expect(result).toEqual(new Date(1902, 0 /* Jan */, 1));
+      });
+
+      it("gets the previous century when the year is out of the range", () => {
+        const result = parse("50", "yy", referenceDate);
+        expect(result).toEqual(new Date(1950, 0 /* Jan */, 1));
+      });
+
+      it("works with a reference date close to the first century", () => {
+        const closeReferenceDate = new Date(0);
+        closeReferenceDate.setFullYear(25, 0 /* Jan */, 1);
+        const expectedResult = new Date(0);
+        expectedResult.setFullYear(50, 0 /* Jan */, 1);
+        expectedResult.setHours(0, 0, 0, 0);
+        const result = parse("50", "yy", closeReferenceDate);
+        expect(result).toEqual(expectedResult);
+      });
+
+      it("interprets 00 as year 100 with a reference date close to the first century", () => {
+        const closeReferenceDate = new Date(0);
+        closeReferenceDate.setFullYear(25, 0 /* Jan */, 1);
+        const expectedResult = new Date(0);
+        expectedResult.setFullYear(100, 0 /* Jan */, 1);
+        expectedResult.setHours(0, 0, 0, 0);
+        const result = parse("00", "yy", closeReferenceDate);
+        expect(result).toEqual(expectedResult);
+      });
+
+      it("works with a BC reference date", () => {
+        const bcReferenceDate = new Date(0);
+        bcReferenceDate.setFullYear(-5, 0 /* Jan */, 1);
+        const expectedResult = new Date(0);
+        expectedResult.setFullYear(-49, 0 /* Jan */, 1);
+        expectedResult.setHours(0, 0, 0, 0);
+        const result = parse("50", "yy", bcReferenceDate);
+        expect(result).toEqual(expectedResult);
       });
     });
 
@@ -426,6 +476,21 @@ describe("parse", () => {
       expect(result).toEqual(new Date(1986, 0 /* Jan */, 1));
     });
 
+    it("narrow fallback for the abbreviated token", () => {
+      const result = parse("1", "QQQ", referenceDate);
+      expect(result).toEqual(new Date(1986, 0 /* Jan */, 1));
+    });
+
+    it("abbreviated fallback for the wide token", () => {
+      const result = parse("Q3", "QQQQ", referenceDate);
+      expect(result).toEqual(new Date(1986, 6 /* Jul */, 1));
+    });
+
+    it("narrow fallback for the wide token", () => {
+      const result = parse("2", "QQQQ", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 1));
+    });
+
     describe("validation", () => {
       const tokensToValidate: Array<
         [string, string, { useAdditionalDayOfYearTokens: boolean }?]
@@ -490,6 +555,21 @@ describe("parse", () => {
     it("narrow", () => {
       const result = parse("1", "qqqqq", referenceDate);
       expect(result).toEqual(new Date(1986, 0 /* Jan */, 1));
+    });
+
+    it("narrow fallback for the abbreviated token", () => {
+      const result = parse("1", "qqq", referenceDate);
+      expect(result).toEqual(new Date(1986, 0 /* Jan */, 1));
+    });
+
+    it("abbreviated fallback for the wide token", () => {
+      const result = parse("Q3", "qqqq", referenceDate);
+      expect(result).toEqual(new Date(1986, 6 /* Jul */, 1));
+    });
+
+    it("narrow fallback for the wide token", () => {
+      const result = parse("2", "qqqq", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 1));
     });
 
     describe("validation", () => {
@@ -558,6 +638,21 @@ describe("parse", () => {
       expect(result).toEqual(new Date(1986, 0 /* Jan */, 1));
     });
 
+    it("narrow fallback for the abbreviated token", () => {
+      const result = parse("J", "MMM", referenceDate);
+      expect(result).toEqual(new Date(1986, 0 /* Jan */, 1));
+    });
+
+    it("abbreviated fallback for the wide token", () => {
+      const result = parse("Nov", "MMMM", referenceDate);
+      expect(result).toEqual(new Date(1986, 10 /* Nov */, 1));
+    });
+
+    it("narrow fallback for the wide token", () => {
+      const result = parse("J", "MMMM", referenceDate);
+      expect(result).toEqual(new Date(1986, 0 /* Jan */, 1));
+    });
+
     describe("validation", () => {
       const tokensToValidate: Array<
         [string, string, { useAdditionalDayOfYearTokens: boolean }?]
@@ -620,6 +715,21 @@ describe("parse", () => {
 
     it("narrow", () => {
       const result = parse("J", "LLLLL", referenceDate);
+      expect(result).toEqual(new Date(1986, 0 /* Jan */, 1));
+    });
+
+    it("narrow fallback for the abbreviated token", () => {
+      const result = parse("J", "LLL", referenceDate);
+      expect(result).toEqual(new Date(1986, 0 /* Jan */, 1));
+    });
+
+    it("abbreviated fallback for the wide token", () => {
+      const result = parse("Nov", "LLLL", referenceDate);
+      expect(result).toEqual(new Date(1986, 10 /* Nov */, 1));
+    });
+
+    it("narrow fallback for the wide token", () => {
+      const result = parse("J", "LLLL", referenceDate);
       expect(result).toEqual(new Date(1986, 0 /* Jan */, 1));
     });
 
@@ -901,6 +1011,36 @@ describe("parse", () => {
       expect(result).toEqual(new Date(1986, 3 /* Apr */, 3));
     });
 
+    it("short fallback for the abbreviated token", () => {
+      const result = parse("Th", "EEE", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 3));
+    });
+
+    it("narrow fallback for the abbreviated token", () => {
+      const result = parse("W", "EEE", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 2));
+    });
+
+    it("narrow fallback for the short token", () => {
+      const result = parse("W", "EEEEEE", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 2));
+    });
+
+    it("abbreviated fallback for the wide token", () => {
+      const result = parse("Mon", "EEEE", referenceDate);
+      expect(result).toEqual(new Date(1986, 2 /* Mar */, 31));
+    });
+
+    it("short fallback for the wide token", () => {
+      const result = parse("Th", "EEEE", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 3));
+    });
+
+    it("narrow fallback for the wide token", () => {
+      const result = parse("W", "EEEE", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 2));
+    });
+
     it("allows to specify which day is the first day of the week", () => {
       const result = parse("Thursday", "EEEE", referenceDate, {
         weekStartsOn: /* Fri */ 5,
@@ -969,6 +1109,36 @@ describe("parse", () => {
     it("short", () => {
       const result = parse("Fr", "iiiiii", referenceDate);
       expect(result).toEqual(new Date(1986, 3 /* Apr */, 4));
+    });
+
+    it("short fallback for the abbreviated token", () => {
+      const result = parse("Th", "iii", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 3));
+    });
+
+    it("narrow fallback for the abbreviated token", () => {
+      const result = parse("W", "iii", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 2));
+    });
+
+    it("narrow fallback for the short token", () => {
+      const result = parse("W", "iiiiii", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 2));
+    });
+
+    it("abbreviated fallback for the wide token", () => {
+      const result = parse("Mon", "iiii", referenceDate);
+      expect(result).toEqual(new Date(1986, 2 /* Mar */, 31));
+    });
+
+    it("short fallback for the wide token", () => {
+      const result = parse("Th", "iiii", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 3));
+    });
+
+    it("narrow fallback for the wide token", () => {
+      const result = parse("W", "iiii", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 2));
     });
 
     describe("validation", () => {
@@ -1041,6 +1211,36 @@ describe("parse", () => {
     it("short", () => {
       const result = parse("Fr", "eeeeee", referenceDate);
       expect(result).toEqual(new Date(1986, 3 /* Apr */, 4));
+    });
+
+    it("short fallback for the abbreviated token", () => {
+      const result = parse("Th", "eee", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 3));
+    });
+
+    it("narrow fallback for the abbreviated token", () => {
+      const result = parse("W", "eee", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 2));
+    });
+
+    it("narrow fallback for the short token", () => {
+      const result = parse("W", "eeeeee", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 2));
+    });
+
+    it("abbreviated fallback for the wide token", () => {
+      const result = parse("Mon", "eeee", referenceDate);
+      expect(result).toEqual(new Date(1986, 2 /* Mar */, 31));
+    });
+
+    it("short fallback for the wide token", () => {
+      const result = parse("Th", "eeee", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 3));
+    });
+
+    it("narrow fallback for the wide token", () => {
+      const result = parse("W", "eeee", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 2));
     });
 
     it("allows to specify which day is the first day of the week", () => {
@@ -1122,6 +1322,36 @@ describe("parse", () => {
       expect(result).toEqual(new Date(1986, 3 /* Apr */, 4));
     });
 
+    it("short fallback for the abbreviated token", () => {
+      const result = parse("Th", "ccc", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 3));
+    });
+
+    it("narrow fallback for the abbreviated token", () => {
+      const result = parse("W", "ccc", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 2));
+    });
+
+    it("narrow fallback for the short token", () => {
+      const result = parse("W", "cccccc", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 2));
+    });
+
+    it("abbreviated fallback for the wide token", () => {
+      const result = parse("Mon", "cccc", referenceDate);
+      expect(result).toEqual(new Date(1986, 2 /* Mar */, 31));
+    });
+
+    it("short fallback for the wide token", () => {
+      const result = parse("Th", "cccc", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 3));
+    });
+
+    it("narrow fallback for the wide token", () => {
+      const result = parse("W", "cccc", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 2));
+    });
+
     it("allows to specify which day is the first day of the week", () => {
       const result = parse("7th", "co", referenceDate, {
         weekStartsOn: /* Fri */ 5,
@@ -1191,6 +1421,16 @@ describe("parse", () => {
       expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 11));
     });
 
+    it("narrow fallback for the abbreviated token", () => {
+      const result = parse("5 p", "h a", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 17));
+    });
+
+    it("narrow fallback for the wide token", () => {
+      const result = parse("5 p", "h aaaa", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 17));
+    });
+
     describe("validation", () => {
       [
         ["a", "AM"],
@@ -1231,6 +1471,16 @@ describe("parse", () => {
       expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 0));
     });
 
+    it("narrow fallback for the abbreviated token", () => {
+      const result = parse("mi", "b", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 0));
+    });
+
+    it("narrow fallback for the wide token", () => {
+      const result = parse("mi", "bbbb", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 0));
+    });
+
     describe("validation", () => {
       [
         ["a", "AM"],
@@ -1268,6 +1518,21 @@ describe("parse", () => {
 
     it("narrow", () => {
       const result = parse("5 in the evening", "h BBBBB", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 17));
+    });
+
+    it("morning", () => {
+      const result = parse("in the morning", "B", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 4));
+    });
+
+    it("narrow fallback for the abbreviated token", () => {
+      const result = parse("5 p", "h B", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 17));
+    });
+
+    it("narrow fallback for the wide token", () => {
+      const result = parse("5 p", "h BBBB", referenceDate);
       expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 17));
     });
 
@@ -1387,6 +1652,16 @@ describe("parse", () => {
     it("zero-padding", () => {
       const result = parse("1", "KK", referenceDate);
       expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 1));
+    });
+
+    it("with AM", () => {
+      const result = parse("11 AM", "K a", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 11));
+    });
+
+    it("with PM", () => {
+      const result = parse("11 PM", "K a", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 23));
     });
 
     describe("validation", () => {
@@ -2238,6 +2513,21 @@ describe("parse", () => {
       const dateString = "2017-01-01";
       const formatString = "MMMM do yyyy";
       const result = parse(dateString, formatString, referenceDate);
+      expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
+    });
+
+    it("returns `Invalid Date` if a numeric token fails to parse a value", () => {
+      const result = parse("abc", "MM", referenceDate);
+      expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
+    });
+
+    it("returns `Invalid Date` if an ordinal token fails to parse a value", () => {
+      const result = parse("abc", "do", referenceDate);
+      expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
+    });
+
+    it("returns `Invalid Date` if a timezone token fails to parse a value", () => {
+      const result = parse("abc", "xx", referenceDate);
       expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
     });
 

--- a/pkgs/core/src/parseISO/index.ts
+++ b/pkgs/core/src/parseISO/index.ts
@@ -244,7 +244,8 @@ function parseTimezone(timezoneString: string): number {
   if (timezoneString === "Z") return 0;
 
   const captures = timezoneString.match(timezoneRegex);
-  if (!captures) return 0;
+  // Invalid ISO-formatted timezone
+  if (!captures) return NaN;
 
   const sign = captures[1] === "+" ? -1 : 1;
   const hours = parseInt(captures[2]);

--- a/pkgs/core/src/parseISO/test.ts
+++ b/pkgs/core/src/parseISO/test.ts
@@ -291,6 +291,12 @@ describe("parseISO", () => {
     });
 
     describe("date", () => {
+      it("returns `Invalid Date` for malformed date component", () => {
+        const result = parseISO("2014-1");
+        expect(result instanceof Date).toBe(true);
+        expect(isNaN(result.getTime())).toBe(true);
+      });
+
       it("returns `Invalid Date` when it contains spaces after the date", () => {
         const result = parseISO("2014-02-11  basketball");
         expect(result instanceof Date).toBe(true);
@@ -344,6 +350,12 @@ describe("parseISO", () => {
     describe("timezones", () => {
       it("returns `Invalid Date` for invalid timezone minutes", () => {
         const result = parseISO("2014-02-11T21:35:45+04:60");
+        expect(result instanceof Date).toBe(true);
+        expect(isNaN(result.getTime())).toBe(true);
+      });
+
+      it("returns `Invalid Date` for malformed timezone", () => {
+        const result = parseISO("2014-02-11T21:35:45+04:5");
         expect(result instanceof Date).toBe(true);
         expect(isNaN(result.getTime())).toBe(true);
       });

--- a/pkgs/core/src/roundToNearestHours/test.ts
+++ b/pkgs/core/src/roundToNearestHours/test.ts
@@ -247,6 +247,32 @@ describe("roundToNearestHours", () => {
     });
   });
 
+  it("returns `Invalid Date` if nearestTo is less than 1", () => {
+    const result = roundToNearestHours(makeDate(15), {
+      // @ts-expect-error - testing the runtime validation of the option
+      nearestTo: 0,
+    });
+    expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
+  });
+
+  it("returns `Invalid Date` if nearestTo is greater than 12", () => {
+    const result = roundToNearestHours(makeDate(15), {
+      // @ts-expect-error - testing the runtime validation of the option
+      nearestTo: 13,
+    });
+    expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
+  });
+
+  it("returns invalid date of the context type if nearestTo is out of range", () => {
+    const result = roundToNearestHours("2024-04-10T07:00:00Z", {
+      // @ts-expect-error - testing the runtime validation of the option
+      nearestTo: 13,
+      in: tz("Asia/Singapore"),
+    });
+    expect(result).toBeInstanceOf(TZDate);
+    expect(isNaN(result.getTime())).toBe(true);
+  });
+
   it("resolves the date type by default", () => {
     const result = roundToNearestHours(Date.now());
     expect(result).toBeInstanceOf(Date);

--- a/pkgs/core/src/roundToNearestMinutes/test.ts
+++ b/pkgs/core/src/roundToNearestMinutes/test.ts
@@ -261,6 +261,22 @@ describe("roundToNearestMinutes", () => {
     expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
   });
 
+  it("returns `Invalid Date` if nearestTo is less than 1", () => {
+    const result = roundToNearestMinutes(makeDate(15), {
+      // @ts-expect-error - testing the runtime validation of the option
+      nearestTo: 0,
+    });
+    expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
+  });
+
+  it("returns `Invalid Date` if nearestTo is greater than 30", () => {
+    const result = roundToNearestMinutes(makeDate(15), {
+      // @ts-expect-error - testing the runtime validation of the option
+      nearestTo: 31,
+    });
+    expect(result instanceof Date && isNaN(result.getTime())).toBe(true);
+  });
+
   it("resolves the date type by default", () => {
     const result = roundToNearestMinutes(Date.now());
     expect(result).toBeInstanceOf(Date);

--- a/pkgs/core/src/setDefaultOptions/test.ts
+++ b/pkgs/core/src/setDefaultOptions/test.ts
@@ -43,6 +43,11 @@ describe("setDefaultOptions", () => {
     });
   });
 
+  it("ignores inherited properties", () => {
+    setDefaultOptions(Object.create({ weekStartsOn: 1 }) as DefaultOptions);
+    expect(getInternalDefaultOptions()).toEqual({});
+  });
+
   it("merges with previous `defaultOptions` calls", () => {
     setDefaultOptions({ weekStartsOn: 1 });
     setDefaultOptions({ firstWeekContainsDate: 4 });

--- a/pkgs/core/src/transpose/test.ts
+++ b/pkgs/core/src/transpose/test.ts
@@ -1,8 +1,22 @@
 import { TZDate, tz } from "@date-fns/tz";
+import { UTCDate } from "@date-fns/utc";
 import { describe, expect, it } from "vitest";
 import { transpose } from "./index.ts";
 
 describe("transpose", () => {
+  it("allows to use date constructor", () => {
+    const date = new Date(2022, 6, 10, 12, 34, 56, 789);
+    const result = transpose(date, UTCDate);
+    expect(result instanceof UTCDate).toBe(true);
+    expect(result.getFullYear()).toBe(2022);
+    expect(result.getMonth()).toBe(6);
+    expect(result.getDate()).toBe(10);
+    expect(result.getHours()).toBe(12);
+    expect(result.getMinutes()).toBe(34);
+    expect(result.getSeconds()).toBe(56);
+    expect(result.getMilliseconds()).toBe(789);
+  });
+
   it("allows to use context function", () => {
     const date = new Date(2022, 6, 10, 12, 34, 56, 789);
     const result = transpose(date, tz("Asia/Singapore"));


### PR DESCRIPTION
## Summary

This PR adds unit tests for previously uncovered lines and branches in the core package, and fixes two small bugs found along the way.

Coverage of the `main` test project (`pnpm vitest run --project main --coverage`):

| Metric | Before | After | Delta |
| --- | --- | --- | --- |
| Statements | 95.87% | 99.60% | +3.73 |
| Branches | 89.92% | 98.87% | +8.95 |
| Functions | 95.25% | 100% | +4.75 |
| Lines | 96.08% | 99.76% | +3.68 |

## Bug fixes

- **`parseISO`**: a malformed timezone component (e.g. `parseISO("2014-02-11T21:35:45+04:5")`) was silently ignored and the date was interpreted as UTC. It now returns `Invalid Date`, consistent with the documented behavior and with the existing handling of invalid timezone minutes (`+04:60`).
- **`fr` locale**: removed a stray trailing quote in the `formatRelative` `tomorrow` format (`"'demain à' p'"` → `"'demain à' p"`). The rendered output is unchanged (verified against the locale snapshot).

## Tests added

- **`parse`**: locale width fallback chains for era (`G`, `GGGG`), quarter (`QQQ`/`QQQQ`, `qqq`/`qqqq`), month (`MMM`/`MMMM`, `LLL`/`LLLL`), day of week (`EEE`/`EEEE`/`EEEEEE`, `iii`/`iiii`/`iiiiii`, `eee`/`eeee`/`eeeeee`, `ccc`/`cccc`/`cccccc`), and day periods (`a`, `b`, `B`); two-digit year normalization (previous-century range, first-century and BC reference dates, `00` → year 100); `K` hour combined with AM/PM; flexible day period `in the morning`; failure paths for numeric, ordinal, and timezone tokens
- **`format`**: positive UTC offset branches of the timezone formatters (`X`/`O` token families)
- **`parseISO`**: malformed date component (`2014-1`) and malformed timezone
- **`roundToNearestMinutes` / `roundToNearestHours`**: `nearestTo` bounds validation, including the context (`in`) variant
- **`intlFormatDistance`**: `month` and `year` units
- **`formatDuration`**: locale without `formatDistance` returns an empty string
- **`transpose`**: date constructor argument (in addition to the context function)
- **`setDefaultOptions`**: inherited properties are ignored
- **Locales `fr`, `eo`, `zh-CN`, `zh-HK`, `zh-TW`**: `formatDistance` forms and suffixes, `formatRelative` (including the zh-CN same/last/next week logic), `ordinalNumber` unit handling, quarter localize/match callbacks; plus `en-US` tests for the shared locale builders' default-width fallbacks (`buildFormatLongFn`, `buildLocalizeFn`, `buildMatchFn`/`buildMatchPatternFn` `valueCallback` options)

The remaining uncovered lines are either test infrastructure (`src/_lib/test/*`) or unreachable defensive branches (e.g. the `cleanEscapedString` fallbacks in `format`/`lightFormat`, the `timestampIsSet` guards in the ISO timezone parsers, which are shielded by incompatible-token validation).

Per the contributing guide, no changelog or version changes are included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSCLCquMBxbcA1QzUxKVt4