### PR TITLE
fix(tz): correct tzOffset sign for negative offsets of less than an hour

### DIFF
--- a/pkgs/tz/src/tzOffset/index.ts
+++ b/pkgs/tz/src/tzOffset/index.ts
@@ -54,8 +54,9 @@ function calcOffset(cacheStr: string, values: string[]): number {
   const minutes = +(values[1] || 0);
   // Convert seconds to minutes by dividing by 60 to keep the function return in minutes.
   const seconds = +(values[2] || 0) / 60;
+  // Read the sign from the hours string: for offsets between -00:01 and -00:59
+  // the hours number is -0, so the sign can't be derived from the number.
+  const sign = values[0]?.[0] === "-" ? -1 : 1;
   return (offsetCache[cacheStr] =
-    hours * 60 + minutes > 0
-      ? hours * 60 + minutes + seconds
-      : hours * 60 - minutes - seconds);
+    sign * (Math.abs(hours) * 60 + minutes + seconds));
 }

--- a/pkgs/tz/src/tzOffset/tests.ts
+++ b/pkgs/tz/src/tzOffset/tests.ts
@@ -67,6 +67,7 @@ describe("tzOffset", () => {
     it("works with ±HH:MM", () => {
       expect(tzOffset("-05:00", date)).toBe(-300);
       expect(tzOffset("-02:30", date)).toBe(-150);
+      expect(tzOffset("-00:30", date)).toBe(-30);
       expect(tzOffset("+05:00", date)).toBe(300);
       expect(tzOffset("+02:30", date)).toBe(150);
       expect(tzOffset("+05:00", new Date("1880-01-15T00:00:00Z"))).toBe(300);
@@ -75,6 +76,7 @@ describe("tzOffset", () => {
     it("works with ±HHMM", () => {
       expect(tzOffset("-0500", date)).toBe(-300);
       expect(tzOffset("-0230", date)).toBe(-150);
+      expect(tzOffset("-0030", date)).toBe(-30);
       expect(tzOffset("+0500", date)).toBe(300);
       expect(tzOffset("+0230", date)).toBe(150);
       expect(tzOffset("+0230", new Date("1880-01-15T00:00:00Z"))).toBe(150);
@@ -100,6 +102,12 @@ describe("tzOffset", () => {
       const date = new Date("2024-04-06T16:30:00.000Z");
       expect(tzOffset("Australia/Adelaide", dst)).toBe(630);
       expect(tzOffset("Australia/Adelaide", date)).toBe(570);
+    });
+
+    it("works with negative offsets of less than an hour", () => {
+      // Liberia used UTC-00:44:30 until January 1972
+      const date = new Date("1970-01-15T00:00:00Z");
+      expect(tzOffset("Africa/Monrovia", date)).toBe(-44.5);
     });
   });
 


### PR DESCRIPTION
## Bug

`tzOffset` returns a positive offset for time zones whose UTC offset is between -00:01 and -00:59, flipping the sign. This corrupts `TZDate` for those zones:

```js
import { tzOffset, TZDate } from "@date-fns/tz";

// Liberia used UTC-00:44:30 until January 1972
tzOffset("Africa/Monrovia", new Date("1970-01-15T00:00:00Z"));
//=> 44.5 (expected -44.5)

tzOffset("-00:30", new Date("2020-01-15T00:00:00Z"));
//=> 30 (expected -30)

new TZDate(1970, 0, 1, 12, 0, "Africa/Monrovia").toISOString();
// treats the zone as UTC+00:44:30, so the result is off by 89 minutes
```

Any LMT-era date in a zone slightly west of Greenwich hits the same path, e.g. `Europe/Dublin` before 1880 is -00:25:21 but comes back as +25.35. Zones at -01:00 or beyond (like the tested 1880 `America/New_York` LMT) are unaffected.

## Root cause

In `calcOffset` (`pkgs/tz/src/tzOffset/index.ts`), the sign is derived from the parsed numbers:

```ts
hours * 60 + minutes > 0
  ? hours * 60 + minutes + seconds
  : hours * 60 - minutes - seconds;
```

For `"-00:44:30"`, `+"-00"` evaluates to `-0`, so `hours * 60 + minutes` is `44` — positive — and the minutes/seconds get added instead of subtracted.

## Fix

Read the sign from the hours string (`"-00"`) instead of the number, then apply it to the absolute value. Both the `Intl` path and the manual `±HH:MM`/`±HHMM`/`±HH` fallback go through `calcOffset`, so both are covered.

## Tests

Added to `pkgs/tz/src/tzOffset/tests.ts`:

- `Africa/Monrovia` in 1970 → `-44.5` (Intl path, seconds-bearing offset)
- `"-00:30"` → `-30` and `"-0030"` → `-30` (offset string formats)

All three fail before the fix (returning `+44.5` / `+30`) and pass after; the rest of the `pkgs/tz` suite is unaffected.
