### PR TITLE
fix(differenceInMonths): make the result independent of argument order

### DIFF
--- a/pkgs/core/src/differenceInMonths/index.ts
+++ b/pkgs/core/src/differenceInMonths/index.ts
@@ -1,7 +1,7 @@
 import { normalizeDates } from "../_lib/normalizeDates/index.ts";
+import { addMonths } from "../addMonths/index.ts";
 import { compareAsc } from "../compareAsc/index.ts";
 import { differenceInCalendarMonths } from "../differenceInCalendarMonths/index.ts";
-import { isLastDayOfMonth } from "../isLastDayOfMonth/index.ts";
 import type { ContextOptions, DateArg } from "../types.ts";
 
 /**
@@ -14,6 +14,15 @@ export interface DifferenceInMonthsOptions extends ContextOptions<Date> {}
  * @category Month Helpers
  * @summary Get the number of full months between the given dates.
  *
+ * @description
+ * Get the number of full months between the given dates.
+ *
+ * A month counts as full when {@link addMonths} would carry the earlier date to
+ * the later one, which means the end of a short month counts: 31 January to 28
+ * February is one full month, because `addMonths` clamps 31 February to the 28th.
+ * The result therefore has the same magnitude whichever order the dates are
+ * given in.
+ *
  * @param laterDate - The later date
  * @param earlierDate - The earlier date
  * @param options - An object with options
@@ -24,40 +33,46 @@ export interface DifferenceInMonthsOptions extends ContextOptions<Date> {}
  * // How many full months are between 31 January 2014 and 1 September 2014?
  * const result = differenceInMonths(new Date(2014, 8, 1), new Date(2014, 0, 31))
  * //=> 7
+ *
+ * @example
+ * // The end of a short month counts as a full month:
+ * const result = differenceInMonths(
+ *   new Date(2014, 1, 28),
+ *   new Date(2014, 0, 31)
+ * )
+ * //=> 1
  */
 export function differenceInMonths(
   laterDate: DateArg<Date> & {},
   earlierDate: DateArg<Date> & {},
   options?: DifferenceInMonthsOptions | undefined,
 ): number {
-  const [laterDate_, workingLaterDate, earlierDate_] = normalizeDates(
+  const [laterDate_, earlierDate_] = normalizeDates(
     options?.in,
-    laterDate,
     laterDate,
     earlierDate,
   );
 
-  const sign = compareAsc(workingLaterDate, earlierDate_);
+  const sign = compareAsc(laterDate_, earlierDate_);
   const difference = Math.abs(
-    differenceInCalendarMonths(workingLaterDate, earlierDate_),
+    differenceInCalendarMonths(laterDate_, earlierDate_),
   );
 
   if (difference < 1) return 0;
 
-  if (workingLaterDate.getMonth() === 1 && workingLaterDate.getDate() > 27)
-    workingLaterDate.setDate(30);
-
-  workingLaterDate.setMonth(workingLaterDate.getMonth() - sign * difference);
-
-  let isLastMonthNotFull = compareAsc(workingLaterDate, earlierDate_) === -sign;
-
-  if (
-    isLastDayOfMonth(laterDate_) &&
-    difference === 1 &&
-    compareAsc(laterDate_, earlierDate_) === 1
-  ) {
-    isLastMonthNotFull = false;
-  }
+  // Walk the earlier of the two dates forward by the calendar-month difference
+  // and see whether it reaches the later one. addMonths clamps to the end of
+  // the target month, so this stays correct when the day-of-month doesn't exist
+  // there (31 January + 1 month is 28 February).
+  //
+  // Stepping the later date backwards instead is not equivalent, because
+  // clamping isn't invertible: 31 December + 2 months is 29 February 2024, but
+  // 29 February 2024 - 2 months is 29 December. Compensating for that on one
+  // operand only is what made differenceInMonths(a, b) and (b, a) disagree.
+  const [earlier, later] =
+    sign > 0 ? [earlierDate_, laterDate_] : [laterDate_, earlierDate_];
+  const isLastMonthNotFull =
+    compareAsc(addMonths(earlier, difference), later) === 1;
 
   const result = sign * (difference - +isLastMonthNotFull);
   return result === 0 ? 0 : result;

--- a/pkgs/core/src/differenceInMonths/test.ts
+++ b/pkgs/core/src/differenceInMonths/test.ts
@@ -1,5 +1,6 @@
 import { TZDate, tz } from "@date-fns/tz";
 import { describe, expect, it } from "vitest";
+import { addMonths } from "../addMonths/index.ts";
 import type { ContextOptions, DateArg } from "../types.ts";
 import { differenceInMonths } from "./index.ts";
 
@@ -121,6 +122,94 @@ describe("differenceInMonths", () => {
 
       const resultIsNegative = isNegativeZero(result);
       expect(resultIsNegative).toBe(false);
+    });
+
+    it("counts a whole year between Feb 28 2026 and Feb 28 2027", () => {
+      const result = differenceInMonths(
+        new Date(2027, 1 /* Feb */, 28),
+        new Date(2026, 1 /* Feb */, 28),
+      );
+      expect(result).toBe(12);
+    });
+
+    it("gives the same magnitude whichever way round the arguments go", () => {
+      // The later date landing on the last day of February used to change the
+      // magnitude depending on argument order.
+      expect(
+        differenceInMonths(
+          new Date(2027, 1 /* Feb */, 28),
+          new Date(2026, 1 /* Feb */, 28),
+        ),
+      ).toBe(12);
+      expect(
+        differenceInMonths(
+          new Date(2026, 1 /* Feb */, 28),
+          new Date(2027, 1 /* Feb */, 28),
+        ),
+      ).toBe(-12);
+
+      expect(
+        differenceInMonths(
+          new Date(2025, 1 /* Feb */, 28),
+          new Date(2024, 4 /* May */, 30),
+        ),
+      ).toBe(9);
+      expect(
+        differenceInMonths(
+          new Date(2024, 4 /* May */, 30),
+          new Date(2025, 1 /* Feb */, 28),
+        ),
+      ).toBe(-9);
+    });
+
+    it("round-trips with addMonths, which clamps to the month end", () => {
+      // In a common year 31 January + 1 month clamps to the 28th...
+      const jan31 = new Date(2026, 0 /* Jan */, 31);
+      expect(addMonths(jan31, 1)).toEqual(new Date(2026, 1 /* Feb */, 28));
+      expect(differenceInMonths(addMonths(jan31, 1), jan31)).toBe(1);
+      expect(differenceInMonths(addMonths(jan31, 3), jan31)).toBe(3);
+
+      // ...and in a leap year it clamps to the 29th instead
+      const leapJan31 = new Date(2024, 0 /* Jan */, 31);
+      expect(addMonths(leapJan31, 1)).toEqual(new Date(2024, 1 /* Feb */, 29));
+      expect(differenceInMonths(addMonths(leapJan31, 1), leapJan31)).toBe(1);
+
+      const leapDay = new Date(2024, 1 /* Feb */, 29);
+      expect(differenceInMonths(addMonths(leapDay, 12), leapDay)).toBe(12);
+    });
+
+    it("follows the century leap year rules", () => {
+      // 2000 is divisible by 400, so it is a leap year and 29 February exists
+      const y2kJan31 = new Date(2000, 0 /* Jan */, 31);
+      expect(addMonths(y2kJan31, 1)).toEqual(new Date(2000, 1 /* Feb */, 29));
+      expect(differenceInMonths(addMonths(y2kJan31, 1), y2kJan31)).toBe(1);
+      expect(
+        differenceInMonths(
+          new Date(2001, 1 /* Feb */, 28),
+          new Date(2000, 1 /* Feb */, 29),
+        ),
+      ).toBe(12);
+      expect(
+        differenceInMonths(
+          new Date(2000, 1 /* Feb */, 29),
+          new Date(2001, 1 /* Feb */, 28),
+        ),
+      ).toBe(-12);
+
+      // 1900 and 2100 are divisible by 100 but not 400, so February has 28 days
+      const jan31In1900 = new Date(1900, 0 /* Jan */, 31);
+      expect(addMonths(jan31In1900, 1)).toEqual(
+        new Date(1900, 1 /* Feb */, 28),
+      );
+      expect(differenceInMonths(addMonths(jan31In1900, 1), jan31In1900)).toBe(
+        1,
+      );
+      expect(
+        differenceInMonths(
+          new Date(2101, 1 /* Feb */, 28),
+          new Date(2100, 1 /* Feb */, 28),
+        ),
+      ).toBe(12);
     });
   });
 


