### PR TITLE
fix: parse en-US narrow noon day period

### DIFF
--- a/pkgs/core/src/locale/en-US/_lib/match/index.ts
+++ b/pkgs/core/src/locale/en-US/_lib/match/index.ts
@@ -80,7 +80,7 @@ const parseDayPeriodPatterns = {
     am: /^a/i,
     pm: /^p/i,
     midnight: /^mi/i,
-    noon: /^no/i,
+    noon: /^n/i,
     morning: /morning/i,
     afternoon: /afternoon/i,
     evening: /evening/i,

--- a/pkgs/core/src/parse/test.ts
+++ b/pkgs/core/src/parse/test.ts
@@ -1231,6 +1231,11 @@ describe("parse", () => {
       expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 0));
     });
 
+    it("narrow noon", () => {
+      const result = parse("n", "bbbbb", referenceDate);
+      expect(result).toEqual(new Date(1986, 3 /* Apr */, 4, 12));
+    });
+
     describe("validation", () => {
       [
         ["a", "AM"],


### PR DESCRIPTION
## Summary

Fixes #4271 by mapping the en-US narrow noon day-period form (`n`) back to `noon` during parsing.

This keeps `format(noon, "bbbbb")` / `parse("n", "bbbbb", ...)` round-trips at 12:00 instead of silently falling through to midnight.

## Checks run locally

- `npx vitest run src/parse/test.ts -t 'AM, PM, noon, midnight'` from `pkgs/core` — 11 passed, 530 skipped
- `npx oxlint pkgs/core/src/locale/en-US/_lib/match/index.ts pkgs/core/src/parse/test.ts` — clean
- `git diff --check` — clean

## Disclosure

This contribution was prepared with AI assistance and locally verified before submission.
