### PR TITLE
Fix `eachMonthOfInterval` and `eachYearOfInterval` on days without midnight

### DIFF
--- a/pkgs/core/src/eachMonthOfInterval/index.ts
+++ b/pkgs/core/src/eachMonthOfInterval/index.ts
@@ -68,8 +68,8 @@ export function eachMonthOfInterval<
   let reversed = +start > +end;
   const endTime = reversed ? +start : +end;
   const date = reversed ? end : start;
-  date.setHours(0, 0, 0, 0);
   date.setDate(1);
+  date.setHours(0, 0, 0, 0);
 
   let step = options?.step ?? 1;
   if (!step) return [];
@@ -83,6 +83,7 @@ export function eachMonthOfInterval<
   while (+date <= endTime) {
     dates.push(constructFrom(start, date));
     date.setMonth(date.getMonth() + step);
+    date.setHours(0, 0, 0, 0);
   }
 
   return reversed ? dates.reverse() : dates;

--- a/pkgs/core/src/eachMonthOfInterval/test.ts
+++ b/pkgs/core/src/eachMonthOfInterval/test.ts
@@ -96,6 +96,20 @@ describe("eachMonthOfInterval", () => {
     ]);
   });
 
+  it("returns starts of months when the interval start is on a day that has no midnight", () => {
+    // In America/Havana the clocks move from 00:00 to 01:00 on 12 March 2023,
+    // so that day has no midnight.
+    const result = eachMonthOfInterval({
+      start: new TZDate(2023, 2 /* Mar */, 12, 12, "America/Havana"),
+      end: new TZDate(2023, 4 /* May */, 20, 12, "America/Havana"),
+    });
+    expect(result.map((d) => d.toISOString())).toEqual([
+      "2023-03-01T00:00:00.000-05:00",
+      "2023-04-01T00:00:00.000-04:00",
+      "2023-05-01T00:00:00.000-04:00",
+    ]);
+  });
+
   it("returns an empty array if the start date is `Invalid Date`", () => {
     const result = eachMonthOfInterval({
       start: new Date(NaN),

--- a/pkgs/core/src/eachYearOfInterval/index.ts
+++ b/pkgs/core/src/eachYearOfInterval/index.ts
@@ -68,8 +68,8 @@ export function eachYearOfInterval<
   let reversed = +start > +end;
   const endTime = reversed ? +start : +end;
   const date = reversed ? end : start;
-  date.setHours(0, 0, 0, 0);
   date.setMonth(0, 1);
+  date.setHours(0, 0, 0, 0);
 
   let step = options?.step ?? 1;
   if (!step) return [];
@@ -83,6 +83,7 @@ export function eachYearOfInterval<
   while (+date <= endTime) {
     dates.push(constructFrom(start, date));
     date.setFullYear(date.getFullYear() + step);
+    date.setHours(0, 0, 0, 0);
   }
 
   return reversed ? dates.reverse() : dates;

--- a/pkgs/core/src/eachYearOfInterval/test.ts
+++ b/pkgs/core/src/eachYearOfInterval/test.ts
@@ -81,6 +81,20 @@ describe("eachYearOfInterval", () => {
     ]);
   });
 
+  it("returns starts of years when the interval start is on a day that has no midnight", () => {
+    // In America/Havana the clocks move from 00:00 to 01:00 on 12 March 2023,
+    // so that day has no midnight.
+    const result = eachYearOfInterval({
+      start: new TZDate(2023, 2 /* Mar */, 12, 12, "America/Havana"),
+      end: new TZDate(2025, 4 /* May */, 20, 12, "America/Havana"),
+    });
+    expect(result.map((d) => d.toISOString())).toEqual([
+      "2023-01-01T00:00:00.000-05:00",
+      "2024-01-01T00:00:00.000-05:00",
+      "2025-01-01T00:00:00.000-05:00",
+    ]);
+  });
+
   it("returns an empty array if the start date is `Invalid Date`", () => {
     const result = eachYearOfInterval({
       start: new Date(NaN),


### PR DESCRIPTION
## Problem

`eachMonthOfInterval` and `eachYearOfInterval` do not return starts of months/years when the interval's start date falls on a day whose local midnight does not exist.

Several zones move the clock forward *at* 00:00 rather than at 02:00 or 03:00 — America/Havana, America/Santiago, Asia/Beirut, Asia/Damascus, America/Asuncion, and America/Sao_Paulo historically. On those days there is no 00:00, and both functions return every element an hour late.

```js
// TZ=America/Havana, date-fns 4.4.0
// 8 March 2026 is the day Cuba moves 00:00 -> 01:00
const d = new Date(2026, 2, 8, 12, 0, 0);

startOfMonth(d);
//=> Sun Mar 01 2026 00:00:00 GMT-0500   ✅

eachMonthOfInterval({ start: d, end: new Date(2026, 5, 1) });
//=> Sun Mar 01 2026 01:00:00 GMT-0500   ❌
//   Wed Apr 01 2026 01:00:00 GMT-0400   ❌
//   Fri May 01 2026 01:00:00 GMT-0400   ❌

startOfYear(d);
//=> Thu Jan 01 2026 00:00:00 GMT-0500   ✅

eachYearOfInterval({ start: d, end: new Date(2028, 5, 1) });
//=> Thu Jan 01 2026 01:00:00 GMT-0500   ❌
//   Fri Jan 01 2027 01:00:00 GMT-0500   ❌
//   Sat Jan 01 2028 01:00:00 GMT-0500   ❌
```

Note that 1 March and 1 January have a perfectly ordinary midnight — the bad value comes from the *start* date and is then carried forward through the whole array. The results contradict the functions' own TSDoc ("The array with starts of months", examples showing `00:00:00`) and disagree with `startOfMonth` / `startOfYear` for the same input.

The same thing reproduces with `TZDate` from `@date-fns/tz`, independently of the process time zone, which is what the added tests use.

**This is not #3097 / #3031 / #2960.** Those report local midnight rendered as UTC (`2022-03-31T23:00:00.000Z` *is* 1 April 00:00 BST), which is correct behaviour. Here the values are an hour late *in the local zone itself* and disagree with `startOfMonth` / `startOfYear` on the same input. This PR does not fix those issues.

## Root cause

Both functions truncate the time-of-day **before** moving the cursor to the first day of the month/year:

```ts
// eachMonthOfInterval/index.ts
date.setHours(0, 0, 0, 0);
date.setDate(1);

// eachYearOfInterval/index.ts
date.setHours(0, 0, 0, 0);
date.setMonth(0, 1);
```

On a day with no local midnight, `setHours(0, 0, 0, 0)` cannot land on 00:00 and the engine normalises it forward to 01:00. `setDate(1)` / `setMonth(0, 1)` then preserve that 01:00 local time-of-day, so the cursor for the 1st is an hour late.

`startOfMonth` and `startOfYear` do the two operations in the opposite order and are therefore correct:

```ts
// startOfMonth/index.ts
_date.setDate(1);
_date.setHours(0, 0, 0, 0);

// startOfYear/index.ts
date_.setFullYear(date_.getFullYear(), 0, 1);
date_.setHours(0, 0, 0, 0);
```

There is a second, related gap: neither loop re-truncates after stepping, so a single unrepresentable midnight persists into every later element. `eachDayOfInterval` already guards against this by re-applying `setHours(0, 0, 0, 0)` after each step.

## Fix

Truncate **after** repositioning, in the same order as `startOfMonth` / `startOfYear`, and re-truncate after each step, matching `eachDayOfInterval`.

```diff
   const date = reversed ? end : start;
-  date.setHours(0, 0, 0, 0);
   date.setDate(1);
+  date.setHours(0, 0, 0, 0);
@@
   while (+date <= endTime) {
     dates.push(constructFrom(start, date));
     date.setMonth(date.getMonth() + step);
+    date.setHours(0, 0, 0, 0);
   }
```

(and the analogous change with `setMonth(0, 1)` / `setFullYear` in `eachYearOfInterval`).

Reordering alone is not sufficient — the in-loop truncation fixes a distinct case. Example: `TZ=Asia/Damascus`, `eachMonthOfInterval` over an interval starting 15 January 1991. 1 April 1991 is itself a day with no local midnight in Damascus, so the cursor becomes 01:00 there (correctly — `startOfMonth` returns 01:00 for that month too), and without the in-loop `setHours` that 01:00 is then carried into every following element:

```
reorder only:   Apr 01 1991 01:00:00   May 01 1991 01:00:00 ❌   Jun 01 1991 01:00:00 ❌
with both:      Apr 01 1991 01:00:00   May 01 1991 00:00:00 ✅   Jun 01 1991 00:00:00 ✅
```

Why this is safe:

- `setDate(1)` and `setMonth(0, 1)` can never overflow — day 1 exists in every month — so repositioning first is unconditionally valid, whatever the current day-of-month.
- The in-loop truncation is a no-op in the ordinary case, because the hours are already 0. It only matters when a month/year boundary *itself* has no midnight, and it cannot affect loop termination: a month or year step always advances further than the ≤ 1 h pullback.
- For a month whose own local midnight does not exist, the fixed function returns 01:00 — exactly what `startOfMonth` returns for that month. The two agree in every case I tested (18 time zones, 1970–2040, every day of the month at several times of day); this PR does not try to invent a midnight that does not exist.
- No public signature, option, or documented behaviour changes.

## Verification

**Fail then pass.** Reverting only the two `index.ts` files to `main` (keeping the new tests) and confirming the fix is genuinely absent from the restored files, then running the new tests:

```
 FAIL  src/eachMonthOfInterval/test.ts > returns starts of months when the interval start is on a day that has no midnight
- Expected
+ Received
  [
-   "2023-03-01T00:00:00.000-05:00",
-   "2023-04-01T00:00:00.000-04:00",
-   "2023-05-01T00:00:00.000-04:00",
+   "2023-03-01T01:00:00.000-05:00",
+   "2023-04-01T01:00:00.000-04:00",
+   "2023-05-01T01:00:00.000-04:00",
  ]

 FAIL  src/eachYearOfInterval/test.ts > returns starts of years when the interval start is on a day that has no midnight
- Expected
+ Received
  [
-   "2023-01-01T00:00:00.000-05:00",
-   "2024-01-01T00:00:00.000-05:00",
-   "2025-01-01T00:00:00.000-05:00",
+   "2023-01-01T01:00:00.000-05:00",
+   "2024-01-01T01:00:00.000-05:00",
+   "2025-01-01T01:00:00.000-05:00",
  ]

 Test Files  2 failed (2)
      Tests  2 failed | 43 passed (45)
```

With the fix applied: `Test Files 2 passed (2)` / `Tests 45 passed (45)`.

**Full suite**, same command on both:

```
with fix:        Test Files 253 passed (253)   Tests 3168 passed | 1 skipped (3169)
untouched main:  Test Files 253 passed (253)   Tests 3166 passed | 1 skipped (3167)
```

The delta is exactly the two new tests. Also green under `TZ=America/Havana`, `America/Santiago`, `Asia/Beirut`, `America/Sao_Paulo` and `Pacific/Chatham` (3168 passed each), and the root workspace suite (`pkgs/tz`, `pkgs/utc`) is 218 passed | 4 todo.

`pnpm oxlint` exits 0, `pnpm tsgo --build` exits 0, and `pnpm oxfmt --check` reports the touched files correctly formatted.

**Breadth.** A property check over every day from 2010-01-01 to 2035-01-01 (9131 start days), asserting `each*OfInterval(...)[0] === startOf*(start)` and that every element is a start of its unit, is clean in all 14 zones tested with the fix. On `main` the same check flags:

| zone | broken start days |
| --- | --- |
| UTC | 0 / 9131 |
| America/Havana | 24 / 9131 |
| America/Santiago | 24 / 9131 |
| Asia/Beirut | 25 / 9131 |
| Asia/Damascus | 12 / 9131 |
| America/Sao_Paulo | 9 / 9131 |

I also checked the sibling functions: `eachDayOfInterval` and `eachQuarterOfInterval` already behave correctly in these zones and are left untouched.

## Tests

Two regression tests, one per function, in the existing style of each file. They use `TZDate` from `@date-fns/tz` rather than the process time zone, so they behave identically under the `tz_tests` matrix. Both pin a historical transition (America/Havana, 12 March 2023) rather than a future one, so they cannot start failing on a tzdata rule change.

## CI

All five workflows ran green on this exact commit (`4ee377f`) on my fork, including the browser and smoke tests I could not run locally:

| workflow | result |
| --- | --- |
| Code quality | ✅ success |
| Node.js tests | ✅ success |
| Browser tests | ✅ success |
| Smoke tests | ✅ success |
| Time zone tests | ✅ success (14m, full zone matrix) |

## What I could not verify

- I did not enumerate every IANA zone with a midnight DST transition — the zones named above are illustrative of the class, not an exhaustive list. The `tz_tests` matrix covers the repo's own zone set and is green.
