### PR TITLE
fix(locale): use localized parseDayPatterns for hr, bs and sr-Latn

### DIFF
--- a/pkgs/core/src/locale/bs/_lib/match/index.ts
+++ b/pkgs/core/src/locale/bs/_lib/match/index.ts
@@ -67,8 +67,8 @@ const matchDayPatterns = {
   wide: /^(nedjelja|ponedjeljak|utorak|srijeda|(četvrtak|cetvrtak)|petak|subota)/i,
 };
 const parseDayPatterns = {
-  narrow: [/^s/i, /^m/i, /^t/i, /^w/i, /^t/i, /^f/i, /^s/i] as const,
-  any: [/^su/i, /^m/i, /^tu/i, /^w/i, /^th/i, /^f/i, /^sa/i] as const,
+  narrow: [/^n/i, /^p/i, /^u/i, /^s/i, /^(č|c)/i, /^p/i, /^s/i] as const,
+  any: [/^ne/i, /^po/i, /^u/i, /^sr/i, /^(č|c)/i, /^pe/i, /^su/i] as const,
 };
 
 const matchDayPeriodPatterns = {

--- a/pkgs/core/src/locale/hr/_lib/match/index.ts
+++ b/pkgs/core/src/locale/hr/_lib/match/index.ts
@@ -81,8 +81,8 @@ const matchDayPatterns = {
   wide: /^(nedjelja|ponedjeljak|utorak|srijeda|(četvrtak|cetvrtak)|petak|subota)/i,
 };
 const parseDayPatterns = {
-  narrow: [/^s/i, /^m/i, /^t/i, /^w/i, /^t/i, /^f/i, /^s/i] as const,
-  any: [/^su/i, /^m/i, /^tu/i, /^w/i, /^th/i, /^f/i, /^sa/i] as const,
+  narrow: [/^n/i, /^p/i, /^u/i, /^s/i, /^(č|c)/i, /^p/i, /^s/i] as const,
+  any: [/^ne/i, /^po/i, /^u/i, /^sr/i, /^(č|c)/i, /^pe/i, /^su/i] as const,
 };
 
 const matchDayPeriodPatterns = {

--- a/pkgs/core/src/locale/sr-Latn/_lib/match/index.ts
+++ b/pkgs/core/src/locale/sr-Latn/_lib/match/index.ts
@@ -67,8 +67,8 @@ const matchDayPatterns = {
   wide: /^(nedelja|ponedeljak|utorak|sreda|(četvrtak|cetvrtak)|petak|subota)/i,
 };
 const parseDayPatterns = {
-  narrow: [/^s/i, /^m/i, /^t/i, /^w/i, /^t/i, /^f/i, /^s/i] as const,
-  any: [/^su/i, /^m/i, /^tu/i, /^w/i, /^th/i, /^f/i, /^sa/i] as const,
+  narrow: [/^n/i, /^p/i, /^u/i, /^s/i, /^(č|c)/i, /^p/i, /^s/i] as const,
+  any: [/^ne/i, /^po/i, /^u/i, /^sr/i, /^(č|c)/i, /^pe/i, /^su/i] as const,
 };
 
 const matchDayPeriodPatterns = {

--- a/pkgs/core/src/parse/test.ts
+++ b/pkgs/core/src/parse/test.ts
@@ -3,6 +3,7 @@ import { parse } from "./index.ts";
 import { assertType } from "../_lib/test/index.ts";
 import { UTCDate } from "@date-fns/utc";
 import { TZDate, tz } from "@date-fns/tz";
+import { bs, hr, srLatn } from "../locale/index.ts";
 
 describe("parse", () => {
   const referenceDate = new Date(1986, 3 /* Apr */, 4, 10, 32, 0, 900);
@@ -906,6 +907,26 @@ describe("parse", () => {
         weekStartsOn: /* Fri */ 5,
       });
       expect(result).toEqual(new Date(1986, 3 /* Apr */, 10));
+    });
+
+    it("parses localized weekday names for hr, bs and sr-Latn (issue with English parse patterns)", () => {
+      // These locales previously shipped English `parseDayPatterns`
+      // (su/m/tu/w/th/f/sa), so parsing their own weekday output failed.
+      const cases = [
+        [hr, "ponedjeljak", 1 /* Mon */],
+        [hr, "srijeda", 3 /* Wed */],
+        [hr, "subota", 6 /* Sat */],
+        [bs, "utorak", 2 /* Tue */],
+        [bs, "srijeda", 3 /* Wed */],
+        [bs, "subota", 6 /* Sat */],
+        [srLatn, "sreda", 3 /* Wed */],
+        [srLatn, "petak", 5 /* Fri */],
+        [srLatn, "subota", 6 /* Sat */],
+      ] as const;
+      for (const [locale, input, day] of cases) {
+        const result = parse(input, "EEEE", referenceDate, { locale });
+        expect(result.getDay()).toBe(day);
+      }
     });
 
     describe("validation", () => {


### PR DESCRIPTION
## Problem

`format` and `parse` do not round-trip for weekday names in the **hr**, **bs**, and **sr-Latn** locales. Parsing a locale's own `format(date, "EEEE", { locale })` output returns `Invalid Date`.

```js
import { format, parse } from "date-fns";
import { hr, bs, srLatn } from "date-fns/locale";

const d = new Date(2024, 0, 8); // Monday
const ref = new Date(2024, 0, 1);

format(d, "EEEE", { locale: hr });                    //=> "ponedjeljak"
parse("ponedjeljak", "EEEE", ref, { locale: hr });    //=> Invalid Date  ❌
parse("utorak",      "EEEE", ref, { locale: bs });    //=> Invalid Date  ❌
parse("sreda",       "EEEE", ref, { locale: srLatn });//=> Invalid Date  ❌
```

This affects every weekday token (`E`, `EEEE`, `c`, …) and every width for these three locales.

## Root cause

In each locale's `_lib/match/index.ts`, `parseDayPatterns` still contains the **English** patterns copied from the en-US template:

```js
const parseDayPatterns = {
  narrow: [/^s/i, /^m/i, /^t/i, /^w/i, /^t/i, /^f/i, /^s/i] as const,
  any: [/^su/i, /^m/i, /^tu/i, /^w/i, /^th/i, /^f/i, /^sa/i] as const,
};
```

The sibling `matchDayPatterns` correctly match the localized names (`ponedjeljak`, `utorak`, …), but the parser then can't map any of those matches to a weekday index, so parsing fails. The Cyrillic `sr` locale and `cs` locale have properly localized `parseDayPatterns`; these three were missed.

## Fix

Replace the English patterns with ones based on the actual localized day names, following the existing `cs` / `sr` style:

```js
const parseDayPatterns = {
  narrow: [/^n/i, /^p/i, /^u/i, /^s/i, /^(č|c)/i, /^p/i, /^s/i] as const,
  any: [/^ne/i, /^po/i, /^u/i, /^sr/i, /^(č|c)/i, /^pe/i, /^su/i] as const,
};
```

(Wednesday `sr…` / Saturday `su…` are disambiguated by the second letter. Narrow ambiguity for repeated initials — P, S — resolves to the first match, exactly as in the `cs` locale.)

## Tests

Added a regression test in `pkgs/core/src/parse/test.ts` asserting `EEEE` round-trips for `hr`, `bs`, and `sr-Latn`.

- `vitest run --project main` → **3149 passed**, 19 skipped, 0 failed.
- The pre-existing `.tp.ts` (`|temporarily|`/Temporal) failures are unrelated (`Temporal is not defined` in the local Node environment) and untouched by this change.