### PR TITLE
fix(locale): accept 季 forms when parsing zh-CN quarters

### DIFF
--- a/pkgs/core/src/locale/zh-CN/_lib/match/index.ts
+++ b/pkgs/core/src/locale/zh-CN/_lib/match/index.ts
@@ -17,8 +17,9 @@ const parseEraPatterns = {
 
 const matchQuarterPatterns = {
   narrow: /^[1234]/i,
-  abbreviated: /^第[一二三四]刻/i,
-  wide: /^第[一二三四]刻钟/i,
+  // Match localize output (季/季度); keep 刻/刻钟 for pre-#2771 strings
+  abbreviated: /^第[一二三四](季|刻)/i,
+  wide: /^第[一二三四](季度|刻钟)/i,
 };
 const parseQuarterPatterns = {
   any: [/(1|一)/i, /(2|二)/i, /(3|三)/i, /(4|四)/i] as const,

--- a/pkgs/core/src/locale/zh-CN/test.ts
+++ b/pkgs/core/src/locale/zh-CN/test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { format } from "../../format/index.ts";
 import { parse } from "../../parse/index.ts";
 import { zhCN } from "./index.ts";
 
@@ -29,5 +30,31 @@ describe("zh-CN locale", () => {
         locale: zhCN,
       }),
     ).toEqual(new Date(2022, 11 /* Dec */, 27));
+  });
+
+  it("round-trips localized quarter tokens (QQQ/QQQQ)", () => {
+    const date = new Date(2024, 6 /* Jul */, 1);
+    const ref = new Date(2024, 0 /* Jan */, 1);
+
+    expect(format(date, "QQQ", { locale: zhCN })).toBe("第三季");
+    expect(parse("第三季", "QQQ", ref, { locale: zhCN })).toEqual(
+      new Date(2024, 6 /* Jul */, 1),
+    );
+
+    expect(format(date, "QQQQ", { locale: zhCN })).toBe("第三季度");
+    expect(parse("第三季度", "QQQQ", ref, { locale: zhCN })).toEqual(
+      new Date(2024, 6 /* Jul */, 1),
+    );
+  });
+
+  it("still parses legacy 刻 quarter forms", () => {
+    const ref = new Date(2024, 0 /* Jan */, 1);
+
+    expect(parse("第三刻", "QQQ", ref, { locale: zhCN })).toEqual(
+      new Date(2024, 6 /* Jul */, 1),
+    );
+    expect(parse("第三刻钟", "QQQQ", ref, { locale: zhCN })).toEqual(
+      new Date(2024, 6 /* Jul */, 1),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- After #2771, zh-CN `format` with `QQQ`/`QQQQ` produces 季/季度 strings, but `matchQuarterPatterns` still only accepted the old 刻/刻钟 forms, so a format then parse round-trip returned `Invalid Date`.
- Update the match patterns to accept 季/季度 (same as zh-HK), while still accepting legacy 刻/刻钟 input.
- Add regression tests for the round-trip and the legacy forms.

Fixes #4270

## Test plan
- [x] `pnpm vitest run src/locale/zh-CN/test.ts` in `pkgs/core` (4 passed)