### PR DESCRIPTION
`differenceInMonths(a, b)` and `differenceInMonths(b, a)` can disagree in magnitude whenever the later of the two dates falls in February on the 28th or 29th:

```js
differenceInMonths(new Date(2027, 1, 28), new Date(2026, 1, 28)) //=> 12
differenceInMonths(new Date(2026, 1, 28), new Date(2027, 1, 28)) //=> -11   <-- same pair
differenceInMonths(new Date(2026, 2, 28), new Date(2027, 2, 28)) //=> -12   <-- March, fine
differenceInCalendarMonths(new Date(2026, 1, 28), new Date(2027, 1, 28)) //=> -12
```

28 February 2026 to 28 February 2027 is a whole year either way round, and `differenceInCalendarMonths` already says 12 for the same pair.

## Cause

The function decides whether the final partial month is full by stepping the later date backwards with `Date#setMonth` and comparing. `setMonth` rolls over when the day-of-month doesn't exist in the target month, so stepping back two months from 29 February 2024 lands on 29 December, not 31 December. A special case pushed February dates to the 30th first to compensate:

```js
if (workingLaterDate.getMonth() === 1 && workingLaterDate.getDate() > 27)
  workingLaterDate.setDate(30);
```

That compensation applies to one operand only, which is why the answer depends on which argument comes first.

## Fix

Step the *earlier* date forwards with `addMonths` instead. `addMonths` already clamps to the end of the target month, so nothing needs compensating and the two directions cannot disagree. Both the February special case and the now-redundant `isLastDayOfMonth` branch come out.

This also makes the round-trip hold:

```js
differenceInMonths(addMonths(d, n), d) === n
```

which is the property the February special case broke. It felt like the right invariant to aim at because it is internal to date-fns: `addMonths` clamps, so `differenceInMonths` has to use the same rule or the two functions contradict each other. `addDays` never faces this because every step is the same size; `addMonths` moves between fields of different lengths, so it must decide what 31 January + 1 month means, and date-fns decided it means 28 February.

## Verification

Swept every day from 1900 to 2100, which covers 1900 and 2100 (divisible by 100, not leap) and 2000 (divisible by 400, leap):

| | before | after |
|---|---|---|
| asymmetric pairs, 954,382 swept | 1,804 | 0 |
| `differenceInMonths(addMonths(d, n), d) === n`, 734,140 checked | 4,623 violations | 0 |
| `differenceInMonths` suite | 21 pass | 25 pass |
| full `pkgs/core` suite | 3,166 pass | 3,169 pass |
| `mise //pkgs/core:test/tz` | | all 378 time zones pass |
| `mise //:lint`, `mise //:types` | | clean |
| bundled size of the function | 1,079 B min / 576 B gzip | 987 B min / 561 B gzip |

Size goes down because `isLastDayOfMonth` pulled in `endOfDay` and `endOfMonth`, while `addMonths` only adds `constructFrom`.

The `pkgs/core` suite has 46 pre-existing failures in `*.tp.ts` on Node 22, from `Temporal` not being defined. Identical count before and after this change.

## One note on the Temporal migration

Since `index.tp.ts` implementations get run against the same test file, it's worth flagging that a naive `since()` won't satisfy the existing `context` test when the migration reaches this function: Temporal gives 1 for 31 December 2023 to 29 February 2024, and the test asserts 2. Temporal counts exact anniversaries where `addMonths` clamps. So the Temporal version will need the clamping rule built on top of it. The tests added here pin that rule explicitly, so it should be straightforward to satisfy.

Refs #3436, #3685, #2178, #1929, #3041, #3316, #3534, #1887
